### PR TITLE
Check if VERSION is set

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,6 +45,7 @@ build-tag:
     - deploy
   script: |
     VERSION=${CI_COMMIT_TAG:-$CI_COMMIT_SHA}
+    if [ -z "$VERSION" ]; then echo VERSION not set; exit 1 ; fi
     # install curl and set up alias to post deployment to rollbar
     apk add --no-cache curl
     rollbar() {


### PR DESCRIPTION
Just an additional sanity check. Deployment isn't actually possible _without_ it being set but I'd rather bail early and notify than attempt to launch non-existing images.