### PR TITLE
Revert "Bump INGEST_SLEEP to 600"

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       - migrate
     entrypoint: ["/bin/bash"]
     command: ["-c", "--",
-      "trap : TERM INT; while true; do ./Run ingest --env ${ENV} --limit ${INGEST_LIMIT:-100}; sleep ${INGEST_SLEEP:-600}; done"
+      "trap : TERM INT; while true; do ./Run ingest --env ${ENV} --limit ${INGEST_LIMIT:-100}; sleep ${INGEST_SLEEP:-300}; done"
     ]
     restart: always
 


### PR DESCRIPTION
This reverts commit a3023f0856bf9ccb15eba639de8b2381cc0e04bf.

Brings us back to a ~2 hour turnaround (100 packages every 5 mins -> 2400 packages every two hours) rather than 4.

I'll confirm that we're at the usual min 1200 requests left per budget window.