### PR TITLE
Adds missing space after link on FAQ page.

### DIFF
--- a/Resources/Markdown/faq.md
+++ b/Resources/Markdown/faq.md
@@ -26,7 +26,7 @@ The index originates from a [master list of SPM compatible repositories](https:/
 
 <h3 id="package-registry">What about the GitHub Package Registry?</h3>
 
-We’re excited to see the GitHub Package Registry get support for Swift packages. There’s [a proposal](https://forums.swift.org/t/swift-package-registry-service/37219)for Swift Package Manager support to support package registries formally, but that pitch is not for a package index or search engine. That’s a different thing.
+We’re excited to see the GitHub Package Registry get support for Swift packages. There’s [a proposal](https://forums.swift.org/t/swift-package-registry-service/37219) for Swift Package Manager support to support package registries formally, but that pitch is not for a package index or search engine. That’s a different thing.
 
 The Swift Package Index will support and index any GitHub’s, or any other implementation of a package registry as soon as they are available.
 


### PR DESCRIPTION
Fixes a typo I [mentioned](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/300#issuecomment-640212876) in feedback on #300. 