### PR TITLE
Score incompatible licenses differently to no license.

### DIFF
--- a/Sources/App/Core/Score.swift
+++ b/Sources/App/Core/Score.swift
@@ -15,6 +15,7 @@ enum Score {
         // Is the license open-source and compatible with the App Store?
         switch candidate.licenseKind {
             case .compatibleWithAppStore: score += 10
+            case .incompatibleWithAppStore: score += 3
             default: break;
         }
 

--- a/Tests/AppTests/ScoreTests.swift
+++ b/Tests/AppTests/ScoreTests.swift
@@ -7,25 +7,35 @@ class ScoreTests: XCTestCase {
 
     func test_computeScore() throws {
         XCTAssertEqual(Score.compute(.init(supportsLatestSwiftVersion: false,
-                                           licenseKind: .incompatibleWithAppStore,
+                                           licenseKind: .noneOrUnknown,
                                            releaseCount: 0,
                                            likeCount: 0)),
                        0)
-        XCTAssertEqual(Score.compute(.init(supportsLatestSwiftVersion: true,
+        XCTAssertEqual(Score.compute(.init(supportsLatestSwiftVersion: false,
                                            licenseKind: .incompatibleWithAppStore,
+                                           releaseCount: 0,
+                                           likeCount: 0)),
+                       3)
+        XCTAssertEqual(Score.compute(.init(supportsLatestSwiftVersion: false,
+                                           licenseKind: .compatibleWithAppStore,
                                            releaseCount: 0,
                                            likeCount: 0)),
                        10)
         XCTAssertEqual(Score.compute(.init(supportsLatestSwiftVersion: true,
-                                           licenseKind: .incompatibleWithAppStore,
-                                           releaseCount: 10,
+                                           licenseKind: .compatibleWithAppStore,
+                                           releaseCount: 0,
                                            likeCount: 0)),
                        20)
         XCTAssertEqual(Score.compute(.init(supportsLatestSwiftVersion: true,
-                                           licenseKind: .incompatibleWithAppStore,
+                                           licenseKind: .compatibleWithAppStore,
+                                           releaseCount: 10,
+                                           likeCount: 0)),
+                       30)
+        XCTAssertEqual(Score.compute(.init(supportsLatestSwiftVersion: true,
+                                           licenseKind: .compatibleWithAppStore,
                                            releaseCount: 10,
                                            likeCount: 50)),
-                       30)
+                       40)
         // current maximum value
         XCTAssertEqual(Score.compute(.init(supportsLatestSwiftVersion: true,
                                            licenseKind: .compatibleWithAppStore,


### PR DESCRIPTION
Merge after #428 

Felt like something we should do now we differentiate them visually.