### PR TITLE
View request path

### DIFF
--- a/Sources/App/Controllers/PackageController.swift
+++ b/Sources/App/Controllers/PackageController.swift
@@ -17,7 +17,7 @@ struct PackageController {
                 return req.eventLoop.future(error: Abort(.notFound))
         }
         return PackageShow.Model.query(database: req.db, owner: owner, repository: repository)
-            .map { PackageShow.View($0).document() }
+            .map { PackageShow.View(path: req.url.path, model: $0).document() }
     }
 
 }

--- a/Sources/App/Core/ErrorMiddleware.swift
+++ b/Sources/App/Core/ErrorMiddleware.swift
@@ -23,8 +23,9 @@ public final class ErrorMiddleware: Middleware {
             ? Current.reportError(req.client, .critical, error)
             : req.eventLoop.future()
         let model = ErrorPage.Model(error)
-        return alert.flatMap { ErrorPage.View(model).document().encodeResponse(for: req,
-                                                                               status: error.status) }
+        return alert.flatMap { ErrorPage.View(path: req.url.path,
+                                              model: model).document().encodeResponse(for: req,
+                                                                                      status: error.status) }
     }
 }
 

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -95,6 +95,14 @@ enum SiteURL: Resourceable {
         }
     }
 
+    static func relativeURL(for path: String) -> String {
+        guard path.hasPrefix("/") else { return "/" + path }
+        return path
+    }
+
+    static func absoluteURL(for path: String) -> String {
+        Current.siteURL() + relativeURL(for: path)
+    }
 }
 
 

--- a/Sources/App/Views/Error/ErrorPage+View.swift
+++ b/Sources/App/Views/Error/ErrorPage+View.swift
@@ -6,9 +6,12 @@ enum ErrorPage {
     final class View: PublicPage {
         let model: Model
 
-        init(_ model: Model) {
+        
+        init(path: String, model: Model) {
             self.model = model
+            super.init(path: path)
         }
+
 
         override func content() -> Node<HTML.BodyContext> {
             .div(

--- a/Sources/App/Views/Home/HomeIndex+View.swift
+++ b/Sources/App/Views/Home/HomeIndex+View.swift
@@ -7,8 +7,9 @@ enum HomeIndex {
 
         let model: Model
 
-        init(_ model: Model) {
+        init(path: String, model: Model) {
             self.model = model
+            super.init(path: path)
         }
 
         override func noScript() -> Node<HTML.BodyContext> {

--- a/Sources/App/Views/MarkdownPage.swift
+++ b/Sources/App/Views/MarkdownPage.swift
@@ -12,7 +12,7 @@ class MarkdownPage: PublicPage {
     let metadata: [String: String]
     let html: String?
 
-    init(_ markdownFilename: String) {
+    init(path: String, _ markdownFilename: String) {
         assert(markdownFilename.split(separator: "/").count < 2, "Filename should not include path separators.")
 
         let pathToMarkdownFile = Current.fileManager.workingDirectory()
@@ -23,6 +23,8 @@ class MarkdownPage: PublicPage {
         let result = markdown.map(MarkdownParser().parse)
         metadata = result?.metadata ?? [:]
         html = result?.html
+        
+        super.init(path: path)
     }
 
     override func pageTitle() -> String? {

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -7,8 +7,9 @@ enum PackageShow {
 
         let model: Model
 
-        init(_ model: Model) {
+        init(path: String, model: Model) {
             self.model = model
+            super.init(path: path)
         }
 
         override func pageTitle() -> String? {

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -4,6 +4,12 @@ import Plot
 
 class PublicPage {
 
+    let path: String
+
+    init(path: String) {
+        self.path = path
+    }
+
     /// The page's full HTML document.
     /// - Returns: A fully formed page inside a <html> element.
     final func document() -> HTML {

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -5,11 +5,14 @@ import Vapor
 
 func routes(_ app: Application) throws {
     app.get { req in
-        HomeIndex.Model.query(database: req.db).map { HomeIndex.View($0).document() }
+        HomeIndex.Model.query(database: req.db).map { HomeIndex.View(path: req.url.path,
+                                                                     model: $0).document() }
     }
 
-    app.get(SiteURL.privacy.pathComponents) { _ in MarkdownPage("privacy.md").document() }
-    app.get(SiteURL.faq.pathComponents) { _ in MarkdownPage("faq.md").document() }
+    app.get(SiteURL.privacy.pathComponents) { req in MarkdownPage(path: req.url.path,
+                                                                  "privacy.md").document() }
+    app.get(SiteURL.faq.pathComponents) { req in MarkdownPage(path: req.url.path,
+                                                              "faq.md").document() }
 
     let packageController = PackageController()
     app.get(SiteURL.packages.pathComponents, use: packageController.index)

--- a/Tests/AppTests/SiteURLTests.swift
+++ b/Tests/AppTests/SiteURLTests.swift
@@ -56,4 +56,14 @@ class SiteURLTests: XCTestCase {
                        "https://indexsite.com/foo%20bar/some%20repo")
     }
 
+    func test_static_relativeURL() throws {
+        XCTAssertEqual(SiteURL.relativeURL(for: "foo"), "/foo")
+        XCTAssertEqual(SiteURL.relativeURL(for: "/foo"), "/foo")
+    }
+
+    func test_static_absoluteURL() throws {
+        Current.siteURL = { "https://indexsite.com" }
+        XCTAssertEqual(SiteURL.absoluteURL(for: "foo"), "https://indexsite.com/foo")
+        XCTAssertEqual(SiteURL.absoluteURL(for: "/foo"), "https://indexsite.com/foo")
+    }
 }

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -30,7 +30,7 @@ class WebpageSnapshotTests: XCTestCase {
     }
 
     func test_HomeIndexView() throws {
-        let page = HomeIndex.View(.mock).document()
+        let page = HomeIndex.View(path: "/", model: .mock).document()
 
         let recordSnapshotForThisTest = false
         record = recordSnapshotForThisTest || recordSnapshotForAllTests
@@ -50,7 +50,7 @@ class WebpageSnapshotTests: XCTestCase {
     }
 
     func test_PackageShowView() throws {
-        let page = PackageShow.View(.mock).document()
+        let page = PackageShow.View(path: "", model: .mock).document()
 
         let recordSnapshotForThisTest = false
         record = recordSnapshotForThisTest || recordSnapshotForAllTests
@@ -72,7 +72,7 @@ class WebpageSnapshotTests: XCTestCase {
     func test_PackageShowView_incompatible_license() throws {
         var model = PackageShow.Model.mock
         model.license = License.gpl_3_0
-        let page = PackageShow.View(model).document()
+        let page = PackageShow.View(path: "", model: model).document()
 
         let recordSnapshotForThisTest = false
         record = recordSnapshotForThisTest || recordSnapshotForAllTests
@@ -97,7 +97,7 @@ class WebpageSnapshotTests: XCTestCase {
         var model = PackageShow.Model.mock
         model.authors = nil
         model.activity = nil
-        let page = PackageShow.View(model).document()
+        let page = PackageShow.View(path: "", model: model).document()
 
         let recordSnapshotForThisTest = false
         record = recordSnapshotForThisTest || recordSnapshotForAllTests
@@ -121,7 +121,7 @@ class WebpageSnapshotTests: XCTestCase {
         // no author or activity info
         var model = PackageShow.Model.mock
         model.languagePlatforms = .init(stable: nil, beta: nil, latest: nil)
-        let page = PackageShow.View(model).document()
+        let page = PackageShow.View(path: "", model: model).document()
 
         let recordSnapshotForThisTest = false
         record = recordSnapshotForThisTest || recordSnapshotForAllTests
@@ -147,7 +147,7 @@ class WebpageSnapshotTests: XCTestCase {
         model.languagePlatforms.stable?.platforms = []
         model.languagePlatforms.beta?.platforms = []
         model.languagePlatforms.latest?.platforms = []
-        let page = PackageShow.View(model).document()
+        let page = PackageShow.View(path: "", model: model).document()
 
         let recordSnapshotForThisTest = false
         record = recordSnapshotForThisTest || recordSnapshotForAllTests
@@ -173,7 +173,7 @@ class WebpageSnapshotTests: XCTestCase {
         model.languagePlatforms.stable?.swiftVersions = []
         model.languagePlatforms.beta?.swiftVersions = []
         model.languagePlatforms.latest?.swiftVersions = []
-        let page = PackageShow.View(model).document()
+        let page = PackageShow.View(path: "", model: model).document()
 
         let recordSnapshotForThisTest = false
         record = recordSnapshotForThisTest || recordSnapshotForAllTests
@@ -194,7 +194,7 @@ class WebpageSnapshotTests: XCTestCase {
 
     func test_ErrorPageView() throws {
         let model = ErrorPage.Model(Abort(.notFound))
-        let page = ErrorPage.View(model).document()
+        let page = ErrorPage.View(path: "", model: model).document()
 
         let recordSnapshotForThisTest = false
         record = recordSnapshotForThisTest || recordSnapshotForAllTests
@@ -214,7 +214,7 @@ class WebpageSnapshotTests: XCTestCase {
     }
 
     func test_MarkdownPage() throws {
-        let page = MarkdownPage("privacy.md").document()
+        let page = MarkdownPage(path: "", "privacy.md").document()
 
         let recordSnapshotForThisTest = false
         record = recordSnapshotForThisTest || recordSnapshotForAllTests


### PR DESCRIPTION
This allows us to reference the current page in page views as follows:

```
SiteURL.absoluteURL(for: path)
```