### PR TITLE
Fix url escaping for all urls, not just search

### DIFF
--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -37,10 +37,10 @@ enum Search {
 
         var packageURL: String? {
             guard
-                let owner = repositoryOwner?.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
-                let name = repositoryName?.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)
+                let owner = repositoryOwner,
+                let name = repositoryName
                 else { return nil }
-            return "/\(owner)/\(name)"
+            return SiteURL.package(.value(owner), .value(name)).relativeURL
         }
 
         var asRecord: Record {

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -45,8 +45,11 @@ enum SiteURL: Resourceable {
             case let .images(name):
                 return "images/\(name)"
 
-            case let .package(.value(owner), .value(repository)):
-                return "\(owner)/\(repository)"
+            case let .package(.value(owner), .value(repo)):
+                let owner = owner.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? owner
+                let repo = repo.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? repo
+                return "\(owner)/\(repo)"
+
             case .package:
                 fatalError("invalid path: \(self)")
 

--- a/Tests/AppTests/SiteURLTests.swift
+++ b/Tests/AppTests/SiteURLTests.swift
@@ -41,4 +41,10 @@ class SiteURLTests: XCTestCase {
         XCTAssertEqual(SiteURL.privacy.absoluteURL, "https://indexsite.com/privacy")
     }
 
+    func test_url_escaping() throws {
+        Current.siteURL = { "https://indexsite.com" }
+        XCTAssertEqual(SiteURL.package(.value("foo bar"), .value("some repo")).absoluteURL,
+                       "https://indexsite.com/foo%20bar/some%20repo")
+    }
+
 }


### PR DESCRIPTION
I just realised while working on the RSS fees that we need to escape the package urls in general and that this should have been in `SiteURL` to begin with.