### PR TITLE
Logging improvements

### DIFF
--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -181,8 +181,9 @@ func reconcileVersions(application: Application, package: Package) -> EventLoopF
         return try Git.tag(at: cacheDir)
     }
     .flatMapError {
-        Current.reportError(application.client, .error,
-                            AppError.genericError(pkgId, "Git.tag failed: \($0.localizedDescription)"))
+        let appError = AppError.genericError(pkgId, "Git.tag failed: \($0.localizedDescription)")
+        application.logger.report(error: appError)
+        return Current.reportError(application.client, .error, appError)
             .transform(to: [])
     }
 

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -70,7 +70,7 @@ func analyze(application: Application, packages: EventLoopFuture<[Package]>) -> 
 
     let versions = checkouts.flatMap { reconcileVersions(application: application, checkouts: $0) }
 
-    let versionsAndManifests = versions.map(getManifests)
+    let versionsAndManifests = versions.map { getManifests(application: application, versions: $0) }
 
     let updateOps = versionsAndManifests.flatMap { updateVersionsAndProducts(on: application.db,
                                                                              results: $0) }
@@ -210,15 +210,15 @@ func reconcileVersions(application: Application, package: Package) -> EventLoopF
 }
 
 
-func getManifests(versions: [Result<(Package, [Version]), Error>]) -> [Result<(Package, [(Version, Manifest)]), Error>] {
-    versions.map { (r: Result<(Package, [Version]), Error>) -> Result<(Package, [(Version, Manifest)]), Error> in
-
-        r.flatMap { (pkg, versions) -> Result<(Package, [(Version, Manifest)]), Error> in
+func getManifests(application: Application,
+                  versions: [Result<(Package, [Version]), Error>]) -> [Result<(Package, [(Version, Manifest)]), Error>] {
+    versions.map { result -> Result<(Package, [(Version, Manifest)]), Error> in
+        result.flatMap { (pkg, versions) -> Result<(Package, [(Version, Manifest)]), Error> in
             let m = versions.map { getManifest(package: pkg, version: $0) }
             let successes = m.compactMap { try? $0.get() }
-            // TODO: report errors (need client and database)
-            //            let errors = m.compactMap { $0.getError() }
-            //            errors.map { Current.reportError(client: client, database: database, error: $0, stage: .analysis) }
+            let errors = m.compactMap { $0.getError() }
+                .map { AppError.genericError(pkg.id, "getManifests failed: \($0.localizedDescription)") }
+            errors.forEach { application.logger.report(error: $0) }
             guard !successes.isEmpty else { return .failure(AppError.noValidVersions(pkg.id, pkg.url)) }
             return .success((pkg, successes))
         }

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -12,10 +12,8 @@ func updateStatus(application: Application,
                 pkg.processingStage = stage
                 return pkg.update(on: application.db)
             case .failure(let error):
-                return recordError(client: application.client,
-                                   database: application.db,
-                                   error: error,
-                                   stage: stage)
+                return Current.reportError(application.client, .error, error)
+                    .flatMap { recordError(database: application.db, error: error, stage: stage) }
         }
     }
     application.logger.debug("updateStatus ops: \(updates.count)")
@@ -23,14 +21,9 @@ func updateStatus(application: Application,
 }
 
 
-// TODO: sas: 2020-05-15: clean this up
-// https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/69
-func recordError(client: Client,
-                 database: Database,
+func recordError(database: Database,
                  error: Error,
                  stage: ProcessingStage) -> EventLoopFuture<Void> {
-    let errorReport = Current.reportError(client, .error, error)
-
     func setStatus(id: Package.Id?, status: Status) -> EventLoopFuture<Void> {
         guard let id = id else { return database.eventLoop.future() }
         return Package.query(on: database)
@@ -43,10 +36,11 @@ func recordError(client: Client,
 
     database.logger.error("\(stage) error: \(error.localizedDescription)")
 
-    guard let error = error as? AppError else { return errorReport }
+    guard let error = error as? AppError else { return database.eventLoop.future() }
+
     switch error {
         case .envVariableNotSet:
-            break
+            return database.eventLoop.future()
         case let .genericError(id, _):
             return setStatus(id: id, status: .ingestionFailed)
         case let .invalidPackageCachePath(id, _):
@@ -60,6 +54,4 @@ func recordError(client: Client,
         case let .noValidVersions(id, _):
             return setStatus(id: id, status: .noValidVersions)
     }
-
-    return errorReport
 }

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -39,7 +39,7 @@ func recordError(database: Database,
     guard let error = error as? AppError else { return database.eventLoop.future() }
 
     switch error {
-        case .envVariableNotSet:
+        case .envVariableNotSet, .shellCommandFailed:
             return database.eventLoop.future()
         case let .genericError(id, _):
             return setStatus(id: id, status: .ingestionFailed)

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -67,7 +67,12 @@ struct Shell {
     // also provide pass-through methods to preserve argument labels
     @discardableResult
     func run(command: ShellOutCommand, at path: String = ".") throws -> String {
-        try run(command, path)
+        do {
+            return try run(command, path)
+        } catch {
+            // re-package error to capture more information
+            throw AppError.shellCommandFailed(command.string, path, error.localizedDescription)
+        }
     }
 
     static let live: Self = .init(run: { cmd, path in

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -10,6 +10,7 @@ struct AppEnvironment {
     var githubToken: () -> String?
     var reportError: (_ client: Client, _ level: AppError.Level, _ error: Error) -> EventLoopFuture<Void>
     var rollbarToken: () -> String?
+    var rollbarLogLevel: () -> AppError.Level
     var shell: Shell
 }
 
@@ -22,6 +23,10 @@ extension AppEnvironment {
         githubToken: { Environment.get("GITHUB_TOKEN") },
         reportError: AppError.report,
         rollbarToken: { Environment.get("ROLLBAR_TOKEN") },
+        rollbarLogLevel: {
+            Environment
+                .get("ROLLBAR_LOG_LEVEL")
+                .flatMap(AppError.Level.init(rawValue:)) ?? .critical },
         shell: .live
     )
 }

--- a/Sources/App/Core/AppError.swift
+++ b/Sources/App/Core/AppError.swift
@@ -15,6 +15,8 @@ enum AppError: LocalizedError {
     case invalidRevision(Version.Id?, _ revision: String?)
     case metadataRequestFailed(Package.Id?, HTTPStatus, URI)
     case noValidVersions(Package.Id?, _ url: String)
+    case shellCommandFailed(_ command: String, _ path: String, _ message: String)
+
     case genericError(Package.Id?, _ message: String)
 
     var localizedDescription: String {
@@ -31,6 +33,13 @@ enum AppError: LocalizedError {
                 return "Metadata request for URI '\(uri.description)' failed with status '\(status)'  (id: \(String(describing: id)))"
             case let .noValidVersions(id, value):
                 return "No valid version found for package '\(value)' (id: \(String(describing: id)))"
+            case let .shellCommandFailed(command, path, message):
+                return """
+                    Shell command failed:
+                    command: "\(command)"
+                    path:    "\(path)"
+                    message: "\(message)"
+                    """
             case let .genericError(id, value):
                 return "Generic error: \(value) (id: \(String(describing: id)))"
         }

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -12,6 +12,7 @@ enum Status: String, Codable {
     case metadataRequestFailed = "metadata_request_failed"
     case notFound = "not_found"
     case noValidVersions = "no_valid_versions"
+    case shellCommandFailed = "shell_command_failed"
 }
 
 

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -337,7 +337,7 @@ class AnalyzerTests: AppTestCase {
         ]
 
         // MUT
-        let results = getManifests(versions: versions)
+        let results = getManifests(application: app, versions: versions)
 
         // validation
         XCTAssertEqual(commands, [

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -84,4 +84,10 @@ class ErrorReportingTests: AppTestCase {
         XCTAssertEqual(packages.map(\.status), [.invalidCachePath, .invalidCachePath])
     }
 
+    func test_AppError_Level_Comparable() throws {
+        XCTAssert(AppError.Level.critical > .error)
+        XCTAssert(AppError.Level.error <= .critical)
+        XCTAssert(AppError.Level.error <= .error)
+    }
+
 }

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -7,8 +7,7 @@ class ErrorReportingTests: AppTestCase {
 
     func test_recordError() throws {
         let pkg = try savePackage(on: app.db, "1")
-        try recordError(client: app.client,
-                        database: app.db,
+        try recordError(database: app.db,
                         error: AppError.invalidPackageUrl(pkg.id, "foo"),
                         stage: .ingestion).wait()
         do {

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -15,6 +15,7 @@ extension AppEnvironment {
         githubToken: { nil },
         reportError: { _, _, _ in .just(value: ()) },
         rollbarToken: { nil },
+        rollbarLogLevel: { .critical },
         shell: .mock
     )
 }


### PR DESCRIPTION
Merge after #132 

Fixes #133 by adding a `ROLLBAR_LOG_LEVEL` env variable (defaulting to `critical` if unset), allowing us to manage the level externally. We're only reporting one critical error at the moment, so this will reign in errors we're reporting.

Fixes #135 

While it's hard to capture the package id or url without wrapping all shell.run calls in error handlers, it's quite simple to at least add the command and path to the existing exceptions. Give that most commands provide enough context from that alone, this should help us with debugging quite a bit. If we still need more, we can go in an wrap the areas where we're lacking detail.