### PR TITLE
Owner package urls

### DIFF
--- a/Sources/App/Controllers/PackageController.swift
+++ b/Sources/App/Controllers/PackageController.swift
@@ -17,4 +17,15 @@ struct PackageController {
             .map { PackageShow.View($0).document() }
     }
 
+    func _show(req: Request) throws -> EventLoopFuture<HTML> {
+        guard
+            let owner = req.parameters.get("owner"),
+            let repository = req.parameters.get("repository")
+            else {
+                return req.eventLoop.future(error: Abort(.notFound))
+        }
+        return PackageShow.Model.query(database: req.db, owner: owner, repository: repository)
+            .map { PackageShow.View($0).document() }
+    }
+
 }

--- a/Sources/App/Migrations/002/CreateOwnerRepositoryIndex.swift
+++ b/Sources/App/Migrations/002/CreateOwnerRepositoryIndex.swift
@@ -1,0 +1,24 @@
+import Fluent
+import SQLKit
+
+
+struct CreateOwnerRepositoryIndex: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        return db.raw(
+            """
+            CREATE UNIQUE INDEX idx_repositories_owner_name
+            ON repositories (LOWER(owner), LOWER(name))
+            """
+        ).run()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        return db.raw("DROP INDEX idx_repositories_owner_name").run()
+    }
+}

--- a/Sources/App/Migrations/002/CreateRepositoriesNameIndex.swift
+++ b/Sources/App/Migrations/002/CreateRepositoriesNameIndex.swift
@@ -1,0 +1,26 @@
+import Fluent
+import SQLKit
+
+
+struct CreateRepositoriesNameIndex: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/176#issuecomment-637710906
+        // for details about this index
+        return db.raw("CREATE EXTENSION pg_trgm").run()
+            .flatMap {
+                db.raw("CREATE INDEX idx_repositories_name ON repositories USING gin (name gin_trgm_ops)").run() }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        return
+            db.raw("DROP INDEX idx_repositories_name").run()
+                .flatMap { db.raw("DROP EXTENSION pg_trgm").run() }
+    }
+}

--- a/Sources/App/Views/PackageController/PackageShow+Query.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Query.swift
@@ -29,6 +29,39 @@ extension PackageShow.Model {
             }
             .unwrap(or: Abort(.notFound))
     }
+
+    static func query(database: Database, owner: String, repository: String) -> EventLoopFuture<Self> {
+        let res = Package.query(on: database)
+            .with(\.$repositories)
+            .with(\.$versions) { $0.with(\.$products) }
+            .join(Repository.self, on: \Repository.$package.$id == \Package.$id)
+            // FIXME: make case-insensitive
+            .filter(Repository.self, \.$owner == owner)
+            .filter(Repository.self, \.$name == repository)
+            .first()
+
+           return res.unwrap(or: Abort(.notFound))
+            .map { p -> Self? in
+                // FIXME: factor out into Model.init?(_ package: Packae)
+
+                // we consider certain attributes as essential and return nil (raising .notFound)
+                guard let title = p.name() else { return nil }
+                return Self.init(title: title,
+                                 url: p.url,
+                                 license: p.repository?.license ?? .none,
+                                 // FIXME: we should probably also display an explainer
+                                 // when summery is nil
+                                 summary: p.repository?.summary ?? "–",
+                                 authors: p.authors(),
+                                 history: p.history(),
+                                 activity: p.activity(),
+                                 products: p.productCounts(),
+                                 releases: p.releaseInfo(),
+                                 languagePlatforms: p.languagePlatformInfo())
+            }
+            .unwrap(or: Abort(.notFound))
+    }
+
 }
 
 

--- a/Sources/App/Views/PackageController/PackageShow+Query.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Query.swift
@@ -48,27 +48,27 @@ extension PackageShow.Model {
                 DatabaseQuery.Value.bind(repository)
             )
             .first()
-
-           return res.unwrap(or: Abort(.notFound))
+        
+        return res.unwrap(or: Abort(.notFound))
             .map { p -> Self? in
                 // FIXME: factor out into Model.init?(_ package: Packae)
-
+                
                 // we consider certain attributes as essential and return nil (raising .notFound)
                 guard let title = p.name() else { return nil }
                 return Self.init(title: title,
                                  url: p.url,
                                  license: p.repository?.license ?? .none,
                                  // FIXME: we should probably also display an explainer
-                                 // when summery is nil
-                                 summary: p.repository?.summary ?? "–",
-                                 authors: p.authors(),
-                                 history: p.history(),
-                                 activity: p.activity(),
-                                 products: p.productCounts(),
-                                 releases: p.releaseInfo(),
-                                 languagePlatforms: p.languagePlatformInfo())
-            }
-            .unwrap(or: Abort(.notFound))
+                    // when summery is nil
+                    summary: p.repository?.summary ?? "–",
+                    authors: p.authors(),
+                    history: p.history(),
+                    activity: p.activity(),
+                    products: p.productCounts(),
+                    releases: p.releaseInfo(),
+                    languagePlatforms: p.languagePlatformInfo())
+        }
+        .unwrap(or: Abort(.notFound))
     }
 
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -36,6 +36,9 @@ public func configure(_ app: Application) throws {
         app.migrations.add(CreateRecentReleases())
         app.migrations.add(CreateSearch())
     }
+    do { // Migration 002 - unique owner/repository index
+        app.migrations.add(CreateOwnerRepositoryIndex())
+    }
 
     app.commands.use(ReconcilerCommand(), as: "reconcile")
     app.commands.use(IngestorCommand(), as: "ingest")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -38,6 +38,7 @@ public func configure(_ app: Application) throws {
     }
     do { // Migration 002 - unique owner/repository index
         app.migrations.add(CreateOwnerRepositoryIndex())
+        app.migrations.add(CreateRepositoriesNameIndex())
     }
 
     app.commands.use(ReconcilerCommand(), as: "reconcile")

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -13,6 +13,8 @@ func routes(_ app: Application) throws {
     app.get(SiteURL.packages.pathComponents, use: packageController.index)
     app.get(SiteURL.package(.name("id")).pathComponents, use: packageController.show)
 
+    app.get(SiteURL._package(.name("owner"), .name("repository")).pathComponents, use: packageController._show)
+
     do {  // admin
         // sas: 2020-06-01: disable admin page until we have an auth mechanism
         //  app.get(Root.admin.pathComponents) { req in PublicPage.admin() }

--- a/Tests/AppTests/Controllers/PackageControllerTests.swift
+++ b/Tests/AppTests/Controllers/PackageControllerTests.swift
@@ -46,4 +46,10 @@ class PackageControllerTests: AppTestCase {
         }
     }
 
+    func test_show_owner_repository() throws {
+        try app.test(.GET, "/owner/package") { response in
+            XCTAssertEqual(response.status, .ok)
+        }
+    }
+
 }

--- a/Tests/AppTests/PackageShowModelTests.swift
+++ b/Tests/AppTests/PackageShowModelTests.swift
@@ -36,6 +36,33 @@ class PackageShowModelTests: AppTestCase {
         XCTAssertEqual(m.products, .init(libraries: 1, executables: 0))
     }
 
+    func test_query_owner_repository() throws {
+        // setup
+        let pkg = try savePackage(on: app.db, "1".url)
+        try Repository(package: pkg,
+                       summary: "summary",
+                       defaultBranch: "master",
+                       license: .mit,
+                       name: "bar",
+                       owner: "foo",
+                       stars: 17,
+                       forks: 42).save(on: app.db).wait()
+        let version = try App.Version(package: pkg,
+                                      reference: .branch("master"),
+                                      packageName: "test package")
+        try version.save(on: app.db).wait()
+        try Product(version: version,
+                    type: .library, name: "lib 1").save(on: app.db).wait()
+
+        // MUT
+        let m = try PackageShow.Model.query(database: app.db, owner: "foo", repository: "bar").wait()
+
+        // validate
+        XCTAssertEqual(m.title, "test package")
+    }
+
+    // TODO: case-insensitive test_query_owner_repository
+
     func test_query_no_title() throws {
         // Tests behaviour when we're lacking data
         // setup package without package name

--- a/Tests/AppTests/PackageShowModelTests.swift
+++ b/Tests/AppTests/PackageShowModelTests.swift
@@ -61,6 +61,31 @@ class PackageShowModelTests: AppTestCase {
         XCTAssertEqual(m.title, "test package")
     }
 
+    func test_query_owner_repository_case_insensitivity() throws {
+        // setup
+        let pkg = try savePackage(on: app.db, "1".url)
+        try Repository(package: pkg,
+                       summary: "summary",
+                       defaultBranch: "master",
+                       license: .mit,
+                       name: "bar",
+                       owner: "foo",
+                       stars: 17,
+                       forks: 42).save(on: app.db).wait()
+        let version = try App.Version(package: pkg,
+                                      reference: .branch("master"),
+                                      packageName: "test package")
+        try version.save(on: app.db).wait()
+        try Product(version: version,
+                    type: .library, name: "lib 1").save(on: app.db).wait()
+
+        // MUT
+        let m = try PackageShow.Model.query(database: app.db, owner: "Foo", repository: "bar").wait()
+
+        // validate
+        XCTAssertEqual(m.title, "test package")
+    }
+
     // TODO: case-insensitive test_query_owner_repository
 
     func test_query_no_title() throws {

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -1,5 +1,6 @@
 @testable import App
 
+import SQLKit
 import XCTVapor
 
 
@@ -147,4 +148,17 @@ final class RepositoryTests: AppTestCase {
             XCTAssertEqual(try! Repository.query(on: app.db).all().wait().count, 1)
         }
     }
+
+    func test_name_index() throws {
+        let db = try XCTUnwrap(app.db as? SQLDatabase)
+        // Quick way to check index exists - this will throw
+        //   "server: index "idx_repositories_name" does not exist (DropErrorMsgNonExistent)"
+        // if it doesn't
+        XCTAssertNoThrow(try db.raw("DROP INDEX idx_repositories_name").run().wait())
+        // Recreate index or else the revert in the next tests setUp is going to fail
+        try db.raw(
+            "CREATE INDEX idx_repositories_name ON repositories USING gin (name gin_trgm_ops)"
+        ).run().wait()
+    }
+
 }


### PR DESCRIPTION
Adds owner/repository url support:

<img width="1142" alt="Screenshot 2020-06-03 at 07 40 17" src="https://user-images.githubusercontent.com/65520/83601538-10cd5100-a571-11ea-944a-1f59d480aa6a.png">

I think this works really well and I'll look to surface these everywhere in a follow-up.

This branch is a continuation of #252 . It's best to maybe look at #252 for its change but merge this one here to merge both, because their migrations are related and sit in the directory `002` together. (Although they can be run independenty just fine.)