### PR TITLE
The /packages route was useful when we supported looking up packages by ID, but serves no purpose now.

### DIFF
--- a/Sources/App/Controllers/PackageController.swift
+++ b/Sources/App/Controllers/PackageController.swift
@@ -4,11 +4,6 @@ import Vapor
 
 struct PackageController {
     
-    func index(req: Request) throws -> EventLoopFuture<Response> {
-        // No such thing as a full index of packages.
-        return req.eventLoop.future(req.redirect(to: "/"))
-    }
-    
     func show(req: Request) throws -> EventLoopFuture<HTML> {
         guard
             let owner = req.parameters.get("owner"),

--- a/Sources/App/Core/SiteURL+siteMap.swift
+++ b/Sources/App/Core/SiteURL+siteMap.swift
@@ -40,8 +40,6 @@ extension SiteURL {
                 return .hourly
             case .images:
                 return .weekly
-            case .packages:
-                return .daily
             case .package:
                 return .daily
             case .privacy:

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -72,7 +72,6 @@ enum SiteURL: Resourceable {
     case addAPackage
     case home
     case images(String)
-    case packages
     case package(_ owner: Parameter<String>, _ repository: Parameter<String>)
     case privacy
     case rssPackages
@@ -108,9 +107,6 @@ enum SiteURL: Resourceable {
             case .package:
                 fatalError("invalid path: \(self)")
                 
-            case .packages:
-                return "packages"
-                
             case .privacy:
                 return "privacy"
                 
@@ -130,7 +126,7 @@ enum SiteURL: Resourceable {
     
     var pathComponents: [PathComponent] {
         switch self {
-            case .admin, .faq, .addAPackage, .home, .packages, .privacy, .rssPackages, .rssReleases, .siteMap:
+            case .admin, .faq, .addAPackage, .home, .privacy, .rssPackages, .rssReleases, .siteMap:
                 return [.init(stringLiteral: path)]
                 
             case let .api(res):

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -23,8 +23,6 @@ func routes(_ app: Application) throws {
     }
     
     let packageController = PackageController()
-    app.get(SiteURL.packages.pathComponents, use: packageController.index)
-    
     app.get(SiteURL.package(.key, .key).pathComponents, use: packageController.show)
     
     do {  // admin

--- a/Tests/AppTests/Controllers/PackageControllerTests.swift
+++ b/Tests/AppTests/Controllers/PackageControllerTests.swift
@@ -31,13 +31,7 @@ class PackageControllerTests: AppTestCase {
         try version.save(on: app.db).wait()
         try product.save(on: app.db).wait()
     }
-    
-    func test_index() throws {
-        try app.test(.GET, "/packages") { response in
-            XCTAssertEqual(response.status, .seeOther)
-        }
-    }
-    
+
     func test_show_owner_repository() throws {
         try app.test(.GET, "/owner/package") { response in
             XCTAssertEqual(response.status, .ok)


### PR DESCRIPTION
This is in preparation for a proper search feature, this route felt unnecessary.