### PR TITLE
Wrap version update in transaction

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       image: swift:5.2.4-bionic
     services:
       postgres:
-        image: postgres:12
+        image: postgres:12.1-alpine
         env:
           POSTGRES_DB: spi_test
           POSTGRES_USER: spi_test

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -207,11 +207,11 @@ func reconcileVersions(application: Application, package: Package) -> EventLoopF
                                commit: revInfo.commit,
                                commitDate: revInfo.date) }
 
-    let transaction = application.db.transaction { db -> EventLoopFuture<[Version]> in
-        let delete = Version.query(on: application.db)
+    let transaction = application.db.transaction { tx -> EventLoopFuture<[Version]> in
+        let delete = Version.query(on: tx)
             .filter(\.$package.$id == pkgId)
             .delete()
-        let insert = versions.flatMap { versions in versions.create(on: db).map { versions }  }
+        let insert = versions.flatMap { versions in versions.create(on: tx).map { versions }  }
         return delete.flatMap { insert }
     }
 

--- a/Sources/App/Views/PackageController/PackageShow+Query.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Query.swift
@@ -26,8 +26,6 @@ extension PackageShow.Model {
         
         return res.unwrap(or: Abort(.notFound))
             .map { p -> Self? in
-                // FIXME: factor out into Model.init?(_ package: Packae)
-                
                 // we consider certain attributes as essential and return nil (raising .notFound)
                 guard let title = p.name() else { return nil }
                 return Self.init(title: title,


### PR DESCRIPTION
Not marking the issue #343 as fixed yet.

In order to confirm we'll need to run a smoke test after this has been deployed and there's been a full pass across the dataset. Only then can we be certain that any version gaps have been filled.

I suspect CenteredCollectionView was in the midst of an update as we rolled out a version. That's why we didn't have versions for a longer time until it came around in the next pass.

This fix here would prevent that from happening or us seeing a gap while the update is in progress.