### PR TITLE
Url for

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,15 @@ db-up-dev:
 	docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 -d postgres:12.1-alpine
 
 db-up-test:
-	docker run --name spi_test -e POSTGRES_DB=spi_test -e POSTGRES_USER=spi_test -e POSTGRES_PASSWORD=xxx -p 5432:5432 -d postgres:12.1-alpine
+	docker run --name spi_test \
+		-e POSTGRES_DB=spi_test \
+		-e POSTGRES_USER=spi_test \
+		-e POSTGRES_PASSWORD=xxx \
+		-e PGDATA=/pgdata \
+		--tmpfs /pgdata:rw,noexec,nosuid,size=1024m \
+		-p 5432:5432 \
+		-d \
+		postgres:12.1-alpine
 
 db-down: db-down-dev db-down-test
 

--- a/Sources/App/Core/Resource.swift
+++ b/Sources/App/Core/Resource.swift
@@ -72,17 +72,3 @@ enum Root: Resourceable {
         }
     }
 }
-
-
-extension Array where Element == PathComponent {
-    static func path(for resource: Resourceable) -> [PathComponent] {
-        resource.pathComponents
-    }
-}
-
-
-extension PathComponent {
-    static func path(for resource: Resourceable) -> [PathComponent] {
-        resource.pathComponents
-    }
-}

--- a/Sources/App/Core/Resource.swift
+++ b/Sources/App/Core/Resource.swift
@@ -34,20 +34,23 @@ enum Root: Resourceable {
     case api(Api)
     case about
     case home
+    case images(String)
     case packages
     case package(_ parameter: Parameter<Package.Id>)
     case privacy
 
     var relativePath: String {
         switch self {
+            case .about:
+                return "about"
             case .admin:
                 return "admin"
             case .api:
                 return "api"
-            case .about:
-                return "about"
             case .home:
                 return ""
+            case let .images(name):
+                return "images/\(name)"
             case .packages, .package(.name):
                 return "packages"
             case let .package(.value(value)):
@@ -69,6 +72,8 @@ enum Root: Resourceable {
                 fatalError("pathComponents must not be called with a value parameter")
             case .admin, .about, .home, .packages, .privacy:
                 return [.init(stringLiteral: relativePath)]
+            case .images:
+                fatalError("invalid resource path for routing - only use in static HTML (DSL)")
         }
     }
 }

--- a/Sources/App/Core/Resource.swift
+++ b/Sources/App/Core/Resource.swift
@@ -86,15 +86,3 @@ extension PathComponent {
         resource.pathComponents
     }
 }
-
-
-
-extension RoutesBuilder {
-    // compensate for lack of a [PathComponent] intialiser
-    public func group(_ path: [PathComponent], configure: (RoutesBuilder) throws -> ()) rethrows {
-        guard let first = path.first, path.count < 2 else {
-            fatalError("path must be a single value")
-        }
-        try group(first, configure: configure)
-    }
-}

--- a/Sources/App/Core/Resource.swift
+++ b/Sources/App/Core/Resource.swift
@@ -1,0 +1,42 @@
+import Plot
+import Vapor
+
+
+enum Resource {
+    case admin
+    case about
+    case home
+    case packages(_ id: Package.Id)
+    case privacy
+
+    var relativePath: String {
+        switch self {
+            case .admin:
+                return "admin"
+            case .about:
+                return "about"
+            case .home:
+                return ""
+            case let .packages(id):
+                return "packages/\(id)"
+            case .privacy:
+                return "privacy"
+        }
+    }
+
+    var absolutePath: String { "/" + relativePath }
+}
+
+
+extension PathComponent {
+    static func url(for resource: Resource, relative: Bool = true) -> PathComponent {
+        .init(stringLiteral: relative ? resource.relativePath : resource.absolutePath)
+    }
+}
+
+
+extension Node where Context: HTMLLinkableContext {
+    static func href(_ resource: Resource) -> Node {
+        .attribute(named: "href", value: resource.absolutePath)
+    }
+}

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -111,9 +111,9 @@ class PublicPage {
             .div(
                 .class("inner"),
                 .a(
-                    .href("/"),
+                    .href(Root.home.absolutePath),
                     .h1(
-                        .img(.src("/images/logo.svg")),
+                        .img(.src(Root.images("logo.svg").absolutePath)),
                         "Swift Package Index"
                     )
                 ),

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -209,7 +209,7 @@ class PublicPage {
                         ),
                         .li(
                             .a(
-                                .href("/privacy"),
+                                .href(.privacy),
                                 "Privacy and Cookies"
                             )
                         ),

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -209,7 +209,7 @@ class PublicPage {
                         ),
                         .li(
                             .a(
-                                .href(.privacy),
+                                .href(Root.privacy.absolutePath),
                                 "Privacy and Cookies"
                             )
                         ),

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -7,14 +7,14 @@ func routes(_ app: Application) throws {
         HomeIndex.Model.query(database: req.db).map { HomeIndex.View($0).document() }
     }
 
-    app.get(.path(for: Root.privacy)) { _ in MarkdownPage("privacy.md").document() }
+    app.get(Root.privacy.pathComponents) { _ in MarkdownPage("privacy.md").document() }
 
     let packageController = PackageController()
-    app.get(.path(for: Root.packages), use: packageController.index)
-    app.get(.path(for: Root.package(.name("id"))), use: packageController.show)
+    app.get(Root.packages.pathComponents, use: packageController.index)
+    app.get(Root.package(.name("id")).pathComponents, use: packageController.show)
 
     do {  // admin
-        app.get(.path(for: Root.admin)) { req in PublicPage.admin() }
+        app.get(Root.admin.pathComponents) { req in PublicPage.admin() }
     }
 
     do {  // api

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -13,8 +13,8 @@ func routes(_ app: Application) throws {
     app.get(.path(for: Root.packages), use: packageController.index)
     app.get(.path(for: Root.package(.name("id"))), use: packageController.show)
 
-    app.group(.path(for: Root.admin)) { admin in
-        admin.get { req in PublicPage.admin() }
+    do {  // admin
+        app.get(.path(for: Root.admin)) { req in PublicPage.admin() }
     }
 
     do {  // api

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -7,20 +7,19 @@ func routes(_ app: Application) throws {
         HomeIndex.Model.query(database: req.db).map { HomeIndex.View($0).document() }
     }
 
-    app.get(.path(for: .privacy)) { _ in MarkdownPage("privacy.md").document() }
+    app.get(.path(for: Root.privacy)) { _ in MarkdownPage("privacy.md").document() }
 
     let packageController = PackageController()
-    app.get(.path(for: .packages), use: packageController.index)
-    app.get(.path(for: .package(.name("id"))), use: packageController.show)
+    app.get(.path(for: Root.packages), use: packageController.index)
+    app.get(.path(for: Root.package(.name("id"))), use: packageController.show)
 
-    app.group("admin") { admin in
+    app.group(.path(for: Root.admin)) { admin in
         admin.get { req in PublicPage.admin() }
     }
 
-    app.group("api") { api in
-        api.get("version") { req in API.Version(version: appVersion) }
-
-        api.get("search", use: API.SearchController.get)
+    do {  // api
+        app.get(Root.api(.version).pathComponents) { req in API.Version(version: appVersion) }
+        app.get(Root.api(.search).pathComponents, use: API.SearchController.get)
 
         // sas: 2020-05-19: shut down public API until we have an auth mechanism
         //  let apiPackageController = API.PackageController()

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -7,11 +7,11 @@ func routes(_ app: Application) throws {
         HomeIndex.Model.query(database: req.db).map { HomeIndex.View($0).document() }
     }
 
-    app.get(.url(for: .privacy)) { _ in MarkdownPage("privacy.md").document() }
+    app.get(.path(for: .privacy)) { _ in MarkdownPage("privacy.md").document() }
 
     let packageController = PackageController()
-    app.get("packages", use: packageController.index)
-    app.get("packages", ":id", use: packageController.show)
+    app.get(.path(for: .packages), use: packageController.index)
+    app.get(.path(for: .package(.name("id"))), use: packageController.show)
 
     app.group("admin") { admin in
         admin.get { req in PublicPage.admin() }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -1,12 +1,13 @@
 import Fluent
 import Vapor
 
+
 func routes(_ app: Application) throws {
     app.get { req in
         HomeIndex.Model.query(database: req.db).map { HomeIndex.View($0).document() }
     }
 
-    app.get("privacy") { _ in MarkdownPage("privacy.md").document() }
+    app.get(.url(for: .privacy)) { _ in MarkdownPage("privacy.md").document() }
 
     let packageController = PackageController()
     app.get("packages", use: packageController.index)

--- a/Tests/AppTests/ResourceTests.swift
+++ b/Tests/AppTests/ResourceTests.swift
@@ -9,23 +9,27 @@ class ResourceTests: XCTestCase {
     let pkgId: Package.Id = UUID(uuidString: "CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE")!
 
     func test_path() throws {
-        let p = PathComponent.path(for: .privacy)
+        let p = PathComponent.path(for: Root.privacy)
         XCTAssertEqual(p.map(\.description), ["privacy"])
     }
 
     func test_path_with_parameter() throws {
-        let p = PathComponent.path(for: .package(.name("id")))
+        let p = PathComponent.path(for: Root.package(.name("id")))
         XCTAssertEqual(p.map(\.description), ["packages", ":id"])
     }
 
+    func test_path_nested() throws {
+        let p = PathComponent.path(for: Root.api(.version))
+        XCTAssertEqual(p.map(\.description), ["api", "version"])
+    }
+
     func test_href() throws {
-        let href = Node<HTML.LinkContext>.href(.privacy)
-        XCTAssertEqual(href.render(), #"href="/privacy""#)
+        XCTAssertEqual(Root.privacy.absolutePath, "/privacy")
     }
 
     func test_href_with_parameters() throws {
-        let href = Node<HTML.LinkContext>.href(.package(.value(pkgId)))
-        XCTAssertEqual(href.render(), #"href="/packages/CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE""#)
+        XCTAssertEqual(
+            Root.package(.value(pkgId)).absolutePath, "/packages/CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE")
     }
 
 }

--- a/Tests/AppTests/ResourceTests.swift
+++ b/Tests/AppTests/ResourceTests.swift
@@ -8,18 +8,18 @@ import XCTest
 class ResourceTests: XCTestCase {
     let pkgId: Package.Id = UUID(uuidString: "CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE")!
 
-    func test_path() throws {
-        let p = PathComponent.path(for: Root.privacy)
+    func test_pathComponents_simple() throws {
+        let p = Root.privacy.pathComponents
         XCTAssertEqual(p.map(\.description), ["privacy"])
     }
 
-    func test_path_with_parameter() throws {
-        let p = PathComponent.path(for: Root.package(.name("id")))
+    func test_pathComponents_with_parameter() throws {
+        let p = Root.package(.name("id")).pathComponents
         XCTAssertEqual(p.map(\.description), ["packages", ":id"])
     }
 
-    func test_path_nested() throws {
-        let p = PathComponent.path(for: Root.api(.version))
+    func test_pathComponents_nested() throws {
+        let p = Root.api(.version).pathComponents
         XCTAssertEqual(p.map(\.description), ["api", "version"])
     }
 

--- a/Tests/AppTests/ResourceTests.swift
+++ b/Tests/AppTests/ResourceTests.swift
@@ -23,7 +23,9 @@ class ResourceTests: XCTestCase {
         XCTAssertEqual(p.map(\.description), ["api", "version"])
     }
 
-    func test_href() throws {
+    func test_absolutePath() throws {
+        XCTAssertEqual(Root.home.absolutePath, "/")
+        XCTAssertEqual(Root.images("foo.png").absolutePath, "/images/foo.png")
         XCTAssertEqual(Root.privacy.absolutePath, "/privacy")
     }
 

--- a/Tests/AppTests/ResourceTests.swift
+++ b/Tests/AppTests/ResourceTests.swift
@@ -8,26 +8,14 @@ import XCTest
 class ResourceTests: XCTestCase {
     let pkgId: Package.Id = UUID(uuidString: "CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE")!
 
-    func test_url_for() throws {
-        do {  // default - relative
-            let p = PathComponent.url(for: .privacy)
-            XCTAssertEqual(p.description, "privacy")
-        }
-        do {  // absolute
-            let p = PathComponent.url(for: .privacy, relative: false)
-            XCTAssertEqual(p.description, "/privacy")
-        }
+    func test_path() throws {
+        let p = PathComponent.path(for: .privacy)
+        XCTAssertEqual(p.map(\.description), ["privacy"])
     }
 
-    func test_url_for_with_parameters() throws {
-        do {  // default - relative
-            let p = PathComponent.url(for: .packages(pkgId))
-            XCTAssertEqual(p.description, "packages/CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE")
-        }
-        do {  // absolute
-            let p = PathComponent.url(for: .packages(pkgId), relative: false)
-            XCTAssertEqual(p.description, "/packages/CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE")
-        }
+    func test_path_with_parameter() throws {
+        let p = PathComponent.path(for: .package(.name("id")))
+        XCTAssertEqual(p.map(\.description), ["packages", ":id"])
     }
 
     func test_href() throws {
@@ -36,7 +24,7 @@ class ResourceTests: XCTestCase {
     }
 
     func test_href_with_parameters() throws {
-        let href = Node<HTML.LinkContext>.href(.packages(pkgId))
+        let href = Node<HTML.LinkContext>.href(.package(.value(pkgId)))
         XCTAssertEqual(href.render(), #"href="/packages/CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE""#)
     }
 

--- a/Tests/AppTests/ResourceTests.swift
+++ b/Tests/AppTests/ResourceTests.swift
@@ -1,0 +1,43 @@
+@testable import App
+
+import Plot
+import Vapor
+import XCTest
+
+
+class ResourceTests: XCTestCase {
+    let pkgId: Package.Id = UUID(uuidString: "CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE")!
+
+    func test_url_for() throws {
+        do {  // default - relative
+            let p = PathComponent.url(for: .privacy)
+            XCTAssertEqual(p.description, "privacy")
+        }
+        do {  // absolute
+            let p = PathComponent.url(for: .privacy, relative: false)
+            XCTAssertEqual(p.description, "/privacy")
+        }
+    }
+
+    func test_url_for_with_parameters() throws {
+        do {  // default - relative
+            let p = PathComponent.url(for: .packages(pkgId))
+            XCTAssertEqual(p.description, "packages/CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE")
+        }
+        do {  // absolute
+            let p = PathComponent.url(for: .packages(pkgId), relative: false)
+            XCTAssertEqual(p.description, "/packages/CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE")
+        }
+    }
+
+    func test_href() throws {
+        let href = Node<HTML.LinkContext>.href(.privacy)
+        XCTAssertEqual(href.render(), #"href="/privacy""#)
+    }
+
+    func test_href_with_parameters() throws {
+        let href = Node<HTML.LinkContext>.href(.packages(pkgId))
+        XCTAssertEqual(href.render(), #"href="/packages/CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE""#)
+    }
+
+}


### PR DESCRIPTION
Fixes #172 

This ended up being quite a bit tricker in the end. Mainly, because I wanted to allow support both for referencing the urls in the DSL (via `.absolutePath` or `.relativePath`) but also in the routing defintion, via `.pathComponents`.

This way there's a single place where we define our Resources now: `Resources.swift`.

I've modified only a few places so far, as an example, but if we decide to go with this I'll go through and do the rest as well.