### PR TITLE
Update pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,6 @@ stages:
   - build
   - deploy
   - smoke-test
-  - scheduled
 
 
 build-sha:
@@ -94,7 +93,7 @@ smoke-test:
 
 
 db-backup (scheduled):
-  stage: scheduled
+  stage: build
   only:
     - schedules
   tags:
@@ -109,7 +108,7 @@ db-backup (scheduled):
 
 
 db-backup (manual):
-  stage: scheduled
+  stage: build
   when: manual
   tags:
     - ceres

--- a/restfiles/active-packages-test.restfile
+++ b/restfiles/active-packages-test.restfile
@@ -1036,8 +1036,8 @@ requests:
     url: ${base_url}/realm/realm-cocoa
     validation:
       status: 200
-  /rhysforyou/Porygon:
-    url: ${base_url}/rhysforyou/Porygon
+  /rhysforyou/Superhighway:
+    url: ${base_url}/rhysforyou/Superhighway
     validation:
       status: 200
   /richardpiazza/CodeQuickKit:

--- a/restfiles/all-packages-test.restfile
+++ b/restfiles/all-packages-test.restfile
@@ -8277,8 +8277,8 @@ requests:
     url: ${base_url}/rhx/gir2swift
     validation:
       status: 200
-  /rhysforyou/Porygon:
-    url: ${base_url}/rhysforyou/Porygon
+  /rhysforyou/Superhighway:
+    url: ${base_url}/rhysforyou/Superhighway
     validation:
       status: 200
   /richardpiazza/BZipCompression:


### PR DESCRIPTION
This moves the backup jobs to they're not blocked by a failing smoke test:

<img width="487" alt="Screenshot 2020-06-15 at 17 45 20" src="https://user-images.githubusercontent.com/65520/84678742-aa610f00-af30-11ea-95ba-3ae9ba1fe719.png">

It also fixes the failing smoke test for the renamed project https://github.com/rhysforyou/Porygon