### PR TITLE
End to end testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 .build/
 .swiftpm/
+SPI-checkouts/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM vapor/swift:latest as build
+FROM swift:5.2.3-bionic as build
 WORKDIR /build
 
 # First just resolve dependencies.
@@ -23,8 +23,12 @@ RUN swift build \
 # ================================
 # Run image
 # ================================
-FROM vapor/ubuntu:18.04
+# we need a swift base image so that we can run `swift dump-package`
+FROM swift:5.2.3-bionic
 WORKDIR /run
+
+# install git so we can run clone/pull/etc
+RUN apt-get update && apt-get install -y git
 
 # Copy build artifacts
 COPY --from=build /build/.build/release /run

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -127,6 +127,8 @@ func pullOrClone(application: Application, package: Package) throws -> EventLoop
     return application.threadPool.runIfActive(eventLoop: application.eventLoopGroup.next()) {
         if Current.fileManager.fileExists(atPath: path) {
             application.logger.info("pulling \(package.url) in \(path)")
+            // git reset --hard to deal with stray .DS_Store files on macOS
+            try Current.shell.run(command: .init(string: "git reset --hard"), at: path)
             let branch = package.repository?.defaultBranch ?? "master"
             try Current.shell.run(command: .gitCheckout(branch: branch), at: path)
             try Current.shell.run(command: .gitPull(), at: path)

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -94,6 +94,8 @@ func pullOrClone(application: Application, package: Package) throws -> EventLoop
     return application.threadPool.runIfActive(eventLoop: application.eventLoopGroup.next()) {
         if Current.fileManager.fileExists(atPath: path) {
             application.logger.info("pulling \(package.url) in \(path)")
+            let branch = package.repository?.defaultBranch ?? "master"
+            try Current.shell.run(command: .gitCheckout(branch: branch), at: path)
             try Current.shell.run(command: .gitPull(), at: path)
         } else {
             application.logger.info("cloning \(package.url) to \(path)")

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -154,12 +154,12 @@ func _reconcileVersions(application: Application, package: Package) throws -> Ev
     guard let pkgId = package.id else {
         throw AppError.genericError(nil, "PANIC: package id nil for package \(package.url)")
     }
-    let tags: EventLoopFuture<[SemVer]> = application.threadPool.runIfActive(eventLoop: application.eventLoopGroup.next()) {
+    let tags: EventLoopFuture<[String]> = application.threadPool.runIfActive(eventLoop: application.eventLoopGroup.next()) {
         application.logger.info("listing tags for package \(package.url)")
         let tags = try Current.shell.run(command: .init(string: "git tag"), at: path)
         return tags.split(separator: "\n")
             .map(String.init)
-            .compactMap(SemVer.parse)
+            .filter(SemVer.isValid)
     }
     // FIXME: also save version for default branch (currently only looking at tags)
 
@@ -171,7 +171,7 @@ func _reconcileVersions(application: Application, package: Package) throws -> Ev
         .delete()
     // ... and insert versions
     let insert: EventLoopFuture<[Version]> = tags
-        .flatMapEachThrowing { try Version(package: package, tagName: "\($0)") }
+        .flatMapEachThrowing { try Version(package: package, tagName: $0) }
         .flatMap { versions in
             versions.create(on: application.db)
                 .map { versions }

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -131,11 +131,11 @@ func pullOrClone(application: Application, package: Package) throws -> EventLoop
             try Current.shell.run(command: .init(string: "git reset --hard"), at: path)
             let branch = package.repository?.defaultBranch ?? "master"
             try Current.shell.run(command: .gitCheckout(branch: branch), at: path)
-            try Current.shell.run(command: .gitPull(), at: path)
+            try Current.shell.run(command: .gitPull(allowingPrompt: false), at: path)
         } else {
             application.logger.info("cloning \(package.url) to \(path)")
             let wdir = Current.fileManager.checkoutsDirectory
-            try Current.shell.run(command: .gitClone(url: URL(string: package.url)!, to: path), at: wdir)
+            try Current.shell.run(command: .gitClone(url: URL(string: package.url)!, to: path, allowingPrompt: false), at: wdir)
         }
         return package
     }

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -42,13 +42,13 @@ struct FileManager {
 
 
 extension FileManager {
-    var checkouts: String {
+    var checkoutsDirectory: String {
         workingDirectory() + "SPI-checkouts"
     }
 
     func cacheDirectoryPath(for package: Package) -> String? {
         guard let dirname = package.cacheDirectoryName else { return nil }
-        return checkouts + "/" + dirname
+        return checkoutsDirectory + "/" + dirname
     }
 }
 

--- a/Sources/App/Core/ShellOutCommand+ext.swift
+++ b/Sources/App/Core/ShellOutCommand+ext.swift
@@ -1,0 +1,38 @@
+import Foundation
+import ShellOut
+
+
+// TODO: upstream this to JohnSundell/ShellOut
+extension ShellOutCommand {
+    private static func git(allowingPrompt: Bool) -> String {
+        allowingPrompt ? "git" : "env GIT_TERMINAL_PROMPT=0 git"
+    }
+
+    static func gitClone(url: URL, to path: String? = nil, allowingPrompt: Bool) -> ShellOutCommand {
+        var command = "\(git(allowingPrompt: allowingPrompt)) clone \(url.absoluteString)"
+        path.map { command.append(argument: $0) }
+        command.append(" --quiet")
+
+        return ShellOutCommand(string: command)
+    }
+
+    static func gitPull(remote: String? = nil, branch: String? = nil, allowingPrompt: Bool) -> ShellOutCommand {
+        var command = "\(git(allowingPrompt: allowingPrompt)) pull"
+        remote.map { command.append(argument: $0) }
+        branch.map { command.append(argument: $0) }
+        command.append(" --quiet")
+
+        return ShellOutCommand(string: command)
+    }
+}
+
+
+private extension String {
+    func appending(argument: String) -> String {
+        return "\(self) \"\(argument)\""
+    }
+
+    mutating func append(argument: String) {
+        self = appending(argument: argument)
+    }
+}

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -105,6 +105,7 @@ extension QueryBuilder where Model == Package {
 extension Package {
     static func fetchUpdateCandidates(_ database: Database, limit: Int) -> EventLoopFuture<[Package]> {
         Package.query(on: database)
+            .with(\.$repositories)
             // TODO: filter out updated in last X minutes
             .sort(\.$updatedAt)
             .limit(limit)

--- a/Sources/App/Models/SemVer.swift
+++ b/Sources/App/Models/SemVer.swift
@@ -38,3 +38,8 @@ extension SemVer {
         }
     }
 }
+
+
+extension SemVer: CustomStringConvertible {
+    var description: String { "\(major).\(minor).\(patch)" }
+}

--- a/Sources/App/Models/SemVer.swift
+++ b/Sources/App/Models/SemVer.swift
@@ -37,6 +37,8 @@ extension SemVer {
             default: return nil
         }
     }
+
+    static func isValid(_ string: String) -> Bool { parse(string) != nil }
 }
 
 

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -86,14 +86,10 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(products[0].type, .executable)
         XCTAssertEqual(products[1].name, "p1")
         XCTAssertEqual(products[1].type, .executable)
-        XCTAssertEqual(Set(arrayLiteral: [products[0].$version.id, products[1].$version.id]),
-                       Set(arrayLiteral: [pkg1.versions[0].id, pkg1.versions[1].id]))
         XCTAssertEqual(products[2].name, "p2")
         XCTAssertEqual(products[2].type, .library)
         XCTAssertEqual(products[3].name, "p2")
         XCTAssertEqual(products[3].type, .library)
-        XCTAssertEqual(Set(arrayLiteral: [products[2].$version.id, products[3].$version.id]),
-                       Set(arrayLiteral: [pkg2.versions[0].id, pkg2.versions[1].id]))
     }
 
     func test_package_status() throws {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -47,11 +47,11 @@ class AnalyzerTests: AppTestCase {
         let path2 = "\(outDir)/github.com-foo-2"
         let expecations: [Command] = [
             // clone of pkg1 and pull of pkg2
-            .init(command: "git clone https://github.com/foo/1 \"\(outDir)/github.com-foo-1\" --quiet",
+            .init(command: "env GIT_TERMINAL_PROMPT=0 git clone https://github.com/foo/1 \"\(outDir)/github.com-foo-1\" --quiet",
                 path: outDir),
             .init(command: "git reset --hard", path: path2),
             .init(command: "git checkout \"master\" --quiet", path: path2),
-            .init(command: "git pull --quiet", path: path2),
+            .init(command: "env GIT_TERMINAL_PROMPT=0 git pull --quiet", path: path2),
             // next, both repos have their tags listed
             .init(command: "git tag", path: path1),
             .init(command: "git tag", path: path2),

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -13,9 +13,8 @@ class AnalyzerTests: AppTestCase {
         var checkoutDir: String? = nil
         Current.fileManager.fileExists = { path in
             // let the check for the second repo checkout path succedd to simulate pull
-            if let outDir = checkoutDir, path == "\(outDir)/github.com-foo-2" {
-                return true
-            }
+            if let outDir = checkoutDir, path == "\(outDir)/github.com-foo-2" { return true }
+            if path.hasSuffix("Package.swift") { return true }
             return false
         }
         Current.fileManager.createDirectory = { path, _, _ in checkoutDir = path }
@@ -49,7 +48,7 @@ class AnalyzerTests: AppTestCase {
         let expecations: [Command] = [
             // clone of pkg1 and pull of pkg2
             .init(command: "git clone https://github.com/foo/1 \"\(outDir)/github.com-foo-1\" --quiet",
-                path: "."),  // "outDir" is translated to "." in this context
+                path: outDir),
             .init(command: "git checkout \"master\" --quiet", path: path2),
             .init(command: "git pull --quiet", path: path2),
             // next, both repos have their tags listed
@@ -133,9 +132,8 @@ class AnalyzerTests: AppTestCase {
         var checkoutDir: String? = nil
         Current.fileManager.fileExists = { path in
             // let the check for the second repo checkout path succedd to simulate pull
-            if let outDir = checkoutDir, path == "\(outDir)/github.com-foo-2" {
-                return true
-            }
+            if let outDir = checkoutDir, path == "\(outDir)/github.com-foo-2" { return true }
+            if path.hasSuffix("Package.swift") { return true }
             return false
         }
         Current.fileManager.createDirectory = { path, _, _ in checkoutDir = path }

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -157,7 +157,7 @@ class AnalyzerTests: AppTestCase {
         // Test setup is identical to `test_basic_analysis` except for the Manifest JSON,
         // which we intentionally broke. Command count must remain the same.
         // TODO: perhaps find a better way to assert success than counting commands - Version count?
-        XCTAssertEqual(commands.count, 12, "was: \(dump(commands))")
+        XCTAssertEqual(commands.count, 13, "was: \(dump(commands))")
     }
 
     func test_reconcileVersions() throws {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -50,6 +50,7 @@ class AnalyzerTests: AppTestCase {
             // clone of pkg1 and pull of pkg2
             .init(command: "git clone https://github.com/foo/1 \"\(outDir)/github.com-foo-1\" --quiet",
                 path: "."),  // "outDir" is translated to "." in this context
+            .init(command: "git checkout \"master\" --quiet", path: path2),
             .init(command: "git pull --quiet", path: path2),
             // next, both repos have their tags listed
             .init(command: "git tag", path: path1),

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -84,16 +84,16 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(products.count, 4)
         XCTAssertEqual(products[0].name, "p1")
         XCTAssertEqual(products[0].type, .executable)
-        XCTAssertEqual(products[0].$version.id, pkg1.versions[0].id)
         XCTAssertEqual(products[1].name, "p1")
         XCTAssertEqual(products[1].type, .executable)
-        XCTAssertEqual(products[1].$version.id, pkg1.versions[1].id)
+        XCTAssertEqual(Set(arrayLiteral: [products[0].$version.id, products[1].$version.id]),
+                       Set(arrayLiteral: [pkg1.versions[0].id, pkg1.versions[1].id]))
         XCTAssertEqual(products[2].name, "p2")
         XCTAssertEqual(products[2].type, .library)
-        XCTAssertEqual(products[2].$version.id, pkg2.versions[0].id)
         XCTAssertEqual(products[3].name, "p2")
         XCTAssertEqual(products[3].type, .library)
-        XCTAssertEqual(products[3].$version.id, pkg2.versions[1].id)
+        XCTAssertEqual(Set(arrayLiteral: [products[2].$version.id, products[3].$version.id]),
+                       Set(arrayLiteral: [pkg2.versions[0].id, pkg2.versions[1].id]))
     }
 
     func test_package_status() throws {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -49,6 +49,7 @@ class AnalyzerTests: AppTestCase {
             // clone of pkg1 and pull of pkg2
             .init(command: "git clone https://github.com/foo/1 \"\(outDir)/github.com-foo-1\" --quiet",
                 path: outDir),
+            .init(command: "git reset --hard", path: path2),
             .init(command: "git checkout \"master\" --quiet", path: path2),
             .init(command: "git pull --quiet", path: path2),
             // next, both repos have their tags listed
@@ -151,7 +152,7 @@ class AnalyzerTests: AppTestCase {
         // Test setup is identical to `test_basic_analysis` except for the Manifest JSON,
         // which we intentionally broke. Command count must remain the same.
         // TODO: perhaps find a better way to assert success than counting commands - Version count?
-        XCTAssertEqual(commands.count, 13, "was: \(dump(commands))")
+        XCTAssertEqual(commands.count, 14, "was: \(dump(commands))")
     }
 
     func test_reconcileVersions() throws {

--- a/Tests/AppTests/SemVerTests.swift
+++ b/Tests/AppTests/SemVerTests.swift
@@ -12,4 +12,8 @@ class SemVerTests: XCTestCase {
         XCTAssertEqual(SemVer.parse("1.2.3rc"), nil)
     }
 
+    func test_isValid() throws {
+        XCTAssert(SemVer.isValid("1.2.3"))
+        XCTAssert(!SemVer.isValid("swift-2.2-SNAPSHOT-2016-01-11-a"))
+    }
 }

--- a/analysis-loop.sh
+++ b/analysis-loop.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -eu
+
+# export LOG_LEVEL=warning
+
+while true; do
+    time vapor-beta run analyze -l 10
+    echo Pausing...
+    sleep 2
+done

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,6 +40,7 @@ services:
     ports:
       - '8080:80'
     command: ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "80"]
+
   migrate:
     image: finestructure/spi-server:latest
     environment:
@@ -49,6 +50,7 @@ services:
     command: ["migrate", "--yes"]
     deploy:
       replicas: 0
+
   revert:
     image: finestructure/spi-server:latest
     environment:
@@ -58,6 +60,7 @@ services:
     command: ["migrate", "--revert", "--yes"]
     deploy:
       replicas: 0
+
   db:
     image: postgres:12.1-alpine
     volumes:
@@ -69,3 +72,34 @@ services:
       POSTGRES_DB: spi_dev
     ports:
       - '5432:5432'
+
+  # commands
+  reconcile:
+    image: finestructure/spi-server:latest
+    environment:
+      <<: *shared_environment
+    depends_on:
+      - db
+    command: ["reconcile"]
+    deploy:
+      replicas: 0
+
+  ingest:
+    image: finestructure/spi-server:latest
+    environment:
+      <<: *shared_environment
+    depends_on:
+      - db
+    command: ["ingest", "-l", "100"]
+    deploy:
+      replicas: 0
+
+  analyze:
+    image: finestructure/spi-server:latest
+    environment:
+      <<: *shared_environment
+    depends_on:
+      - db
+    command: ["analyze", "-l", "10"]
+    deploy:
+      replicas: 0


### PR DESCRIPTION
@daveverwer These are a few small fixes that cropped up while end-to-end testing processing all whole 2.7k packages.

I’ve now successfully processed everything locally and on my Digital Ocean box *) except for 5 packages I had to delete manually because they brought up the git login prompt (see #27 ) -EDIT: the commit I just added fixes this. It went well all in all!

I’ll send you the db details for the Digital Ocean DB to have a look at the data. We’ve got close to 30k versions and around 26k products (plus the 2.7 packages and repositories) in there now.

Have a look through the data - it should be mostly complete, except for a few minor omissions, I think (default branch versions and fork links, most notably). The main purpose was to run it end to end once to make sure processing isn’t interrupted by errors bubbling up and to have the full table structure with all entities in place.

*) The DO box ran out of disk space with 100 packages left to process 😅 - so that data is almost complete as well. The checkout size is 16.6GB now.