### PR TITLE
Clean up index.lock files

### DIFF
--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -98,6 +98,11 @@ func pullOrClone(application: Application, package: Package) -> EventLoopFuture<
     return application.threadPool.runIfActive(eventLoop: application.eventLoopGroup.next()) {
         if Current.fileManager.fileExists(atPath: cacheDir) {
             application.logger.info("pulling \(package.url) in \(cacheDir)")
+            // clean up stray index.lock files that might remain from aborted commands
+            let indexLock = cacheDir + "/.git/index.lock"
+            if Current.fileManager.fileExists(atPath: indexLock) {
+                try Current.shell.run(command: .removeFile(from: indexLock))
+            }
             // git reset --hard to deal with stray .DS_Store files on macOS
             try Current.shell.run(command: .init(string: "git reset --hard"), at: cacheDir)
             let branch = package.repository?.defaultBranch ?? "master"

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -101,6 +101,7 @@ func pullOrClone(application: Application, package: Package) -> EventLoopFuture<
             // clean up stray index.lock files that might remain from aborted commands
             let indexLock = cacheDir + "/.git/index.lock"
             if Current.fileManager.fileExists(atPath: indexLock) {
+                application.logger.info("Removing stale index.lock at path: \(indexLock)")
                 try Current.shell.run(command: .removeFile(from: indexLock))
             }
             // git reset --hard to deal with stray .DS_Store files on macOS

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -506,7 +506,7 @@ class AnalyzerTests: AppTestCase {
 
         // validation
         XCTAssertEqual(res.map(\.isSuccess), [true])
-        assertSnapshot(matching: commands, as: .dump, record: true)
+        assertSnapshot(matching: commands, as: .dump)
     }
 }
 

--- a/Tests/AppTests/__Snapshots__/AnalyzerTests/test_issue_70.1.txt
+++ b/Tests/AppTests/__Snapshots__/AnalyzerTests/test_issue_70.1.txt
@@ -1,0 +1,5 @@
+▿ 4 elements
+  - "rm \"-f\" \".../github.com-foo-1/.git/index.lock\""
+  - "git reset --hard"
+  - "git checkout \"master\" --quiet"
+  - "git pull --quiet"


### PR DESCRIPTION
Fixes #70 

There are quite a few commands that trip over existing `index.lock` files and it'd be tedious to instrument them all with a coping mechanism.

I think what's happening when an `index.lock` sticks around is that an analysis process gets interrupted midstream and then the next job can't proceed. So I think simply ensuring that we clean up stray files should be good enough.