### PR TITLE
Use in-memory fs for ~20% test speedup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,15 @@ db-up-dev:
 	docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 -d postgres:12.1-alpine
 
 db-up-test:
-	docker run --name spi_test -e POSTGRES_DB=spi_test -e POSTGRES_USER=spi_test -e POSTGRES_PASSWORD=xxx -p 5432:5432 -d postgres:12.1-alpine
+	docker run --name spi_test \
+		-e POSTGRES_DB=spi_test \
+		-e POSTGRES_USER=spi_test \
+		-e POSTGRES_PASSWORD=xxx \
+		-e PGDATA=/pgdata \
+		--tmpfs /pgdata:rw,noexec,nosuid,size=1024m \
+		-p 5432:5432 \
+		-d \
+		postgres:12.1-alpine
 
 db-down: db-down-dev db-down-test
 


### PR DESCRIPTION
Speeds up tests and avoid leaving behind a volume on disk