### PR TITLE
Replace shorthand emojis in Search Record response

### DIFF
--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -58,7 +58,7 @@ enum Search {
                   packageURL: packageURL,
                   repositoryName: repositoryName,
                   repositoryOwner: repositoryOwner,
-                  summary: summary)
+                  summary: summary?.replaceShorthandEmojis())
         }
     }
 


### PR DESCRIPTION
Closes #493 

⚠️ Untested!

In the dev environment is there a way to ingest a specific library for testing? I've run `make analyze` so I have one library that I can test with locally (but doesn't have emojis in the summary!). Is there a way I can specify the repo URL?