### PR TITLE
License enum

### DIFF
--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -69,9 +69,9 @@ func insertOrUpdateRepository(on database: Database, for package: Package, metad
         .flatMap { repo -> EventLoopFuture<Void> in
             if let repo = repo {
                 repo.defaultBranch = metadata.defaultBranch
-                repo.description = metadata.description
+                repo.summary = metadata.description
                 repo.forks = metadata.forksCount
-                repo.license = metadata.license?.key
+                repo.license = .init(from: metadata.license)
                 repo.stars = metadata.stargazersCount
                 // TODO: find and assign parent repo
                 return repo.save(on: database)

--- a/Sources/App/Migrations/CreateRepository.swift
+++ b/Sources/App/Migrations/CreateRepository.swift
@@ -11,7 +11,7 @@ struct CreateRepository: Migration {
             // TODO: adapt to "official" way, once it's there
             // https://discordapp.com/channels/431917998102675485/684159753189982218/703351108915036171
             .unique(on: "package_id")
-            .field("description", .string)
+            .field("summary", .string)
             .field("default_branch", .string)
             .field("license", .string)
             .field("stars", .int)

--- a/Sources/App/Models/License.swift
+++ b/Sources/App/Models/License.swift
@@ -1,0 +1,30 @@
+
+enum License: String, Codable {
+    case agpl_3_0 = "agpl-3.0"
+    case apache_2_0 = "apache-2.0"
+    case bsd_2_clause = "bsd-2-clause"
+    case bsd_3_clause = "bsd-3-clause"
+    case cc0_1_0 = "cc0-1.0"
+    case epl_1_0 = "epl-1.0"
+    case gpl_3_0 = "gpl-3.0"
+    case isc
+    case lgpl_2_1 = "lgpl-2.1"
+    case lgpl_3_0 = "lgpl-3.0"
+    case mit
+    case mpl_2_0 = "mpl-2.0"
+    case other
+    case unlicense  // TODO: is this an actual license name or meant to say "unlicensed"?
+    case zlib
+    case none
+}
+
+
+extension License {
+    init(from dto: Github.License?) {
+        if let key = dto?.key {
+            self = License(rawValue: key) ?? .other
+        } else {
+            self = .none
+        }
+    }
+}

--- a/Sources/App/Models/License.swift
+++ b/Sources/App/Models/License.swift
@@ -13,7 +13,7 @@ enum License: String, Codable {
     case mit
     case mpl_2_0 = "mpl-2.0"
     case other
-    case unlicense  // TODO: is this an actual license name or meant to say "unlicensed"?
+    case unlicense  // NB: this is an actual license and *not* a typo of "unlicensed"
     case zlib
     case none
 }

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -19,14 +19,14 @@ final class Repository: Model, Content {
     @Parent(key: "package_id")
     var package: Package
 
-    @Field(key: "description")
-    var description: String?
+    @Field(key: "summary")
+    var summary: String?
 
     @Field(key: "default_branch")
     var defaultBranch: String?
 
     @Field(key: "license")
-    var license: String?
+    var license: License
 
     @Field(key: "stars")
     var stars: Int?
@@ -41,15 +41,15 @@ final class Repository: Model, Content {
 
     init(id: Id? = nil,
          package: Package,
-         description: String? = nil,
+         summary: String? = nil,
          defaultBranch: String? = nil,
-         license: String? = nil,
+         license: License = .none,
          stars: Int? = nil,
          forks: Int? = nil,
          forkedFrom: Repository? = nil) throws {
         self.id = id
         self.$package.id = try package.requireID()
-        self.description = description
+        self.summary = summary
         self.defaultBranch = defaultBranch
         self.license = license
         self.stars = stars
@@ -62,9 +62,9 @@ final class Repository: Model, Content {
     init(id: Id? = nil, package: Package, metadata: Github.Metadata) throws {
         self.id = id
         self.$package.id = try package.requireID()
-        self.description = metadata.description
+        self.summary = metadata.description
         self.defaultBranch = metadata.defaultBranch
-        self.license = metadata.license?.key
+        self.license = .init(from: metadata.license)
         self.stars = metadata.stargazersCount
         self.forks = metadata.forksCount
         // if let parent = metadata.parent {

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -45,14 +45,14 @@ class IngestorTests: AppTestCase {
         do {  // test insert
             try insertOrUpdateRepository(on: app.db, for: pkg, metadata: .mock(for: pkg)).wait()
             let repos = try Repository.query(on: app.db).all().wait()
-            XCTAssertEqual(repos.map(\.description), [.some("This is package foo")])
+            XCTAssertEqual(repos.map(\.summary), [.some("This is package foo")])
         }
         do {  // test update - run the same package again, with different metadata
             var md = Github.Metadata.mock(for: pkg)
             md.description = "New description"
             try insertOrUpdateRepository(on: app.db, for: pkg, metadata: md).wait()
             let repos = try Repository.query(on: app.db).all().wait()
-            XCTAssertEqual(repos.map(\.description), [.some("New description")])
+            XCTAssertEqual(repos.map(\.summary), [.some("New description")])
         }
     }
 
@@ -154,7 +154,7 @@ class IngestorTests: AppTestCase {
         // validate
         let repos = try Repository.query(on: app.db).all().wait()
         XCTAssertEqual(repos.count, 2)
-        XCTAssertEqual(repos.map(\.description),
+        XCTAssertEqual(repos.map(\.summary),
                        [.some("This is package 1"), .some("This is package 3")])
         (try Package.query(on: app.db).all().wait()).forEach {
             if $0.url == "2" {

--- a/Tests/AppTests/LicenseTests.swift
+++ b/Tests/AppTests/LicenseTests.swift
@@ -1,0 +1,20 @@
+@testable import App
+
+import XCTVapor
+
+
+class LicenseTests: XCTestCase {
+
+    func test_init_from_dto() throws {
+        XCTAssertEqual(License(from: Github.License(key: "mit")), .mit)
+        XCTAssertEqual(License(from: Github.License(key: "agpl-3.0")), .agpl_3_0)
+        XCTAssertEqual(License(from: Github.License(key: "other")), .other)
+        XCTAssertEqual(License(from: .none), .none)
+    }
+
+    func test_init_from_dto_unknown() throws {
+        // ensure unknown licenses are mapped to `.other`
+        XCTAssertEqual(License(from: Github.License(key: "non-existing license")), .other)
+    }
+
+}

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -4,6 +4,25 @@ import XCTVapor
 
 
 final class RepositoryTests: AppTestCase {
+
+    func test_save() throws {
+        let pkg = Package(id: UUID(), url: "1", status: .none)
+        try pkg.save(on: app.db).wait()
+        let repo = try Repository(id: UUID(), package: pkg, summary: "desc", defaultBranch: "branch", license: .mit, stars: 42, forks: 17, forkedFrom: nil)
+
+        try repo.save(on: app.db).wait()
+
+        do {
+            let r = try XCTUnwrap(Repository.find(repo.id, on: app.db).wait())
+            XCTAssertEqual(r.$package.id, pkg.id)
+            XCTAssertEqual(r.summary, "desc")
+            XCTAssertEqual(r.defaultBranch, "branch")
+            XCTAssertEqual(r.license, .mit)
+            XCTAssertEqual(r.stars, 42)
+            XCTAssertEqual(r.forks, 17)
+            XCTAssertEqual(r.forkedFrom, nil)
+        }
+    }
     
     func test_package_relationship() throws {
         let pkg = Package(url: "p1")


### PR DESCRIPTION
- makes `License` an enum
- map unknown licenses to `.other`
- I've looked at the distinct values present in both the new and the old server, should be the complete list currently seen
