### PR TITLE
Search Input Delay

### DIFF
--- a/Public/javascripts/search_core.js
+++ b/Public/javascripts/search_core.js
@@ -39,7 +39,7 @@ export class SPISearchCore {
     // When any input is received by the query field, perform the search.
     queryFieldElement.addEventListener('input', debounce(() => {
       this.performSearch()
-    }), 300)
+    }, 200), 300)
   }
 
   performSearch() {


### PR DESCRIPTION
- Using debounce with a delay of 200ms on input event listener

Currently the search runs every time a letter is added, and it looks like the 300 value on the same line was meant to be part of debounce - I've left it in until you can confirm it is or isn't for that.

I've compiled the project to create the `.min` files locally using CodeKit; but many files were changed, including image binaries(?). Let me know how to complete this PR if you do want the delay between adding chars to the search box!