### PR TITLE
Issue 62 improve error handling

### DIFF
--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -141,11 +141,12 @@ func pullOrClone(application: Application, package: Package) -> EventLoopFuture<
 }
 
 
-func reconcileVersions(application: Application, checkouts: [Result<Package, Error>]) -> EventLoopFuture<[Result<[Version], Error>]> {
-    let ops = checkouts.map { checkout -> EventLoopFuture<[Version]> in
+func reconcileVersions(application: Application, checkouts: [Result<Package, Error>]) -> EventLoopFuture<[Result<(Package, [Version]), Error>]> {
+    let ops = checkouts.map { checkout -> EventLoopFuture<(Package, [Version])> in
         switch checkout {
             case .success(let pkg):
                 return reconcileVersions(application: application, package: pkg)
+                    .map { (pkg, $0) }
             case .failure(let error):
                 return application.eventLoopGroup.future(error: error)
         }

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -262,6 +262,7 @@ func updateStatus(application: Application, results: [Result<Package, Error>]) -
                                    stage: .analysis)
         }
     }
+    application.logger.debug("updateStatus ops: \(updates.count)")
     return EventLoopFuture.andAllComplete(updates, on: application.eventLoopGroup.next())
 }
 

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -174,8 +174,9 @@ func getManifests(versions: [Result<(Package, [Version]), Error>]) -> [Result<(P
         r.flatMap { (pkg, versions) -> Result<(Package, [(Version, Manifest)]), Error> in
             let m = versions.map { getManifest(package: pkg, version: $0) }
             let successes = m.compactMap { try? $0.get() }
-            let errors = m.compactMap { $0.getError() }
-            // TODO: report errors
+            // TODO: report errors (need client and database)
+            //            let errors = m.compactMap { $0.getError() }
+            //            errors.map { Current.reportError(client: client, database: database, error: $0, stage: .analysis) }
             guard !successes.isEmpty else { return .failure(AppError.noValidVersions(pkg.id, pkg.url)) }
             return .success((pkg, successes))
         }

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -29,7 +29,7 @@ struct AnalyzerCommand: Command {
 }
 
 
-func analyze(application: Application, id: Package.Id) throws -> EventLoopFuture<Void> {
+func analyze(application: Application, id: Package.Id) -> EventLoopFuture<Void> {
     let packages = Package.query(on: application.db)
         .with(\.$repositories)
         .filter(\.$id == id)
@@ -40,7 +40,7 @@ func analyze(application: Application, id: Package.Id) throws -> EventLoopFuture
 }
 
 
-func analyze(application: Application, limit: Int) throws -> EventLoopFuture<Void> {
+func analyze(application: Application, limit: Int) -> EventLoopFuture<Void> {
     let packages = Package.fetchCandidates(application.db, for: .analysis, limit: limit)
     return analyze(application: application, packages: packages)
 }

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -266,16 +266,3 @@ func updateStatus(application: Application, results: [Result<Package, Error>]) -
     application.logger.debug("updateStatus ops: \(updates.count)")
     return EventLoopFuture.andAllComplete(updates, on: application.eventLoopGroup.next())
 }
-
-
-// FIXME: move
-extension Result {
-    func getError() -> Error? {
-        switch self {
-        case .success:
-            return nil
-        case .failure(let error):
-            return error
-        }
-    }
-}

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -91,6 +91,7 @@ func insertOrUpdateRepository(on database: Database, for package: Package, metad
 
 
 // TODO: sas: 2020-05-15: clean this up
+// https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/69
 func recordError(client: Client, database: Database, error: Error, stage: ProcessingStage) -> EventLoopFuture<Void> {
     let errorReport = Current.reportError(client, .error, error)
 

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -113,7 +113,7 @@ func recordError(client: Client, database: Database, error: Error, stage: Proces
         case let .genericError(id, _):
             return setStatus(id: id, status: .ingestionFailed)
         case let .invalidPackageCachePath(id, _):
-            return setStatus(id: id, status: .analysisFailed)
+            return setStatus(id: id, status: .invalidCachePath)
         case let .invalidPackageUrl(id, _):
             return setStatus(id: id, status: .invalidUrl)
         case let .invalidRevision(id, _):

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -57,7 +57,7 @@ func updateTables(client: Client, database: Database, result: Result<PackageMeta
                 return pkg.save(on: database)
             }
     } catch {
-        return recordIngestionError(client: client, database: database, error: error)
+        return recordError(client: client, database: database, error: error, stage: .ingestion)
     }
 }
 
@@ -90,30 +90,38 @@ func insertOrUpdateRepository(on database: Database, for package: Package, metad
 }
 
 
-func recordIngestionError(client: Client, database: Database, error: Error) -> EventLoopFuture<Void> {
+// TODO: sas: 2020-05-15: clean this up
+func recordError(client: Client, database: Database, error: Error, stage: ProcessingStage) -> EventLoopFuture<Void> {
     let errorReport = Current.reportError(client, .error, error)
 
     func setStatus(id: Package.Id?, status: Status) -> EventLoopFuture<Void> {
-        Package.find(id, on: database).flatMap { pkg in
-            guard let pkg = pkg else { return database.eventLoop.makeSucceededFuture(()) }
-            pkg.status = status
-            pkg.processingStage = .ingestion
-            return pkg.save(on: database)
-                .flatMap { errorReport }
-        }
+        guard let id = id else { return database.eventLoop.future() }
+        return Package.query(on: database)
+            .filter(\.$id == id)
+            .set(\.$processingStage, to: stage)
+            .set(\.$status, to: status)
+            .update()
+
     }
 
-    database.logger.error("Ingestion error: \(error.localizedDescription)")
+    database.logger.error("\(stage) error: \(error.localizedDescription)")
 
+    guard let error = error as? AppError else { return errorReport }
     switch error {
-        case let AppError.invalidPackageUrl(id, _):
-            return setStatus(id: id, status: .invalidUrl)
-        case let AppError.metadataRequestFailed(id, _, _):
-            return setStatus(id: id, status: .metadataRequestFailed)
-        case let AppError.genericError(id, _):
-            return setStatus(id: id, status: .ingestionFailed)
-        default:
+        case .envVariableNotSet:
             break
+        case let .genericError(id, _):
+            return setStatus(id: id, status: .ingestionFailed)
+        case let .invalidPackageCachePath(id, _):
+            return setStatus(id: id, status: .analysisFailed)
+        case let .invalidPackageUrl(id, _):
+            return setStatus(id: id, status: .invalidUrl)
+        case let .invalidRevision(id, _):
+            return setStatus(id: id, status: .analysisFailed)
+        case let .metadataRequestFailed(id, _, _):
+            return setStatus(id: id, status: .metadataRequestFailed)
+        case let .noValidVersions(id, _):
+            return setStatus(id: id, status: .noValidVersions)
     }
 
     return errorReport

--- a/Sources/App/Controllers/API/APIPackageController.swift
+++ b/Sources/App/Controllers/API/APIPackageController.swift
@@ -49,7 +49,7 @@ extension API {
                             Command.Response(status: "ok", rows: limit)
                 }
                 case .analyze:
-                    return try analyze(application: req.application, limit: limit)
+                    return analyze(application: req.application, limit: limit)
                         .map {
                             Command.Response(status: "ok", rows: limit)
                 }

--- a/Sources/App/Core/AppError.swift
+++ b/Sources/App/Core/AppError.swift
@@ -9,12 +9,13 @@ import Vapor
 
 
 enum AppError: LocalizedError {
-    case envVariableNotSet(String)
-    case invalidPackageUrl(Package.Id?, String)
-    case invalidPackageCachePath(Package.Id?, String)
-    case invalidRevision(Version.Id?, String?)
+    case envVariableNotSet(_ variable: String)
+    case invalidPackageUrl(Package.Id?, _ url: String)
+    case invalidPackageCachePath(Package.Id?, _ path: String)
+    case invalidRevision(Version.Id?, _ revision: String?)
     case metadataRequestFailed(Package.Id?, HTTPStatus, URI)
-    case genericError(Package.Id?, String)
+    case noValidVersions(Package.Id?, _ url: String)
+    case genericError(Package.Id?, _ message: String)
 
     var localizedDescription: String {
         switch self {
@@ -28,6 +29,8 @@ enum AppError: LocalizedError {
                 return "Invalid revision: \(value ?? "nil") (id: \(String(describing: id)))"
             case let .metadataRequestFailed(id, status, uri):
                 return "Metadata request for URI '\(uri.description)' failed with status '\(status)'  (id: \(String(describing: id)))"
+            case let .noValidVersions(id, value):
+                return "No valid version found for package '\(value)' (id: \(String(describing: id)))"
             case let .genericError(id, value):
                 return "Generic error: \(value) (id: \(String(describing: id)))"
         }

--- a/Sources/App/Core/AppError.swift
+++ b/Sources/App/Core/AppError.swift
@@ -8,26 +8,6 @@
 import Vapor
 
 
-//struct ProcessingError: LocalizedError {
-//    var packageId: Package.Id?
-//    var type: Type
-//
-//    enum `Type` {
-//        case invalidPackageCachePath(_ url: String)
-//        case invalidPackageURL(_ url: String)
-//        case noValidVersions(_ url: String)
-//    }
-//
-//    var status: Status {
-//        switch type {
-//            case .invalidPackageCachePath: return .invalidCachePath
-//            case .invalidPackageURL: return .invalidUrl
-//            case .noValidVersions: return .noValidVersions
-//        }
-//    }
-//}
-
-
 enum AppError: LocalizedError {
     case envVariableNotSet(_ variable: String)
     case invalidPackageUrl(Package.Id?, _ url: String)

--- a/Sources/App/Core/AppError.swift
+++ b/Sources/App/Core/AppError.swift
@@ -8,22 +8,24 @@
 import Vapor
 
 
-struct ProcessingError: LocalizedError {
-    var packageId: Package.Id
-    var type: Type
-
-    enum `Type` {
-        case invalidPackageURL(_ url: String)
-        case noValidVersions(_ url: String)
-    }
-
-    var status: Status {
-        switch type {
-            case .invalidPackageURL: return .invalidUrl
-            case .noValidVersions: return .noValidVersions
-        }
-    }
-}
+//struct ProcessingError: LocalizedError {
+//    var packageId: Package.Id?
+//    var type: Type
+//
+//    enum `Type` {
+//        case invalidPackageCachePath(_ url: String)
+//        case invalidPackageURL(_ url: String)
+//        case noValidVersions(_ url: String)
+//    }
+//
+//    var status: Status {
+//        switch type {
+//            case .invalidPackageCachePath: return .invalidCachePath
+//            case .invalidPackageURL: return .invalidUrl
+//            case .noValidVersions: return .noValidVersions
+//        }
+//    }
+//}
 
 
 enum AppError: LocalizedError {

--- a/Sources/App/Core/AppError.swift
+++ b/Sources/App/Core/AppError.swift
@@ -8,6 +8,24 @@
 import Vapor
 
 
+struct ProcessingError: LocalizedError {
+    var packageId: Package.Id
+    var type: Type
+
+    enum `Type` {
+        case invalidPackageURL(_ url: String)
+        case noValidVersions(_ url: String)
+    }
+
+    var status: Status {
+        switch type {
+            case .invalidPackageURL: return .invalidUrl
+            case .noValidVersions: return .noValidVersions
+        }
+    }
+}
+
+
 enum AppError: LocalizedError {
     case envVariableNotSet(_ variable: String)
     case invalidPackageUrl(Package.Id?, _ url: String)

--- a/Sources/App/Core/Extensions/Result+ext.swift
+++ b/Sources/App/Core/Extensions/Result+ext.swift
@@ -1,0 +1,11 @@
+
+extension Result {
+    func getError() -> Error? {
+        switch self {
+        case .success:
+            return nil
+        case .failure(let error):
+            return error
+        }
+    }
+}

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -4,11 +4,13 @@ import Vapor
 
 enum Status: String, Codable {
     case ok
-    case invalidUrl = "invalid_url"
-    case notFound = "not_found"
-    case metadataRequestFailed = "metadata_request_failed"
-    case ingestionFailed = "ingestion_failed"
+    // errors
     case analysisFailed = "analysis_failed"
+    case ingestionFailed = "ingestion_failed"
+    case invalidUrl = "invalid_url"
+    case metadataRequestFailed = "metadata_request_failed"
+    case notFound = "not_found"
+    case noValidVersions = "no_valid_versions"
 }
 
 

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -7,6 +7,7 @@ enum Status: String, Codable {
     // errors
     case analysisFailed = "analysis_failed"
     case ingestionFailed = "ingestion_failed"
+    case invalidCachePath = "invalid_cache_path"
     case invalidUrl = "invalid_url"
     case metadataRequestFailed = "metadata_request_failed"
     case notFound = "not_found"

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -272,23 +272,6 @@ class AnalyzerTests: AppTestCase {
 extension AnalyzerTests {
 
     func test_pullOrClone_error_handling() throws {
-        #warning("WIP")
-        try XCTSkipIf(true)
-        try savePackages(on: app.db, ["1", "2".gh].urls, processingStage: .ingestion)
-
-        let res: EventLoopFuture<[Package]> = Package.fetchCandidates(app.db, for: .analysis, limit: 10)
-            .flatMapEach(on: app.eventLoopGroup.next()) { pullOrClone(application: self.app, package: $0) }
-            .flatMapEach(on: app.eventLoopGroup.next()) { pkg in
-                pkg.status = .ok
-                return pkg.save(on: self.app.db).transform(to: pkg)
-        }
-        let packages = try res.wait()
-
-        XCTAssertEqual(packages.count, 2)
-        XCTAssertEqual(packages.map(\.status), [.ok, .ok, .ok])
-    }
-
-    func test_pullOrClone_error_handling_2() throws {
         try savePackages(on: app.db, ["1", "2".gh].urls, processingStage: .ingestion)
 
         let pkgs = Package.fetchCandidates(app.db, for: .analysis, limit: 10)

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -174,7 +174,7 @@ class AnalyzerTests: AppTestCase {
         try Repository(package: pkg, defaultBranch: "master").save(on: app.db).wait()
 
         // MUT
-        let versions = try _reconcileVersions(application: app, package: pkg).wait()
+        let versions = try reconcileVersions(application: app, package: pkg).wait()
 
         // validate
         assertEquals(versions, \.reference?.description, ["master", "1.2.3"])

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -216,7 +216,7 @@ class AnalyzerTests: AppTestCase {
         // validate
         XCTAssertEqual(results.count, 2)
         XCTAssertEqual(results.map(\.isSuccess), [false, true])
-        let versions = try XCTUnwrap(results.last).get()
+        let (_, versions) = try XCTUnwrap(results.last).get()
         assertEquals(versions, \.reference?.description, ["master", "1.2.3"])
     }
 

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -87,14 +87,8 @@ class AnalyzerTests: AppTestCase {
         // validate products (each version has 2 products)
         let products = try Product.query(on: app.db).sort(\.$name).all().wait()
         XCTAssertEqual(products.count, 4)
-        XCTAssertEqual(products[0].name, "p1")
-        XCTAssertEqual(products[0].type, .executable)
-        XCTAssertEqual(products[1].name, "p1")
-        XCTAssertEqual(products[1].type, .executable)
-        XCTAssertEqual(products[2].name, "p2")
-        XCTAssertEqual(products[2].type, .library)
-        XCTAssertEqual(products[3].name, "p2")
-        XCTAssertEqual(products[3].type, .library)
+        assertEquals(products, \.name, ["p1", "p1", "p2", "p2"])
+        assertEquals(products, \.type, [.executable, .executable, .library, .library])
     }
 
     func test_package_status() throws {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -174,7 +174,7 @@ class AnalyzerTests: AppTestCase {
         try Repository(package: pkg, defaultBranch: "master").save(on: app.db).wait()
 
         // MUT
-        let (_, versions) = try reconcileVersions(application: app, result: .success(pkg)).wait()
+        let versions = try _reconcileVersions(application: app, package: pkg).wait()
 
         // validate
         assertEquals(versions, \.reference?.description, ["master", "1.2.3"])
@@ -263,6 +263,18 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(try Version.query(on: app.db).count().wait(), 4)
         XCTAssertEqual(try Product.query(on: app.db).count().wait(), 8)
     }
+
+}
+
+
+// MARK: - error handling tests
+
+extension AnalyzerTests {
+
+    func test_pullOrClone_error_handling() throws {
+        // FIXME
+    }
+
 }
 
 

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -60,8 +60,6 @@ class ErrorReportingTests: AppTestCase {
     }
 
     func test_invalidPackageCachePath() throws {
-        #warning("WIP")
-        try XCTSkipIf(true)
         // setup
         try savePackages(on: app.db, ["1", "2"], processingStage: .ingestion)
 
@@ -70,7 +68,7 @@ class ErrorReportingTests: AppTestCase {
 
         // validation
         let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
-        XCTAssertEqual(packages.map(\.status), [.invalidUrl, .invalidUrl])
+        XCTAssertEqual(packages.map(\.status), [.invalidCachePath, .invalidCachePath])
     }
 
 }

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -59,4 +59,17 @@ class ErrorReportingTests: AppTestCase {
         XCTAssertEqual(reportedLevel, .error)
     }
 
+    func test_invalidPackageCachePath() throws {
+        try XCTSkipIf(true, "WIP")
+        // setup
+        try savePackages(on: app.db, ["1", "2"], processingStage: .ingestion)
+
+        // MUT
+        try analyze(application: app, limit: 10).wait()
+
+        // validation
+        let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+        XCTAssertEqual(packages.map(\.status), [.invalidUrl, .invalidUrl])
+    }
+
 }

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -60,7 +60,8 @@ class ErrorReportingTests: AppTestCase {
     }
 
     func test_invalidPackageCachePath() throws {
-        try XCTSkipIf(true, "WIP")
+        #warning("WIP")
+        try XCTSkipIf(true)
         // setup
         try savePackages(on: app.db, ["1", "2"], processingStage: .ingestion)
 

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -126,11 +126,13 @@ class IngestorTests: AppTestCase {
         XCTAssertEqual(md.map(\.isSuccess), [true, false, true])
     }
 
-    func test_recordIngestionError() throws {
+    // TODO: sas-2020-05-15: move
+    func test_recordError() throws {
         let pkg = try savePackage(on: app.db, "1")
-        try recordIngestionError(client: app.client,
-                                 database: app.db,
-                                 error: AppError.invalidPackageUrl(pkg.id, "foo")).wait()
+        try recordError(client: app.client,
+                        database: app.db,
+                        error: AppError.invalidPackageUrl(pkg.id, "foo"),
+                        stage: .ingestion).wait()
         do {
             let pkg = try fetch(id: pkg.id, on: app.db)
             XCTAssertEqual(pkg.status, .invalidUrl)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ x-shared: &shared
     # set these variables via the environment or a `.env` file, which
     # docker-compose reads and uses to populate variables
     CHECKOUTS_DIR: ${CHECKOUTS_DIR}
+    ENV: "production"
     DATABASE_HOST: ${DATABASE_HOST}
     DATABASE_PORT: ${DATABASE_PORT}
     DATABASE_NAME: ${DATABASE_NAME}
@@ -27,7 +28,7 @@ services:
       - migrate
     ports:
       - '8080:80'
-    command: ["serve", "--env", "production", "--hostname", "0.0.0.0", "--port", "80"]
+    command: ["serve", "--env", "${ENV}", "--hostname", "0.0.0.0", "--port", "80"]
     deploy:
       update_config:
         order: start-first
@@ -39,7 +40,7 @@ services:
       - migrate
     entrypoint: ["/bin/bash"]
     command: ["-c", "--",
-      "trap : TERM INT; while true; do ./Run reconcile; sleep ${RECONCILE_SLEEP:-120}; done"
+      "trap : TERM INT; while true; do ./Run reconcile --env ${ENV}; sleep ${RECONCILE_SLEEP:-120}; done"
     ]
 
   ingest:
@@ -49,7 +50,7 @@ services:
       - migrate
     entrypoint: ["/bin/bash"]
     command: ["-c", "--",
-      "trap : TERM INT; while true; do ./Run ingest --limit ${INGEST_LIMIT:-100}; sleep ${INGEST_SLEEP:-10}; done"
+      "trap : TERM INT; while true; do ./Run ingest --env ${ENV} --limit ${INGEST_LIMIT:-100}; sleep ${INGEST_SLEEP:-10}; done"
     ]
 
   analyze:
@@ -59,7 +60,7 @@ services:
       - migrate
     entrypoint: ["/bin/bash"]
     command: ["-c", "--",
-      "trap : TERM INT; while true; do ./Run analyze --limit ${ANALYZE_LIMIT:-50}; sleep ${ANALYZE_SLEEP:-10}; done"
+      "trap : TERM INT; while true; do ./Run analyze --env ${ENV} --limit ${ANALYZE_LIMIT:-50}; sleep ${ANALYZE_SLEEP:-10}; done"
     ]
 
   migrate:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ x-shared: &shared
     DATABASE_USERNAME: ${DATABASE_USERNAME}
     DATABASE_PASSWORD: ${DATABASE_PASSWORD}
     GITHUB_TOKEN: ${GITHUB_TOKEN}
+    ROLLBAR_TOKEN: ${ROLLBAR_TOKEN}
     LOG_LEVEL: ${LOG_LEVEL}
   volumes:
     - checkouts:/checkouts

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ x-shared: &shared
     # set these variables via the environment or a `.env` file, which
     # docker-compose reads and uses to populate variables
     CHECKOUTS_DIR: ${CHECKOUTS_DIR}
-    ENV: "production"
     DATABASE_HOST: ${DATABASE_HOST}
     DATABASE_PORT: ${DATABASE_PORT}
     DATABASE_NAME: ${DATABASE_NAME}


### PR DESCRIPTION
This reworks the analysis part of #62 

I still needs to go through the Ingestor and there are some other things I need to clean up but I wanted to push this out before it gets even bigger.

This main cleans up `Analyzer`, avoid a mix of throwing, futures, and Results in favour of just futures and Results. It also adds more tests to the individual stages and makes the main `analyze` function (line 49++) more organised and cleaner. I hope it's more readable now!

I've also added an issue to go in and add some doc strings (#68 ) and a follow up around testing (#69 )

Just maybe a couple of lines to the point of this exercise: it's very easy to accidentally return early from an array of futures and there are a few ways this can happen:

- calling `flatten` on an array of futures
- throwing exceptions into that flatten or any other "gatherer" that calles `.andAllSuceed` or one of the family

Esp the throwing is easily done accidentally by forgetting to wrap an error into a future instead of throwing. What this does then is collapse arrays of futures into returning as soon as the first future fails (short circuiting).

So the exercise here was to remove or encapsulate throws and make sure we use `whenAllComplete` and `andAllComplete`. This also allowed me to reduce some of the nesting inside the main `analyze` function.

I hope all this makes some sense, happy to take a look at it together!