### PR TITLE
Shell mock

### DIFF
--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -25,11 +25,11 @@ struct AnalyzerCommand: Command {
 func analyze(application: Application, limit: Int) throws -> EventLoopFuture<Void> {
     // get or create directory
     let checkoutDir = application.directory.checkouts
-    if !FileManager.default.fileExists(atPath: checkoutDir) {
+    if !Current.fileManager().fileExists(atPath: checkoutDir) {
         application.logger.info("Creating checkouts directory at path: \(checkoutDir)")
-        try FileManager.default.createDirectory(atPath: checkoutDir,
-                                                withIntermediateDirectories: false,
-                                                attributes: nil)
+        try Current.fileManager().createDirectory(atPath: checkoutDir,
+                                                  withIntermediateDirectories: false,
+                                                  attributes: nil)
     }
 
     // pull or clone repos
@@ -59,7 +59,7 @@ func pullOrClone(application: Application, package: Package) throws -> EventLoop
     }
     let path = application.directory.checkouts + "/" + basename
     return application.threadPool.runIfActive(eventLoop: application.eventLoopGroup.next()) {
-        if FileManager.default.fileExists(atPath: path) {
+        if Current.fileManager().fileExists(atPath: path) {
             application.logger.info("pulling \(package.url) in \(path)")
             try shellOut(to: .gitPull(), at: path)
         } else {

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -25,8 +25,9 @@ struct AnalyzerCommand: Command {
 func analyze(application: Application, limit: Int) throws -> EventLoopFuture<Void> {
     // get or create directory
     let checkoutDir = application.directory.checkouts
+    application.logger.info("Checkout directory: \(checkoutDir)")
     if !Current.fileManager.fileExists(atPath: checkoutDir) {
-        application.logger.info("Creating checkouts directory at path: \(checkoutDir)")
+        application.logger.info("Creating checkout directory at path: \(checkoutDir)")
         try Current.fileManager.createDirectory(atPath: checkoutDir,
                                                   withIntermediateDirectories: false,
                                                   attributes: nil)
@@ -61,10 +62,10 @@ func pullOrClone(application: Application, package: Package) throws -> EventLoop
     return application.threadPool.runIfActive(eventLoop: application.eventLoopGroup.next()) {
         if Current.fileManager.fileExists(atPath: path) {
             application.logger.info("pulling \(package.url) in \(path)")
-            try shellOut(to: .gitPull(), at: path)
+            try Current.shell.run(command: .gitPull(), at: path)
         } else {
             application.logger.info("cloning \(package.url) to \(path)")
-            try shellOut(to: .gitClone(url: URL(string: package.url)!, to: path))
+            try Current.shell.run(command: .gitClone(url: URL(string: package.url)!, to: path))
         }
         return package
     }

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -25,9 +25,9 @@ struct AnalyzerCommand: Command {
 func analyze(application: Application, limit: Int) throws -> EventLoopFuture<Void> {
     // get or create directory
     let checkoutDir = application.directory.checkouts
-    if !Current.fileManager().fileExists(atPath: checkoutDir) {
+    if !Current.fileManager.fileExists(atPath: checkoutDir) {
         application.logger.info("Creating checkouts directory at path: \(checkoutDir)")
-        try Current.fileManager().createDirectory(atPath: checkoutDir,
+        try Current.fileManager.createDirectory(atPath: checkoutDir,
                                                   withIntermediateDirectories: false,
                                                   attributes: nil)
     }
@@ -59,7 +59,7 @@ func pullOrClone(application: Application, package: Package) throws -> EventLoop
     }
     let path = application.directory.checkouts + "/" + basename
     return application.threadPool.runIfActive(eventLoop: application.eventLoopGroup.next()) {
-        if Current.fileManager().fileExists(atPath: path) {
+        if Current.fileManager.fileExists(atPath: path) {
             application.logger.info("pulling \(package.url) in \(path)")
             try shellOut(to: .gitPull(), at: path)
         } else {

--- a/Sources/App/Core/AppEnvironment+testing.swift
+++ b/Sources/App/Core/AppEnvironment+testing.swift
@@ -10,21 +10,21 @@ extension AppEnvironment {
                           "https://github.com/finestructure/SwiftPMLibrary-Server"].urls)
         },
         fetchMetadata: { _, _ in .just(value: .mock) },
-        fileManager: { .mock },
+        fileManager: .mock,
         githubToken: { ProcessInfo.processInfo.environment["GITHUB_TOKEN"] }
     )
 
     static let e2eTestingShort: Self = .init(
         fetchMasterPackageList: { _ in .just(value: testUrls) },
         fetchMetadata: { _, pkg in .just(value: .mock(for: pkg)) },
-        fileManager: { .mock },
+        fileManager: .mock,
         githubToken: { nil }
     )
 
     static let e2eTestingFull: Self = .init(
         fetchMasterPackageList: liveFetchMasterPackageList,
         fetchMetadata: { _, pkg in .just(value: .mock(for: pkg)) },
-        fileManager: { .mock },
+        fileManager: .mock,
         githubToken: { nil }
     )
 }

--- a/Sources/App/Core/AppEnvironment+testing.swift
+++ b/Sources/App/Core/AppEnvironment+testing.swift
@@ -11,21 +11,24 @@ extension AppEnvironment {
         },
         fetchMetadata: { _, _ in .just(value: .mock) },
         fileManager: .mock,
-        githubToken: { ProcessInfo.processInfo.environment["GITHUB_TOKEN"] }
+        githubToken: { ProcessInfo.processInfo.environment["GITHUB_TOKEN"] },
+        shell: .mock
     )
 
     static let e2eTestingShort: Self = .init(
         fetchMasterPackageList: { _ in .just(value: testUrls) },
         fetchMetadata: { _, pkg in .just(value: .mock(for: pkg)) },
         fileManager: .mock,
-        githubToken: { nil }
+        githubToken: { nil },
+        shell: .mock
     )
 
     static let e2eTestingFull: Self = .init(
         fetchMasterPackageList: liveFetchMasterPackageList,
         fetchMetadata: { _, pkg in .just(value: .mock(for: pkg)) },
         fileManager: .mock,
-        githubToken: { nil }
+        githubToken: { nil },
+        shell: .mock
     )
 }
 
@@ -33,9 +36,21 @@ extension AppEnvironment {
 extension FileManager {
     static let mock = Self.mock(fileExists: true)
     static func mock(fileExists: Bool) -> Self {
-        .init(fileExists: { _ in fileExists },
-              createDirectory: { _, _, _ in })
+        .init(fileExists: { path in
+            print("ℹ️ MOCK: file at \(path) exists")
+            return fileExists
+        },
+              createDirectory: { path, _, _ in
+                print("ℹ️ MOCK: imagine we're creating a directory at path: \(path)")
+        })
     }
+}
+
+
+extension Shell {
+    static let mock: Self = .init(run: { cmd, path in
+        print("ℹ️ MOCK: imagine we're running \(cmd) at path: \(path)")
+    })
 }
 
 

--- a/Sources/App/Core/AppEnvironment+testing.swift
+++ b/Sources/App/Core/AppEnvironment+testing.swift
@@ -10,20 +10,32 @@ extension AppEnvironment {
                           "https://github.com/finestructure/SwiftPMLibrary-Server"].urls)
         },
         fetchMetadata: { _, _ in .just(value: .mock) },
+        fileManager: { .mock },
         githubToken: { ProcessInfo.processInfo.environment["GITHUB_TOKEN"] }
     )
 
     static let e2eTestingShort: Self = .init(
         fetchMasterPackageList: { _ in .just(value: testUrls) },
         fetchMetadata: { _, pkg in .just(value: .mock(for: pkg)) },
+        fileManager: { .mock },
         githubToken: { nil }
     )
 
     static let e2eTestingFull: Self = .init(
         fetchMasterPackageList: liveFetchMasterPackageList,
         fetchMetadata: { _, pkg in .just(value: .mock(for: pkg)) },
+        fileManager: { .mock },
         githubToken: { nil }
     )
+}
+
+
+extension FileManager {
+    static let mock = Self.mock(fileExists: true)
+    static func mock(fileExists: Bool) -> Self {
+        .init(fileExists: { _ in fileExists },
+              createDirectory: { _, _, _ in })
+    }
 }
 
 

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -4,6 +4,7 @@ import Vapor
 struct AppEnvironment {
     var fetchMasterPackageList: (_ client: Client) throws -> EventLoopFuture<[URL]>
     var fetchMetadata: (_ client: Client, _ package: Package) throws -> EventLoopFuture<Github.Metadata>
+    var fileManager: () -> FileManager
     var githubToken: () -> String?
 }
 
@@ -11,8 +12,26 @@ extension AppEnvironment {
     static let live: Self = .init(
         fetchMasterPackageList: liveFetchMasterPackageList,
         fetchMetadata: Github.fetchMetadata(client:package:),
+        fileManager: { .live },
         githubToken: { ProcessInfo.processInfo.environment["GITHUB_TOKEN"] }
     )
+}
+
+
+struct FileManager {
+    var fileExists: (String) -> Bool
+    var createDirectory: (String, Bool, [FileAttributeKey : Any]?) throws -> Void
+
+    func fileExists(atPath path: String) -> Bool { fileExists(path) }
+    func createDirectory(atPath path: String,
+                         withIntermediateDirectories createIntermediates: Bool,
+                         attributes: [FileAttributeKey : Any]?) throws {
+        try createDirectory(path, createIntermediates, attributes)
+    }
+
+    static let live: Self = .init(
+        fileExists: Foundation.FileManager.default.fileExists(atPath:),
+        createDirectory: Foundation.FileManager.default.createDirectory(atPath:withIntermediateDirectories:attributes:))
 }
 
 

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -4,7 +4,7 @@ import Vapor
 struct AppEnvironment {
     var fetchMasterPackageList: (_ client: Client) throws -> EventLoopFuture<[URL]>
     var fetchMetadata: (_ client: Client, _ package: Package) throws -> EventLoopFuture<Github.Metadata>
-    var fileManager: () -> FileManager
+    var fileManager: FileManager
     var githubToken: () -> String?
 }
 
@@ -12,7 +12,7 @@ extension AppEnvironment {
     static let live: Self = .init(
         fetchMasterPackageList: liveFetchMasterPackageList,
         fetchMetadata: Github.fetchMetadata(client:package:),
-        fileManager: { .live },
+        fileManager: .live,
         githubToken: { ProcessInfo.processInfo.environment["GITHUB_TOKEN"] }
     )
 }

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -11,7 +11,13 @@ class AnalyzerTests: AppTestCase {
         let urls = ["https://github.com/foo/1", "https://github.com/foo/2"]
         try savePackages(on: app.db, urls.urls)
         var checkoutDir: String? = nil
-        Current.fileManager.fileExists = { _ in false }
+        Current.fileManager.fileExists = { path in
+            // let the check for the second repo checkout path succedd to simulate pull
+            if let outDir = checkoutDir, path == "\(outDir)/github.com-foo-2" {
+                return true
+            }
+            return false
+        }
         Current.fileManager.createDirectory = { path, _, _ in
             checkoutDir = path
         }
@@ -28,7 +34,7 @@ class AnalyzerTests: AppTestCase {
         XCTAssert(outDir.hasSuffix("SPI-checkouts"), "unexpected checkout dir, was: \(outDir)")
         XCTAssertEqual(commands,
                        ["git clone https://github.com/foo/1 \"\(outDir)/github.com-foo-1\" --quiet",
-                        "git clone https://github.com/foo/2 \"\(outDir)/github.com-foo-2\" --quiet"]
+                        "git pull --quiet"]
         )
     }
 

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -1,0 +1,36 @@
+@testable import App
+
+import Vapor
+import XCTest
+
+
+class AnalyzerTests: AppTestCase {
+    
+    func test_basic_analysis() throws {
+        // setup
+        let urls = ["https://github.com/foo/1", "https://github.com/foo/2"]
+        try savePackages(on: app.db, urls.urls)
+        var checkoutDir: String? = nil
+        Current.fileManager.fileExists = { _ in false }
+        Current.fileManager.createDirectory = { path, _, _ in
+            checkoutDir = path
+        }
+        var commands = [String]()
+        Current.shell.run = { cmd, _ in
+            commands.append(cmd.string)
+        }
+
+        // MUT
+        try analyze(application: app, limit: 10).wait()
+
+        // validation
+        let outDir = try XCTUnwrap(checkoutDir)
+        XCTAssert(outDir.hasSuffix("SPI-checkouts"), "unexpected checkout dir, was: \(outDir)")
+        XCTAssertEqual(commands,
+                       ["git clone https://github.com/foo/1 \"\(outDir)/github.com-foo-1\" --quiet",
+                        "git clone https://github.com/foo/2 \"\(outDir)/github.com-foo-2\" --quiet"]
+        )
+    }
+
+    // TODO: refresh checkout with error (continuation)
+}


### PR DESCRIPTION
Yep, re-opening correctly picks up only the new commits.

This extends `AppEnvrionment` with a facility to mock out and test file management and shell commands.