### PR TITLE
Change issue pluralisation

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -21,6 +21,7 @@ extension PackageShow {
         }
 
         struct Activity: Equatable {
+            var openIssuesCount: Int
             var openIssues: Link?
             var openPullRequests: Link?
             var lastIssueClosedAt: String?
@@ -101,7 +102,9 @@ extension PackageShow.Model {
             .compactMap { $0 }
 
         return .group(
-            Self.listPhrase(opening: "There are ", nodes: openItems, closing: ". ") +
+            Self.listPhrase(opening: .text("There is ".pluralized(for: activity.openIssuesCount,
+                                                                  plural: "There are ")),
+                            nodes: openItems, closing: ". ") +
                 Self.listPhrase(opening: "The ", nodes: lastClosed, conjunction: " and the ", closing: ".")
         )
     }

--- a/Sources/App/Views/PackageController/PackageShow+Query.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Query.swift
@@ -110,7 +110,8 @@ extension Package {
         }
         let lastIssueClosed = repo.lastIssueClosedAt.map { "\(date: $0, relativeTo: Current.date())" }
         let lastPRClosed = repo.lastPullRequestClosedAt.map { "\(date: $0, relativeTo: Current.date())" }
-        return .init(openIssues: openIssues,
+        return .init(openIssuesCount: repo.openIssues ?? 0,
+                     openIssues: openIssues,
                      openPullRequests: openPRs,
                      lastIssueClosedAt: lastIssueClosed,
                      lastPullRequestClosedAt: lastPRClosed)

--- a/Tests/AppTests/Mocks/PackageShowModel+mock.swift
+++ b/Tests/AppTests/Mocks/PackageShowModel+mock.swift
@@ -24,6 +24,7 @@ extension PackageShow.Model {
                                     url: "https://github.com/Alamofire/Alamofire/releases")
             ),
               activity: .init(
+                openIssuesCount: 27,
                 openIssues: .init(label: "27 open issues",
                                   url: "https://github.com/Alamofire/Alamofire/issues"),
                 openPullRequests: .init(label: "5 open pull requests",

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -329,7 +329,8 @@ final class PackageTests: AppTestCase {
 
         // validate
         XCTAssertEqual(res,
-                       .init(openIssues: .init(label: "27 open issues",
+                       .init(openIssuesCount: 27,
+                             openIssues: .init(label: "27 open issues",
                                                url: "https://github.com/Alamofire/Alamofire/issues"),
                              openPullRequests: .init(label: "1 open pull request",
                                                      url: "https://github.com/Alamofire/Alamofire/pulls"),


### PR DESCRIPTION
Fixes #302 

<img width="621" alt="Screenshot 2020-06-09 at 08 42 24" src="https://user-images.githubusercontent.com/65520/84114911-6ef4ab00-aa2d-11ea-8bf9-6201bd11d66c.png">

<img width="609" alt="Screenshot 2020-06-09 at 08 42 48" src="https://user-images.githubusercontent.com/65520/84114919-71570500-aa2d-11ea-8324-b75c5ad5c3a1.png">

I get that "There are 1 open issue" has a wrong start but I don't know, "There is ... and ..." reads wrong to me as well 🤷 🙂 