### PR TITLE
Package update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-VAPOR=vapor-beta
 DOCKER_IMAGE=registry.gitlab.com/finestructure/swiftpackageindex
 
 ifndef VERSION
@@ -14,10 +13,10 @@ else
 endif
 
 build:
-	$(VAPOR) build
+	swift build
 
 run:
-	$(VAPOR) run
+	swift run
 
 test:
 	swift test --enable-test-discovery --enable-code-coverage
@@ -37,22 +36,22 @@ test-e2e: db-reset reconcile ingest analyze
 	@# run import sequence test
 
 migrate:
-	echo y | $(VAPOR) run migrate
+	echo y | swift run Run migrate
 
 revert:
-	$(VAPOR) run migrate --revert
+	swift run Run migrate --revert
 
 routes:
-	$(VAPOR) run routes
+	swift run Run routes
 
 reconcile:
-	$(VAPOR) run reconcile
+	swift run Run reconcile
 
 ingest:
-	$(VAPOR) run ingest --limit 1
+	swift run Run ingest --limit 1
 
 analyze:
-	$(VAPOR) run analyze --limit 1
+	swift run Run analyze --limit 1
 
 db-up: db-up-dev db-up-test
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/vapor/fluent.git",
         "state": {
           "branch": null,
-          "revision": "55f47ca0afe37a247d1a77d1db3c309de1d3af80",
-          "version": "4.0.0-rc.3.1"
+          "revision": "e681c93df3201a2d8ceef15e8a9a0634578df233",
+          "version": "4.0.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-kit.git",
         "state": {
           "branch": null,
-          "revision": "7396d1ac4fa7d510b1c280351e98b8192a4ec34b",
-          "version": "1.0.0"
+          "revision": "8ac0bc2764d3c93e5a30e7799492ea518afd9cc0",
+          "version": "1.0.1"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/vapor/sql-kit.git",
         "state": {
           "branch": null,
-          "revision": "3800a6f5fe5cb781420ebe059ff93392bc67cb9c",
-          "version": "3.1.0"
+          "revision": "ced1bbf79d8df7bd106e3d898b28cbc77bd69100",
+          "version": "3.3.0"
         }
       },
       {
@@ -195,8 +195,8 @@
         "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
         "state": {
           "branch": null,
-          "revision": "5c3d2141fb0e55da411577012c917962b6b3517e",
-          "version": "1.8.0"
+          "revision": "2fd91357e90efe82bfa6845d1e7d5bc2f5025d35",
+          "version": "1.8.1"
         }
       },
       {
@@ -204,8 +204,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "75ee9c8453945e6ff8b1e95ed9e4c742fdb38540",
-          "version": "4.9.0"
+          "revision": "2bfe7149d9786e2e601898cb10b9ba9072f60c0b",
+          "version": "4.10.0"
         }
       },
       {

--- a/Tests/AppTests/ErrorMiddlewareTests.swift
+++ b/Tests/AppTests/ErrorMiddlewareTests.swift
@@ -70,7 +70,7 @@ class ErrorMiddlewareTests: AppTestCase {
 
         try app.test(.GET, "500") { response in
             XCTAssertEqual(reportedLevel, .critical)
-            XCTAssertEqual(reportedError, Abort(.internalServerError).localizedDescription)
+            XCTAssert(reportedError?.contains("Abort.500: Internal Server Error") ?? false)
         }
     }
 


### PR DESCRIPTION
This drops the dependency of having the vapor toolbox installed to run the Makefile targets. The toolbox is convenient but unnecessary for what we do.

Also bump the packages to some new release versions.