### PR TITLE
Migrate Package.status to non-optional, defaulting to .new

### DIFF
--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -13,8 +13,8 @@ func updatePackage(application: Application,
                     .load(on: application.db)
                     .flatMap { pkg.$versions.load(on: application.db) }
                     .flatMap {
-                        if stage == .ingestion && pkg.status == .none {
-                            // newly ingested package: leave status == .none for fast-track
+                        if stage == .ingestion && pkg.status == .new {
+                            // newly ingested package: leave status == .new for fast-track
                             // analysis
                         } else {
                             pkg.status = .ok

--- a/Sources/App/Migrations/004/UpdatePackageStatusNew.swift
+++ b/Sources/App/Migrations/004/UpdatePackageStatusNew.swift
@@ -1,0 +1,27 @@
+import Fluent
+import SQLKit
+
+
+struct UpdatePackageStatusNew: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        return db.raw("ALTER TABLE packages ALTER COLUMN status SET DEFAULT 'new'").run()
+            .flatMap {
+                db.raw("ALTER TABLE packages ALTER COLUMN status SET NOT NULL").run()
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        return db.raw("ALTER TABLE packages ALTER COLUMN status DROP NOT NULL").run()
+            .flatMap {
+                db.raw("ALTER TABLE packages ALTER COLUMN status DROP DEFAULT").run()
+        }
+    }
+}

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -4,6 +4,7 @@ import Vapor
 
 enum Status: String, Codable {
     case ok
+    case new
     // errors
     case analysisFailed = "analysis_failed"
     case ingestionFailed = "ingestion_failed"
@@ -47,8 +48,8 @@ final class Package: Model, Content {
     @Field(key: "score")
     var score: Int?
 
-    @OptionalEnum(key: "status")
-    var status: Status?
+    @Enum(key: "status")
+    var status: Status
 
     @Field(key: "url")
     var url: String
@@ -66,7 +67,7 @@ final class Package: Model, Content {
     init(id: UUID? = nil,
          url: URL,
          score: Int? = nil,
-         status: Status? = nil,
+         status: Status = .new,
          processingStage: ProcessingStage? = nil) {
         self.id = id
         self.url = url.absoluteString
@@ -118,7 +119,7 @@ extension Package {
         Package.query(on: database)
             .with(\.$repositories)
             .filter(for: stage)
-            .sort(.sql(raw: "status IS NOT NULL"))
+            .sort(.sql(raw: "status != 'new'"))
             .sort(\.$updatedAt)
             .limit(limit)
             .all()

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -36,13 +36,16 @@ public func configure(_ app: Application) throws {
         app.migrations.add(CreateRecentReleases())
         app.migrations.add(CreateSearch())
     }
-    do { // Migration 002 - unique owner/repository index
+    do {  // Migration 002 - unique owner/repository index
         app.migrations.add(CreateOwnerRepositoryIndex())
         app.migrations.add(CreateRepositoriesNameIndex())
     }
-    do { // Migration 003 - update recent packages/releases views
+    do {  // Migration 003 - update recent packages/releases views
         app.migrations.add(UpdateRecentPackages1())
         app.migrations.add(UpdateRecentReleases1())
+    }
+    do {  // Migration 004 - make status required, defaulting to 'new'
+        app.migrations.add(UpdatePackageStatusNew())
     }
 
     app.commands.use(ReconcilerCommand(), as: "reconcile")

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -393,7 +393,7 @@ class AnalyzerTests: AppTestCase {
 
     func test_updateProducts() throws {
         // setup
-        let p = Package(id: UUID(), url: "1", status: .none)
+        let p = Package(id: UUID(), url: "1")
         let v = try Version(id: UUID(), package: p, reference: .tag(.init(1, 0, 0)), packageName: "1")
         let m = Manifest(name: "1", products: [.init(name: "p1", type: .library),
                                                .init(name: "p2", type: .executable)])

--- a/Tests/AppTests/Controllers/PackageControllerTests.swift
+++ b/Tests/AppTests/Controllers/PackageControllerTests.swift
@@ -10,7 +10,7 @@ class PackageControllerTests: AppTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         
-        let package = Package(id: testPackageId, url: "https://github.com/user/package.git", status: .none)
+        let package = Package(id: testPackageId, url: "https://github.com/user/package.git")
         let repository = try Repository(id: UUID(),
                                         package: package,
                                         summary: "This is a test package",

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -35,7 +35,7 @@ class IngestorTests: AppTestCase {
         // assert packages have been updated
         (try Package.query(on: app.db).all().wait()).forEach {
             XCTAssert($0.updatedAt! > lastUpdate)
-            XCTAssertEqual($0.status, .none)
+            XCTAssertEqual($0.status, .new)
             XCTAssertEqual($0.processingStage, .ingestion)
         }
     }
@@ -135,7 +135,7 @@ class IngestorTests: AppTestCase {
         // validate
         do {
             let pkgs = try Package.query(on: app.db).sort(\.$url).all().wait()
-            XCTAssertEqual(pkgs.map(\.status), [.metadataRequestFailed, .none])
+            XCTAssertEqual(pkgs.map(\.status), [.metadataRequestFailed, .new])
             XCTAssertEqual(pkgs.map(\.processingStage), [.ingestion, .ingestion])
         }
     }
@@ -145,7 +145,7 @@ class IngestorTests: AppTestCase {
         // them into analysis
         let pkgs = [
             Package(id: UUID(), url: "1", status: .ok, processingStage: .reconciliation),
-            Package(id: UUID(), url: "2", status: .none, processingStage: .reconciliation)
+            Package(id: UUID(), url: "2", status: .new, processingStage: .reconciliation)
             ]
         try pkgs.save(on: app.db).wait()
         let results: [Result<Package, Error>] = [ .success(pkgs[0]), .success(pkgs[1])]
@@ -156,7 +156,7 @@ class IngestorTests: AppTestCase {
         // validate
         do {
             let pkgs = try Package.query(on: app.db).sort(\.$url).all().wait()
-            XCTAssertEqual(pkgs.map(\.status), [.ok, .none])
+            XCTAssertEqual(pkgs.map(\.status), [.ok, .new])
             XCTAssertEqual(pkgs.map(\.processingStage), [.ingestion, .ingestion])
         }
     }
@@ -218,7 +218,7 @@ class IngestorTests: AppTestCase {
             if $0.url == "2" {
                 XCTAssertEqual($0.status, .metadataRequestFailed)
             } else {
-                XCTAssertEqual($0.status, .none)
+                XCTAssertEqual($0.status, .new)
             }
             XCTAssert($0.updatedAt! > lastUpdate)
         }
@@ -265,11 +265,11 @@ class IngestorTests: AppTestCase {
         // validate packages
         let pkgs = try Package.query(on: app.db).sort(\.$url).all().wait()
         // the first package gets the update ...
-        XCTAssertEqual(pkgs[0].status, .none)
+        XCTAssertEqual(pkgs[0].status, .new)
         XCTAssertEqual(pkgs[0].processingStage, .ingestion)
         XCTAssert(pkgs[0].updatedAt! > lastUpdate)
         // ... the second package remains unchanged ...
-        XCTAssertEqual(pkgs[1].status, nil)
+        XCTAssertEqual(pkgs[1].status, .new)
         XCTAssertEqual(pkgs[1].processingStage, .reconciliation)
         XCTAssert(pkgs[1].updatedAt! < lastUpdate)
         // ... and an error report has been triggered

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -141,7 +141,7 @@ class IngestorTests: AppTestCase {
     }
 
     func test_updatePackages_new() throws {
-        // Ensure newly ingested packages are passed on with status = nil to fast-track
+        // Ensure newly ingested packages are passed on with status = new to fast-track
         // them into analysis
         let pkgs = [
             Package(id: UUID(), url: "1", status: .ok, processingStage: .reconciliation),

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -28,9 +28,11 @@ final class PackageTests: AppTestCase {
 
     func test_save_status() throws {
         do {  // default status
-            try Package(url: "1").save(on: app.db).wait()
-            let pkg = try XCTUnwrap(try Package.query(on: app.db).first().wait())
-            XCTAssertEqual(pkg.status, .none)
+            let pkg = Package()  // avoid using init with default argument in order to test db default
+            pkg.url = "1"
+            try pkg.save(on: app.db).wait()
+            let readBack = try XCTUnwrap(try Package.query(on: app.db).first().wait())
+            XCTAssertEqual(readBack.status, .new)
         }
         do {  // with status
             try Package(url: "2", status: .ok).save(on: app.db).wait()

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -46,10 +46,10 @@ class PipelineTests: AppTestCase {
     }
 
     func test_fetchCandidates_ingestion_prefer_new() throws {
-        // make sure records with status = NULL come first, then least recent
+        // make sure records with status = new come first, then least recent
         try  [
             Package(url: "1", status: .notFound, processingStage: .reconciliation),
-            Package(url: "2", status: .none, processingStage: .reconciliation),
+            Package(url: "2", status: .new, processingStage: .reconciliation),
             Package(url: "3", status: .ok, processingStage: .reconciliation),
             ].save(on: app.db).wait()
         // fast forward our clock by the deadtime interval
@@ -85,12 +85,12 @@ class PipelineTests: AppTestCase {
     }
 
     func test_fetchCandidates_analysis_prefer_new() throws {
-        // Test pick up from ingestion stage with status = NULL: status = NULL first, then FIFO
+        // Test pick up from ingestion stage with status = new first, then FIFO
         try  [
             Package(url: "1", status: .notFound, processingStage: .ingestion),
             Package(url: "2", status: .ok, processingStage: .ingestion),
             Package(url: "3", status: .analysisFailed, processingStage: .ingestion),
-            Package(url: "4", status: .none, processingStage: .ingestion),
+            Package(url: "4", status: .new, processingStage: .ingestion),
             ].save(on: app.db).wait()
         let batch = try Package.fetchCandidates(app.db, for: .analysis, limit: 10).wait()
         XCTAssertEqual(batch.map(\.url), ["4", "1", "2", "3"])
@@ -119,7 +119,7 @@ class PipelineTests: AppTestCase {
         do {  // validate
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
             XCTAssertEqual(packages.map(\.url), ["1", "2", "3"].asGithubUrls)
-            XCTAssertEqual(packages.map(\.status), [.none, .none, .none])
+            XCTAssertEqual(packages.map(\.status), [.new, .new, .new])
             XCTAssertEqual(packages.map(\.processingStage), [.reconciliation, .reconciliation, .reconciliation])
         }
 
@@ -129,7 +129,7 @@ class PipelineTests: AppTestCase {
         do { // validate
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
             XCTAssertEqual(packages.map(\.url), ["1", "2", "3"].asGithubUrls)
-            XCTAssertEqual(packages.map(\.status), [.none, .none, .none])
+            XCTAssertEqual(packages.map(\.status), [.new, .new, .new])
             XCTAssertEqual(packages.map(\.processingStage), [.ingestion, .ingestion, .ingestion])
         }
 
@@ -152,7 +152,7 @@ class PipelineTests: AppTestCase {
         do {  // validate - only new package moves to .reconciliation stage
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
             XCTAssertEqual(packages.map(\.url), ["1", "3", "4"].asGithubUrls)
-            XCTAssertEqual(packages.map(\.status), [.ok, .ok, .none])
+            XCTAssertEqual(packages.map(\.status), [.ok, .ok, .new])
             XCTAssertEqual(packages.map(\.processingStage), [.analysis, .analysis, .reconciliation])
         }
 
@@ -162,7 +162,7 @@ class PipelineTests: AppTestCase {
         do {  // validate - only new package moves to .ingestion stage
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
             XCTAssertEqual(packages.map(\.url), ["1", "3", "4"].asGithubUrls)
-            XCTAssertEqual(packages.map(\.status), [.ok, .ok, .none])
+            XCTAssertEqual(packages.map(\.status), [.ok, .ok, .new])
             XCTAssertEqual(packages.map(\.processingStage), [.analysis, .analysis, .ingestion])
         }
 

--- a/Tests/AppTests/ProductTests.swift
+++ b/Tests/AppTests/ProductTests.swift
@@ -6,7 +6,7 @@ import XCTVapor
 class ProductTests: AppTestCase {
 
     func test_Product_save() throws {
-        let pkg = Package(id: UUID(), url: "1", status: .none)
+        let pkg = Package(id: UUID(), url: "1")
         let ver = try Version(id: UUID(), package: pkg)
         let prod = try Product(id: UUID(), version: ver, type: .library, name: "p1")
         try pkg.save(on: app.db).wait()
@@ -22,7 +22,7 @@ class ProductTests: AppTestCase {
 
     func test_delete_cascade() throws {
         // delete version must delete products
-        let pkg = Package(id: UUID(), url: "1", status: .none)
+        let pkg = Package(id: UUID(), url: "1")
         let ver = try Version(id: UUID(), package: pkg)
         let prod = try Product(id: UUID(), version: ver, type: .library, name: "p1")
         try pkg.save(on: app.db).wait()

--- a/Tests/AppTests/ReconcilerTests.swift
+++ b/Tests/AppTests/ReconcilerTests.swift
@@ -18,7 +18,7 @@ class ReconcilerTests: AppTestCase {
             XCTAssertNotNil($0.id)
             XCTAssertNotNil($0.createdAt)
             XCTAssertNotNil($0.updatedAt)
-            XCTAssertEqual($0.status, .none)
+            XCTAssertEqual($0.status, .new)
             XCTAssertEqual($0.processingStage, .reconciliation)
         }
     }

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -7,7 +7,7 @@ import XCTVapor
 final class RepositoryTests: AppTestCase {
 
     func test_save() throws {
-        let pkg = Package(id: UUID(), url: "1", status: .none)
+        let pkg = Package(id: UUID(), url: "1")
         try pkg.save(on: app.db).wait()
         let repo = try Repository(id: UUID(),
                                   package: pkg,
@@ -84,7 +84,7 @@ final class RepositoryTests: AppTestCase {
 
     func test_delete_cascade() throws {
         // delete package must delete repository
-        let pkg = Package(id: UUID(), url: "1", status: .none)
+        let pkg = Package(id: UUID(), url: "1")
         let repo = try Repository(id: UUID(), package: pkg)
         try pkg.save(on: app.db).wait()
         try repo.save(on: app.db).wait()
@@ -102,7 +102,7 @@ final class RepositoryTests: AppTestCase {
 
     func test_defaultBranch() throws {
         // setup
-        let pkg = Package(id: UUID(), url: "1", status: .none)
+        let pkg = Package(id: UUID(), url: "1")
         let repo = try Repository(id: UUID(), package: pkg, defaultBranch: "default")
         try pkg.save(on: app.db).wait()
         try repo.save(on: app.db).wait()

--- a/Tests/AppTests/VersionTests.swift
+++ b/Tests/AppTests/VersionTests.swift
@@ -38,7 +38,7 @@ class VersionTests: AppTestCase {
 
     func test_delete_cascade() throws {
         // delete package must delete version
-        let pkg = Package(id: UUID(), url: "1", status: .none)
+        let pkg = Package(id: UUID(), url: "1")
         let ver = try Version(id: UUID(), package: pkg)
         try pkg.save(on: app.db).wait()
         try ver.save(on: app.db).wait()


### PR DESCRIPTION
This modifies #263 to change `Package.status: Status?` to `Package.status: Status` and adds a new default case `new`.

A bit trickier than expected, because I couldn't see a way to write the migration in Fluent. I'm also glad that we've got our tests, because while the type system guides many things, it does _not_ catch when you compare a non-optional to `.none`. I.e. this here compiles

```
enum Status {
    case ok
}
print(Status.ok == .none)  // false
```

which I found surprising.

They also caught the raw SQL which of course escaped the type system:

```
            .sort(.sql(raw: "status IS NOT NULL"))
```

That all is to say: please take a close look if I missed anything else 😅 