### PR TITLE
Add NOT NULL constraints to make unique index work

### DIFF
--- a/Sources/App/Migrations/009/CreateBuild.swift
+++ b/Sources/App/Migrations/009/CreateBuild.swift
@@ -1,5 +1,6 @@
 import Fluent
 
+
 struct CreateBuild: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         return database.schema("builds")

--- a/Sources/App/Migrations/010/UpdateBuildNonNull.swift
+++ b/Sources/App/Migrations/010/UpdateBuildNonNull.swift
@@ -1,0 +1,22 @@
+import Fluent
+
+
+struct UpdateBuildNonNull: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("builds")
+            .deleteField("platform").field("platform", .json, .required)
+            .deleteField("status").field("status", .string, .required)
+            .deleteField("swift_version").field("swift_version", .json, .required)
+            .unique(on: "version_id", "platform", "swift_version")
+            .update()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("builds")
+            .deleteField("platform").field("platform", .json)
+            .deleteField("status").field("status", .string)
+            .deleteField("swift_version").field("swift_version", .json)
+            .unique(on: "version_id", "platform", "swift_version")
+            .update()
+    }
+}

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -29,7 +29,7 @@ final class Build: Model, Content {
     var logs: String?
 
     @Field(key: "platform")
-    var platform: Platform?
+    var platform: Platform
 
     @Field(key: "status")
     var status: Build.Status
@@ -42,7 +42,7 @@ final class Build: Model, Content {
     init(id: Id? = nil,
          version: Version,
          logs: String? = nil,
-         platform: Platform? = nil,
+         platform: Platform,
          status: Status,
          swiftVersion: SwiftVersion) throws {
         self.id = id
@@ -94,13 +94,13 @@ extension Build {
 
 extension Build {
     struct PostTriggerDTO: Codable {
-        var platform: Platform?
+        var platform: Platform
         var swiftVersion: SwiftVersion
     }
 
     struct PostCreateDTO: Codable {
         var logs: String?
-        var platform: Platform?
+        var platform: Platform
         var status: Status
         var swiftVersion: SwiftVersion
     }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -64,6 +64,9 @@ public func configure(_ app: Application) throws {
     do { // Migration 009 - add builds table
         app.migrations.add(CreateBuild())
     }
+    do { // Migration 010 - add non-null constraints to builds fields
+        app.migrations.add(UpdateBuildNonNull())
+    }
 
     app.commands.use(ReconcilerCommand(), as: "reconcile")
     app.commands.use(IngestorCommand(), as: "ingest")

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -67,7 +67,9 @@ class ApiTests: AppTestCase {
         let v = try Version(package: p)
         try v.save(on: app.db).wait()
         let versionId = try XCTUnwrap(v.id)
-        let dto: Build.PostCreateDTO = .init(status: .ok, swiftVersion: .init(5, 2, 0))
+        let dto: Build.PostCreateDTO = .init(platform: .macos("10.15"),
+                                             status: .ok,
+                                             swiftVersion: .init(5, 2, 0))
         let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
 
         // MUT
@@ -97,7 +99,9 @@ class ApiTests: AppTestCase {
         let v = try Version(package: p)
         try v.save(on: app.db).wait()
         let versionId = try XCTUnwrap(v.id)
-        let dto: Build.PostCreateDTO = .init(status: .ok, swiftVersion: .init(5, 2, 0))
+        let dto: Build.PostCreateDTO = .init(platform: .macos("10.15"),
+                                             status: .ok,
+                                             swiftVersion: .init(5, 2, 0))
         let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
 
         // MUT - no auth header
@@ -131,7 +135,9 @@ class ApiTests: AppTestCase {
         let v = try Version(package: p)
         try v.save(on: app.db).wait()
         let versionId = try XCTUnwrap(v.id)
-        let dto: Build.PostCreateDTO = .init(status: .ok, swiftVersion: .init(5, 2, 0))
+        let dto: Build.PostCreateDTO = .init(platform: .macos("10.15"),
+                                             status: .ok,
+                                             swiftVersion: .init(5, 2, 0))
         let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
 
         // MUT - no auth header

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -23,7 +23,7 @@ class BuildTests: AppTestCase {
         do {  // validate
             let b = try XCTUnwrap(Build.find(b.id, on: app.db).wait())
             XCTAssertEqual(b.logs, "logs")
-            XCTAssertEqual(b.platform, .some(.linux("ubuntu-18.04")))
+            XCTAssertEqual(b.platform, .linux("ubuntu-18.04"))
             XCTAssertEqual(b.$version.id, v.id)
             XCTAssertEqual(b.status, .ok)
         }
@@ -35,7 +35,10 @@ class BuildTests: AppTestCase {
         let pkg = try savePackage(on: app.db, "1")
         let v = try Version(package: pkg)
         try v.save(on: app.db).wait()
-        let b = try Build(version: v, status: .ok, swiftVersion: .init(5, 2, 0))
+        let b = try Build(version: v,
+                          platform: .init(name: .unknown, version: "some"),
+                          status: .ok,
+                          swiftVersion: .init(5, 2, 0))
         try b.save(on: app.db).wait()
         XCTAssertEqual(try Build.query(on: app.db).count().wait(), 1)
 

--- a/restfiles/post-build.restfile
+++ b/restfiles/post-build.restfile
@@ -1,12 +1,18 @@
 variables:
-    base_url: http://localhost:8080/api
-    version_id: f1689f37-9383-477c-81da-4f492825ac5d
+    # base_url: http://localhost:8080/api
+    base_url: https://staging.swiftpackageindex.com/api
+    # set here or via env variables:
+    # env version_id=... builder_token=... rester ...
+    # version_id: 
+    # builder_token: 
 
 requests:
 
     post build:
         url: ${base_url}/versions/${version_id}/builds
         method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
         body:
             json:
                 logs: some logs

--- a/restfiles/trigger-build.restfile
+++ b/restfiles/trigger-build.restfile
@@ -1,7 +1,10 @@
 variables:
-    base_url: http://localhost:8080/api
-    version_id: d7007076-3214-402a-ab7b-600fa2e28df2  # ValueCodable 0.1.0
-    builder_token: secr3t
+    base_url: https://staging.swiftpackageindex.com/api
+    # base_url: http://localhost:8080/api
+    # set here or via env variables:
+    # env version_id=... builder_token=... rester ...
+    # version_id: 
+    # builder_token: 
 
 requests:
 
@@ -12,13 +15,13 @@ requests:
             Authorization: Bearer ${builder_token}
         body:
             json:
-                # platform:
-                #     name: macos
-                #     version: "10.15"
+                platform:
+                    name: unknown
+                    version: test
                 swiftVersion:
                     major: 5
                     minor: 2
-                    patch: 0
+                    patch: 4
 
         validation:
             status: 201


### PR DESCRIPTION
We need to make the fields in the unique index `NOT NULL`, in particular `platform` because the unique check breaks down when there’s a NULL in a multi-column unique key.