### PR TITLE
Bump re-ingestion deadtime to 90 mins

### DIFF
--- a/Sources/App/Core/Constants.swift
+++ b/Sources/App/Core/Constants.swift
@@ -21,7 +21,7 @@ enum Constants {
     static let recentPackagesLimit = 7
     static let recentReleasesLimit = 7
 
-    static let reIngestionDeadtime: TimeInterval = 60 * 60  // in seconds
+    static let reIngestionDeadtime: TimeInterval = 90 * 60  // in seconds
 
     static let searchLimit = 20
     static let searchLimitLeeway = 5

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -69,7 +69,7 @@ class PipelineTests: AppTestCase {
             Package(url: "2", status: .ok, processingStage: .analysis),
             ].save(on: app.db).wait()
         let p2 = try Package.query(on: app.db).filter(by: "2").first().wait()!
-        let sql = "update packages set updated_at = updated_at - interval '61 mins' where id = '\(p2.id!.uuidString)'"
+        let sql = "update packages set updated_at = updated_at - interval '91 mins' where id = '\(p2.id!.uuidString)'"
         try (app.db as! SQLDatabase).raw(.init(sql)).run().wait()
         let batch = try Package.fetchCandidates(app.db, for: .ingestion, limit: 10).wait()
         XCTAssertEqual(batch.map(\.url), ["2"])


### PR DESCRIPTION
Quick one: I've been monitoring the rate limit counts and we're currently running out after about 40mins into the hour of budget. Bumping this a little to see the effect mainly, I'll properly look into run rates etc later but for now I want to check if the assumption is sound that this will conserve the budget.