### PR TITLE
Prepare for populate versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ reconcile:
 ingest:
 	$(VAPOR) run ingest --limit 1
 
-inspect:
-	$(VAPOR) run inspect --limit 1
+analyze:
+	$(VAPOR) run analyze --limit 1
 
 db-up: db-up-dev db-up-test
 

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -3,7 +3,7 @@ import Vapor
 import ShellOut
 
 
-struct InspectorCommand: Command {
+struct AnalyzerCommand: Command {
     let defaultLimit = 1
 
     struct Signature: CommandSignature {
@@ -11,18 +11,18 @@ struct InspectorCommand: Command {
         var limit: Int?
     }
 
-    var help: String { "Run package inspection (fetching git repository and inspecting content)" }
+    var help: String { "Run package analysis (fetching git repository and inspecting content)" }
 
     func run(using context: CommandContext, signature: Signature) throws {
         let limit = signature.limit ?? defaultLimit
-        context.console.info("Inspecting (limit: \(limit)) ...")
+        context.console.info("Analyzing (limit: \(limit)) ...")
 
-        try inspect(application: context.application, limit: limit).wait()
+        try analyze(application: context.application, limit: limit).wait()
     }
 }
 
 
-func inspect(application: Application, limit: Int) throws -> EventLoopFuture<Void> {
+func analyze(application: Application, limit: Int) throws -> EventLoopFuture<Void> {
     // get or create directory
     let checkoutDir = application.directory.checkouts
     if !FileManager.default.fileExists(atPath: checkoutDir) {
@@ -40,8 +40,7 @@ func inspect(application: Application, limit: Int) throws -> EventLoopFuture<Voi
 
 
 func refreshCheckouts(application: Application, limit: Int) -> EventLoopFuture<[Result<Package, Error>]>  {
-    Package.query(on: application.db)
-        .updateCandidates(limit: limit)
+    Package.fetchUpdateCandidates(application.db, limit: limit)
         .flatMapEach(on: application.db.eventLoop) { pkg in
             do {
                 return try pullOrClone(application: application, package: pkg)

--- a/Sources/App/Commands/Inspector.swift
+++ b/Sources/App/Commands/Inspector.swift
@@ -60,6 +60,9 @@ func pullOrClone(application: Application, package: Package) throws -> EventLoop
     }
     let path = application.directory.checkouts + "/" + basename
     let promise = application.eventLoopGroup.next().makePromise(of: Package.self)
+    // FIXME: use runIfActive instead
+    // https://discordapp.com/channels/431917998102675485/444249946808647699/705452538438221845
+    //    application.threadPool.runIfActive(eventLoop: <#T##EventLoop#>, <#T##body: () throws -> T##() throws -> T#>)
     application.threadPool.submit { _ in
         do {
             if FileManager.default.fileExists(atPath: path) {

--- a/Sources/App/Controllers/PackageController.swift
+++ b/Sources/App/Controllers/PackageController.swift
@@ -46,6 +46,11 @@ struct PackageController {
                 return ingest(client: req.client, database: req.db, limit: limit)
                     .map {
                         Command.Response(status: "ok", rows: limit)
+                }
+            case .analyze:
+                return try analyze(application: req.application, limit: limit)
+                    .map {
+                        Command.Response(status: "ok", rows: limit)
             }
             case .none:
                 return req.eventLoop.makeFailedFuture(Abort(.notFound))
@@ -58,6 +63,7 @@ extension PackageController {
     enum Command: String {
         case reconcile
         case ingest
+        case analyze
 
         struct Response: Content {
             var status: String

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -1,10 +1,3 @@
-//
-//  File.swift
-//  
-//
-//  Created by Sven A. Schmidt on 26/04/2020.
-//
-
 import Vapor
 
 

--- a/Sources/App/Migrations/CreateVersion.swift
+++ b/Sources/App/Migrations/CreateVersion.swift
@@ -12,7 +12,7 @@ struct CreateVersion: Migration {
             .field("package_name", .string)
             .field("commit", .string)
             .field("supported_platforms", .array(of: .string))
-            .field("swift_versions", .array(of: .json))
+            .field("swift_versions", .array(of: .json), .sql(.default("{}")))
             .create()
     }
 

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -96,11 +96,12 @@ extension QueryBuilder where Model == Package {
 }
 
 
-extension QueryBuilder where Model == Package {
-    func updateCandidates(limit: Int) -> EventLoopFuture<[Package]> {
-        // TODO: filter out updated in last X minutes
-        sort(\.$updatedAt)
-        .limit(limit)
-        .all()
+extension Package {
+    static func fetchUpdateCandidates(_ database: Database, limit: Int) -> EventLoopFuture<[Package]> {
+        Package.query(on: database)
+            // TODO: filter out updated in last X minutes
+            .sort(\.$updatedAt)
+            .limit(limit)
+            .all()
     }
 }

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -38,6 +38,9 @@ final class Package: Model, Content {
     @Children(for: \.$package)
     var repositories: [Repository]
 
+    @Children(for: \.$package)
+    var versions: [Version]
+
     init() { }
 
     init(id: UUID? = nil, url: URL, status: Status = .none) {

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -35,12 +35,22 @@ final class Package: Model, Content {
     @Field(key: "last_commit_at")  // TODO: shouldn't this rather live in Repository?
     var lastCommitAt: Date?
 
+    @Children(for: \.$package)
+    var repositories: [Repository]
+
     init() { }
 
     init(id: UUID? = nil, url: URL, status: Status = .none) {
         self.id = id
         self.url = url.absoluteString
         self.status = status
+    }
+}
+
+
+extension Package {
+    var repository: Repository? {
+        get { repositories.first }
     }
 }
 

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -53,7 +53,21 @@ final class Package: Model, Content {
 
 extension Package {
     var repository: Repository? {
-        get { repositories.first }
+        repositories.first
+    }
+}
+
+
+extension Package {
+    var defaultVersion: Version? {
+        // TODO: sas 2020-04-30: find a more convenient way to use this. In order to avoid
+        // fatalErrors from lack of lazy loading, the caller needs to use it on a Package that's
+        // been fetched like so:
+        //   Package.query(on: db).with(\.$versions).with(\.$repositories)
+        // That's awkward. Should instead defaultBranch take a parameter (on: db) and do this
+        // itself?
+        guard let defaultBranch = repository?.defaultBranch else { return nil }
+        return versions.first(where: { $0.branchName == defaultBranch })
     }
 }
 

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -39,9 +39,21 @@ final class Repository: Model, Content {
 
     init() { }
 
-    init(id: UUID? = nil, package: Package, forkedFrom: Repository? = nil) throws {
+    init(id: UUID? = nil,
+         package: Package,
+         description: String? = nil,
+         defaultBranch: String? = nil,
+         license: String? = nil,
+         stars: Int? = nil,
+         forks: Int? = nil,
+         forkedFrom: Repository? = nil) throws {
         self.id = id
         self.$package.id = try package.requireID()
+        self.description = description
+        self.defaultBranch = defaultBranch
+        self.license = license
+        self.stars = stars
+        self.forks = forks
         if let forkId = forkedFrom?.id {
             self.$forkedFrom.id = forkId
         }

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -61,3 +61,10 @@ final class Repository: Model, Content {
         // }
     }
 }
+
+
+extension Repository: Equatable {
+    static func == (lhs: Repository, rhs: Repository) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/Sources/App/Models/Version.swift
+++ b/Sources/App/Models/Version.swift
@@ -81,3 +81,10 @@ final class Version: Model, Content {
         self.supportedPlatforms = supportedPlatforms
     }
 }
+
+
+extension Version: Equatable {
+    static func == (lhs: Version, rhs: Version) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/Sources/App/Models/Version.swift
+++ b/Sources/App/Models/Version.swift
@@ -41,6 +41,7 @@ final class Version: Model, Content {
     @Parent(key: "package_id")
     var package: Package
 
+    // TODO: sas-2020-04-30: Explore folding branch/rag into an enum with associated value String
     @Field(key: "branch_name")
     var branchName: String?
 
@@ -64,8 +65,19 @@ final class Version: Model, Content {
 
     init() { }
 
-    init(id: UUID? = nil, package: Package) throws {
+    init(id: UUID? = nil,
+         package: Package,
+         branchName: String? = nil,
+         tagName: String? = nil,
+         packageName: String? = nil,
+         commit: String? = nil,
+         supportedPlatforms: [Platform] = []) throws {
         self.id = id
         self.$package.id = try package.requireID()
+        self.branchName = branchName
+        self.tagName = tagName
+        self.packageName = packageName
+        self.commit = commit
+        self.supportedPlatforms = supportedPlatforms
     }
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -32,7 +32,7 @@ public func configure(_ app: Application) throws {
 
     app.commands.use(ReconcilerCommand(), as: "reconcile")
     app.commands.use(IngestorCommand(), as: "ingest")
-    app.commands.use(InspectorCommand(), as: "inspect")
+    app.commands.use(AnalyzerCommand(), as: "analyze")
 
     // register routes
     try routes(app)

--- a/Tests/AppTests/AppTestCase.swift
+++ b/Tests/AppTests/AppTestCase.swift
@@ -1,0 +1,16 @@
+import XCTVapor
+
+
+class AppTestCase: XCTestCase {
+    var app: Application!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        app = try setup(.testing)
+    }
+
+    override func tearDownWithError() throws {
+        app.shutdown()
+        try super.tearDownWithError()
+    }
+}

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 
 class GithubTests: XCTestCase {
-
+    
     func test_getHeader() throws {
         do { // without token
             Current.githubToken = { nil }

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -5,17 +5,8 @@ import Vapor
 import XCTest
 
 
-class IngestorTests: XCTestCase {
-    var app: Application!
-
-    override func setUpWithError() throws {
-        app = try setup(.testing)
-    }
-
-    override func tearDownWithError() throws {
-        app.shutdown()
-    }
-
+class IngestorTests: AppTestCase {
+    
     func test_ingest_basic() throws {
         // setup
         let urls = ["https://github.com/finestructure/Gala",

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -89,6 +89,22 @@ class IngestorTests: AppTestCase {
 
     func test_fetchMetadata_badMetadata() throws {
         // setup
+        Current.fetchMetadata = { _, _ in
+            .just(error: AppError.metadataRequestFailed(nil, .badRequest, URI("1")))
+        }
+        let pkg = try savePackage(on: app.db, "1".url)
+
+        // MUT
+        let md = try fetchMetadata(for: pkg, with: app.client).wait()
+
+        // validate
+        XCTAssert(md.isFailure)
+    }
+
+    func test_fetchMetadata_badMetadata_bulk() throws {
+        // Test to ensure fetch failures don't break the pipeline
+        // (which is easy to get wrong by not catching and rewrapping into a future)
+        // setup
         let urls = ["1", "2", "3"]
         Current.fetchMetadata = { _, pkg in
             if pkg.url == "2" {
@@ -96,10 +112,12 @@ class IngestorTests: AppTestCase {
             }
             return .just(value: .mock(for: pkg))
         }
-        try savePackages(on: app.db, urls.compactMap(URL.init(string:)))
+        try urls.urls.map { Package(url: $0) }.save(on: app.db).wait()
 
         // MUT
-        let md = try fetchMetadata(client: app.client, database: app.db, limit: 10).wait()
+        let md = try Package.query(on: app.db).all()
+            .flatMapEach(on: app.db.eventLoop) { fetchMetadata(for: $0, with: self.app.client) }
+            .wait()
 
         // validate
         XCTAssertEqual(md.count, 3)

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -77,12 +77,12 @@ final class PackageTests: AppTestCase {
         XCTAssertEqual(res.map(\.url), ["https://foo.com/1"])
     }
 
-    func test_updateCandidates() throws {
+    func test_fetchUpdateCandidates() throws {
         let packages = try ["https://foo.com/1", "https://foo.com/2"].map {
             try savePackage(on: app.db, $0.url)
         }
         try Package.update(packages[0])(on: app.db).wait()
-        let batch = try Package.query(on: app.db).updateCandidates(limit: 10).wait()
+        let batch = try Package.fetchUpdateCandidates(app.db, limit: 10).wait()
             .map(\.url)
         XCTAssertEqual(batch, ["https://foo.com/2", "https://foo.com/1"])
     }

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -95,4 +95,18 @@ final class PackageTests: XCTestCase {
             .map(\.url)
         XCTAssertEqual(batch, ["https://foo.com/2", "https://foo.com/1"])
     }
+
+    func test_repository() throws {
+        let pkg = try savePackage(on: app.db, "1".url)
+        do {
+            let pkg = try XCTUnwrap(Package.query(on: app.db).with(\.$repositories).first().wait())
+            XCTAssertEqual(pkg.repository, nil)
+        }
+        do {
+            let repo = try Repository(package: pkg)
+            try repo.save(on: app.db).wait()
+            let pkg = try XCTUnwrap(Package.query(on: app.db).with(\.$repositories).first().wait())
+            XCTAssertEqual(pkg.repository, repo)
+        }
+    }
 }

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -109,4 +109,18 @@ final class PackageTests: XCTestCase {
             XCTAssertEqual(pkg.repository, repo)
         }
     }
+
+    func test_versions() throws {
+        let pkg = try savePackage(on: app.db, "1".url)
+        let versions = [
+            try Version(package: pkg, branchName: "branch"),
+            try Version(package: pkg, branchName: "default"),
+            try Version(package: pkg, tagName: "tag"),
+        ]
+        try versions.create(on: app.db).wait()
+        do {
+            let pkg = try XCTUnwrap(Package.query(on: app.db).with(\.$versions).first().wait())
+            XCTAssertEqual(pkg.versions.count, 3)
+        }
+    }
 }

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -5,17 +5,8 @@ import Vapor
 import XCTVapor
 
 
-final class PackageTests: XCTestCase {
-    var app: Application!
-
-    override func setUpWithError() throws {
-        app = try setup(.testing)
-    }
-
-    override func tearDownWithError() throws {
-        app.shutdown()
-    }
-
+final class PackageTests: AppTestCase {
+    
     func test_localCacheDirectory() throws {
         XCTAssertEqual(
             Package(url: "https://github.com/finestructure/Arena".url).localCacheDirectory,

--- a/Tests/AppTests/ReconcilerTests.swift
+++ b/Tests/AppTests/ReconcilerTests.swift
@@ -4,17 +4,8 @@ import Vapor
 import XCTest
 
 
-class ReconcilerTests: XCTestCase {
-    var app: Application!
-
-    override func setUpWithError() throws {
-        app = try setup(.testing)
-    }
-
-    override func tearDownWithError() throws {
-        app.shutdown()
-    }
-
+class ReconcilerTests: AppTestCase {
+    
     func test_basic_reconciliation() throws {
         let urls = ["1", "2", "3"]
         Current.fetchMasterPackageList = { _ in .just(value: urls.urls) }

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -3,17 +3,8 @@
 import XCTVapor
 
 
-final class RepositoryTests: XCTestCase {
-    var app: Application!
-
-    override func setUpWithError() throws {
-        app = try setup(.testing)
-    }
-
-    override func tearDownWithError() throws {
-        app.shutdown()
-    }
-
+final class RepositoryTests: AppTestCase {
+    
     func test_package_relationship() throws {
         let pkg = Package(url: "p1".url)
         try pkg.save(on: app.db).wait()

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -94,3 +94,12 @@ extension Result {
         return false
     }
 }
+
+
+extension Array where Element: FluentKit.Model {
+    public func save(on database: Database) -> EventLoopFuture<Void> {
+        map {
+            $0.save(on: database)
+        }.flatten(on: database.eventLoop)
+    }
+}

--- a/Tests/AppTests/VersionTests.swift
+++ b/Tests/AppTests/VersionTests.swift
@@ -3,17 +3,8 @@
 import XCTVapor
 
 
-class VersionTests: XCTestCase {
-    var app: Application!
-
-    override func setUpWithError() throws {
-        app = try setup(.testing)
-    }
-
-    override func tearDownWithError() throws {
-        app.shutdown()
-    }
-
+class VersionTests: AppTestCase {
+    
     func test_Version_save() throws {
         let pkg = try savePackage(on: app.db, "1".url)
         let v = try Version(package: pkg)

--- a/Tests/AppTests/VersionTests.swift
+++ b/Tests/AppTests/VersionTests.swift
@@ -36,4 +36,14 @@ class VersionTests: XCTestCase {
             XCTAssertEqual(v.swiftVersions, ["4.0.0", "5.2.0"])
         }
     }
+
+    func test_Version_empty_supportedPlatforms_error() throws {
+        // Test for
+        // invalid field: swift_versions type: Array<SemVer> error: Unexpected data type: JSONB[]. Expected array.
+        // Fix is .sql(.default("{}"))
+        let pkg = try savePackage(on: app.db, "1".url)
+        let v = try Version(package: pkg)
+        try v.save(on: app.db).wait()
+        _ = try XCTUnwrap(Version.find(v.id, on: app.db).wait())
+    }
 }


### PR DESCRIPTION
Clearing the deck before actually creating versions. This includes

- review changes
- relationship accessors and tests between Package/Respository and Package/Version
- fix for reading empty `Version.swiftVersion` from db
- `Package.defaultVersion`
- replace `submit` with `runIfActive`
