### PR TITLE
Perf test

### DIFF
--- a/Sources/App/Commands/CreateRestfile.swift
+++ b/Sources/App/Commands/CreateRestfile.swift
@@ -63,6 +63,7 @@ func createRestfile(application: Application, variant: Variant) -> EventLoopFutu
         var url: String
     }
     print("# auto-generated via `vapor run create-restfile \(variant.rawValue)`")
+    print("mode: random")
     print("requests:")
     return db.raw(query)
         .all(decoding: Record.self)

--- a/restfiles/all-packages-test.restfile
+++ b/restfiles/all-packages-test.restfile
@@ -1,4 +1,5 @@
 # auto-generated via `vapor run create-restfile all`
+mode: random
 requests:
   /0111b/JSONDecoder-Keypath:
     url: ${base_url}/0111b/JSONDecoder-Keypath
@@ -5926,6 +5927,10 @@ requests:
       status: 200
   /jhoogstraat/StandardRouting:
     url: ${base_url}/jhoogstraat/StandardRouting
+    validation:
+      status: 200
+  /jjjkkkjjj/Matft:
+    url: ${base_url}/jjjkkkjjj/Matft
     validation:
       status: 200
   /jjochen/JJFloatingActionButton:

--- a/restfiles/perf-test-search.restfile
+++ b/restfiles/perf-test-search.restfile
@@ -1,0 +1,124 @@
+# run as follows
+# env base_url=... rester perf-test-search.restfile --count 100 --stats
+mode: random
+requests:
+    /search/dogs:
+        url: ${base_url}/api/search
+        query:
+            query: dogs
+        validation:
+            status: 200
+    /search/distinct:        
+        url: ${base_url}/api/search
+        query:
+            query: distinct
+        validation:
+            status: 200
+    /search/hospital:        
+        url: ${base_url}/api/search
+        query:
+            query: hospital
+        validation:
+            status: 200
+    /search/organic:        
+        url: ${base_url}/api/search
+        query:
+            query: organic
+        validation:
+            status: 200
+    /search/crowd:        
+        url: ${base_url}/api/search
+        query:
+            query: crowd
+        validation:
+            status: 200
+    /search/second-hand:        
+        url: ${base_url}/api/search
+        query:
+            query: second-hand
+        validation:
+            status: 200
+    /search/noise:        
+        url: ${base_url}/api/search
+        query:
+            query: noise
+        validation:
+            status: 200
+    /search/argument:        
+        url: ${base_url}/api/search
+        query:
+            query: argument
+        validation:
+            status: 200
+    /search/bumpy:        
+        url: ${base_url}/api/search
+        query:
+            query: bumpy
+        validation:
+            status: 200
+    /search/exciting:        
+        url: ${base_url}/api/search
+        query:
+            query: exciting
+        validation:
+            status: 200
+    /search/dreary:        
+        url: ${base_url}/api/search
+        query:
+            query: dreary
+        validation:
+            status: 200
+    /search/large:        
+        url: ${base_url}/api/search
+        query:
+            query: large
+        validation:
+            status: 200
+    /search/superb:        
+        url: ${base_url}/api/search
+        query:
+            query: superb
+        validation:
+            status: 200
+    /search/improve:        
+        url: ${base_url}/api/search
+        query:
+            query: improve
+        validation:
+            status: 200
+    /search/skin:        
+        url: ${base_url}/api/search
+        query:
+            query: skin
+        validation:
+            status: 200
+    /search/button:        
+        url: ${base_url}/api/search
+        query:
+            query: button
+        validation:
+            status: 200
+    /search/weight:        
+        url: ${base_url}/api/search
+        query:
+            query: weight
+        validation:
+            status: 200
+    /search/forgetful:        
+        url: ${base_url}/api/search
+        query:
+            query: forgetful
+        validation:
+            status: 200
+    /search/tawdry:        
+        url: ${base_url}/api/search
+        query:
+            query: tawdry
+        validation:
+            status: 200
+    /search/wing:        
+        url: ${base_url}/api/search
+        query:
+            query: wing
+        validation:
+            status: 200


### PR DESCRIPTION
Just adding some snippets for performance testing

Fixes #262 

With the new Mac mini I don't think we'll need to be concerned about performance. I've just run a test with 20 random search terms and it served (on the box, to cut out latency) more than 50 requests per second.

A test running random gets against our full package list (`all-packages-test.restfile`) gave 45 req/sec (again directly on the host).