### PR TITLE
Report unknown versions and platforms

### DIFF
--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -292,7 +292,6 @@ func updateVersion(on database: Database, version: Version, manifest: Manifest) 
     version.packageName = manifest.name
     version.swiftVersions = manifest.swiftLanguageVersions?.compactMap(SwiftVersion.init) ?? []
     version.supportedPlatforms = manifest.platforms?.compactMap(Platform.init(from:)) ?? []
-
     return version.save(on: database)
 }
 

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -295,37 +295,9 @@ func updateVersionsAndProducts(on database: Database,
 
 
 func updateVersion(on database: Database, client: Client, version: Version, manifest: Manifest) -> EventLoopFuture<Void> {
-    var ops = database.eventLoop.future()
-
     version.packageName = manifest.name
-
-    if let versions = manifest.swiftLanguageVersions {
-        let parsed = versions.compactMap(SwiftVersion.init)
-        version.swiftVersions = parsed
-        if versions.count != parsed.count {
-            ops = ops.flatMap {
-                Current.reportError(client, .critical,
-                                    AppError.genericError(version.$package.id,
-                                                          "unknown version in: \(versions)"))
-            }
-        }
-    } else {
-        version.swiftVersions = []
-    }
-
-    if let platforms = manifest.platforms {
-        let parsed = platforms.compactMap(Platform.init(from:))
-        version.supportedPlatforms = parsed
-        if platforms.count != parsed.count {
-            ops = ops.flatMap {
-                Current.reportError(client, .critical,
-                                    AppError.genericError(version.$package.id,
-                                                          "unknown platform in: \(platforms)"))
-            }
-        }
-    } else {
-        version.supportedPlatforms =  []
-    }
+    version.swiftVersions = manifest.swiftLanguageVersions?.compactMap(SwiftVersion.init) ?? []
+    version.supportedPlatforms = manifest.platforms?.compactMap(Platform.init(from:)) ?? []
 
     return version.save(on: database)
 }

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -436,7 +436,7 @@ class AnalyzerTests: AppTestCase {
                                 swiftLanguageVersions: ["1", "2", "3.0.0"])
 
         // MUT
-        _ = try updateVersion(on: app.db, client: app.client, version: version, manifest: manifest).wait()
+        _ = try updateVersion(on: app.db, version: version, manifest: manifest).wait()
 
         // read back and validate
         let v = try Version.query(on: app.db).first().wait()!
@@ -495,7 +495,7 @@ class AnalyzerTests: AppTestCase {
         ]
 
         // MUT
-        let res = try updateVersionsAndProducts(on: app.db, client: app.client, results: results).wait()
+        let res = try updateVersionsAndProducts(on: app.db, results: results).wait()
 
         // validation
         XCTAssertEqual(res.map(\.isSuccess), [false, true])

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -445,6 +445,21 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(v.supportedPlatforms, [.ios("11.0"), .macos("10.10")])
     }
 
+    func test_updateVersion_reportUnknownPlatforms() throws {
+        // Ensure we report encountering unhandled platforms
+        // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/51
+
+        // Asserting that the platform name cases agree is the only thing we need to do.
+        // - Platform.version is a String on both sides
+        // - Swift Versions map to SemVar and so there is no conceivable way at this time
+        //   to write an incompatible Swift Version
+        // The only possible issue could be adding a new platform to Manifest.Platform
+        // and forgetting to add it to Platform (the model). This test will fail in
+        // that case.
+        XCTAssertEqual(Manifest.Platform.Name.allCases.map(\.rawValue).sorted(),
+                       Platform.Name.allCases.map(\.rawValue).sorted())
+    }
+
     func test_updateProducts() throws {
         // setup
         let p = Package(id: UUID(), url: "1")

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -436,7 +436,7 @@ class AnalyzerTests: AppTestCase {
                                 swiftLanguageVersions: ["1", "2", "3.0.0"])
 
         // MUT
-        _ = try updateVersion(on: app.db, version: version, manifest: manifest).wait()
+        _ = try updateVersion(on: app.db, client: app.client, version: version, manifest: manifest).wait()
 
         // read back and validate
         let v = try Version.query(on: app.db).first().wait()!
@@ -480,7 +480,7 @@ class AnalyzerTests: AppTestCase {
         ]
 
         // MUT
-        let res = try updateVersionsAndProducts(on: app.db, results: results).wait()
+        let res = try updateVersionsAndProducts(on: app.db, client: app.client, results: results).wait()
 
         // validation
         XCTAssertEqual(res.map(\.isSuccess), [false, true])


### PR DESCRIPTION
Fixes #51 

Merge after #417 

I looked into adding a whole error reporting flow on new platforms but I ended up rolling that back, because it was a bit fiddly and seemed like unnecessarily complex. I don't think we'd be _surprised_ by a new platform being added as a valid key to the Manifest and the downside of blowing through our Rollbar budget when it happens and we've not updated by the time a package rolls in seems to be bigger.

The error scenario is that versions won't be parsed, which we'll see. What more important to test is that the adoption of a new Platform case to be made to both the model and the DTO. That's why I added that extra test to ensure the cases line up.

Does that make sense?