### PR TITLE
Add package score as HTML comment to package listing

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -15,6 +15,7 @@ extension PackageShow {
         var summary: String
         var title: String
         var url: String
+        var score: Int?
 
         struct History: Equatable {
             var since: String

--- a/Sources/App/Views/PackageController/PackageShow+Query.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Query.swift
@@ -41,7 +41,8 @@ extension PackageShow.Model {
                     // when summary is nil
                     summary: p.repository?.summary ?? "–",
                     title: title,
-                    url: p.url
+                    url: p.url,
+                    score: p.score
                 )
             }
             .unwrap(or: Abort(.notFound))

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -29,7 +29,7 @@ enum PackageShow {
                 .div(
                     .class("split"),
                     .div(
-                        .comment("Package Score is \(model.score.map(String.init) ?? "unknown") for \(model.title)"),
+                        .comment(model.score.map(String.init) ?? "unknown"),
                         .h2(.text(model.title)),
                         .element(named: "small", nodes: [ // TODO: Fix after Plot update
                             .a(

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -29,6 +29,7 @@ enum PackageShow {
                 .div(
                     .class("split"),
                     .div(
+                        .comment("Package Score is \(model.score.map(String.init) ?? "unknown") for \(model.title)"),
                         .h2(.text(model.title)),
                         .element(named: "small", nodes: [ // TODO: Fix after Plot update
                             .a(

--- a/Tests/AppTests/Mocks/PackageShowModel+mock.swift
+++ b/Tests/AppTests/Mocks/PackageShowModel+mock.swift
@@ -58,7 +58,8 @@ extension PackageShow.Model {
             stars: 17,
             summary: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. Vivamus vehicula urna eget ipsum laoreet, sed porttitor sapien malesuada. Mauris faucibus tellus at augue vehicula, vitae aliquet felis ullamcorper. Praesent vitae leo rhoncus, egestas elit id, porttitor lacus. Cras ac bibendum mauris. Praesent luctus quis nulla sit amet tempus. Ut pharetra non augue sed pellentesque.",
             title: "Alamofire",
-            url: "https://github.com/Alamofire/Alamofire.git"
+            url: "https://github.com/Alamofire/Alamofire.git",
+            score: 10
         )
     }
 }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div><!--Package Score is unknown for Alamofire-->
+          <div><!--10-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div>
+          <div><!--Package Score is unknown for Alamofire-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_incompatible_license.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_incompatible_license.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div><!--Package Score is unknown for Alamofire-->
+          <div><!--10-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_incompatible_license.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_incompatible_license.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div>
+          <div><!--Package Score is unknown for Alamofire-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div><!--Package Score is unknown for Alamofire-->
+          <div><!--10-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div>
+          <div><!--Package Score is unknown for Alamofire-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_lpInfo.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_lpInfo.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div><!--Package Score is unknown for Alamofire-->
+          <div><!--10-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_lpInfo.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_lpInfo.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div>
+          <div><!--Package Score is unknown for Alamofire-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_platforms.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_platforms.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div><!--Package Score is unknown for Alamofire-->
+          <div><!--10-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_platforms.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_platforms.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div>
+          <div><!--Package Score is unknown for Alamofire-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_versions.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_versions.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div><!--Package Score is unknown for Alamofire-->
+          <div><!--10-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_versions.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_versions.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div>
+          <div><!--Package Score is unknown for Alamofire-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_unknown_license.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_unknown_license.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div><!--Package Score is unknown for Alamofire-->
+          <div><!--10-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_unknown_license.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_unknown_license.1.txt
@@ -53,7 +53,7 @@
     <main>
       <div class="inner">
         <div class="split">
-          <div>
+          <div><!--Package Score is unknown for Alamofire-->
             <h2>Alamofire</h2>
             <small>
               <a id="package_url" href="https://github.com/Alamofire/Alamofire.git">https://github.com/Alamofire/Alamofire.git</a>


### PR DESCRIPTION
Closes #440 

Score is set in an un-executed part of the tests hence it shows as unknown there. Tested locally with a real package and working fine.

Feel free to close unmerged if the need/desire has gone.