### PR TITLE
Builds page

### DIFF
--- a/Sources/App/Controllers/PackageController.swift
+++ b/Sources/App/Controllers/PackageController.swift
@@ -18,8 +18,16 @@ struct PackageController {
     }
 
     func builds(req: Request) throws -> EventLoopFuture<HTML> {
-        let model = BuildIndex.Model.mock
-        return req.eventLoop.future(BuildIndex.View(path: req.url.path, model: model).document())
+        guard
+            let owner = req.parameters.get("owner"),
+            let repository = req.parameters.get("repository")
+        else {
+            return req.eventLoop.future(error: Abort(.notFound))
+        }
+        return Package.query(on: req.db, owner: owner, repository: repository)
+            .map(BuildIndex.Model.init(package:))
+            .unwrap(or: Abort(.notFound))
+            .map { BuildIndex.View(path: req.url.path, model: $0).document() }
     }
 
 }

--- a/Sources/App/Controllers/PackageController.swift
+++ b/Sources/App/Controllers/PackageController.swift
@@ -16,5 +16,9 @@ struct PackageController {
             .unwrap(or: Abort(.notFound))
             .map { PackageShow.View(path: req.url.path, model: $0).document() }
     }
-    
+
+    func builds(req: Request) throws -> EventLoopFuture<HTML> {
+        req.eventLoop.future(BuildIndex.View(path: req.url.path).document())
+    }
+
 }

--- a/Sources/App/Controllers/PackageController.swift
+++ b/Sources/App/Controllers/PackageController.swift
@@ -18,7 +18,8 @@ struct PackageController {
     }
 
     func builds(req: Request) throws -> EventLoopFuture<HTML> {
-        req.eventLoop.future(BuildIndex.View(path: req.url.path).document())
+        let model = BuildIndex.Model.mock
+        return req.eventLoop.future(BuildIndex.View(path: req.url.path, model: model).document())
     }
 
 }

--- a/Sources/App/Core/RSS.swift
+++ b/Sources/App/Core/RSS.swift
@@ -57,7 +57,8 @@ extension RSSFeed {
 extension RecentPackage {
     var rssItem: Node<RSS.ChannelContext> {
         let link = SiteURL.package(.value(repositoryOwner),
-                                   .value(repositoryName)).absoluteURL()
+                                   .value(repositoryName),
+                                   .none).absoluteURL()
         return .item(
             .guid(.text(link), .isPermaLink(true)),
             .title(packageName),
@@ -86,7 +87,8 @@ extension RecentPackage {
 extension RecentRelease {
     var rssItem: Node<RSS.ChannelContext> {
         let link = SiteURL.package(.value(repositoryOwner),
-                                   .value(repositoryName)).absoluteURL(anchor: version)
+                                   .value(repositoryName),
+                                   .none).absoluteURL(anchor: version)
         return .item(
             .guid(.text(link), .isPermaLink(true)),
             .title("\(packageName) - \(version)"),

--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -49,7 +49,7 @@ enum Search {
                 let owner = repositoryOwner,
                 let name = repositoryName
             else { return nil }
-            return SiteURL.package(.value(owner), .value(name)).relativeURL()
+            return SiteURL.package(.value(owner), .value(name), .none).relativeURL()
         }
         
         var asRecord: Record {

--- a/Sources/App/Core/SiteURL+siteMap.swift
+++ b/Sources/App/Core/SiteURL+siteMap.swift
@@ -19,8 +19,10 @@ extension SiteURL {
             },
             .forEach(packages) { p in
                 .url(
-                    .loc(SiteURL.package(.value(p.owner), .value(p.repository)).absoluteURL()),
-                    .changefreq(SiteURL.package(.value(p.owner), .value(p.repository)).changefreq)
+                    .loc(
+                        SiteURL.package(.value(p.owner), .value(p.repository), .none).absoluteURL()),
+                    .changefreq(
+                        SiteURL.package(.value(p.owner), .value(p.repository), .none).changefreq)
                 )
             }
         )

--- a/Sources/App/Views/Home/HomeIndex+Query.swift
+++ b/Sources/App/Views/Home/HomeIndex+Query.swift
@@ -18,7 +18,8 @@ extension HomeIndex.Model {
     static func makeLink(_ recent: RecentPackage) -> Link {
         return .init(label: recent.packageName,
                      url: SiteURL.package(.value(recent.repositoryOwner),
-                                          .value(recent.repositoryName)).relativeURL())
+                                          .value(recent.repositoryName),
+                                          .none).relativeURL())
     }
     
     static func makeDatedLink(_ recent: RecentPackage) -> DatedLink {
@@ -34,6 +35,7 @@ extension HomeIndex.Model.Release {
         version = recent.version
         date = "\(date: recent.releasedAt, relativeTo: Current.date())"
         url = SiteURL.package(.value(recent.repositoryOwner),
-                              .value(recent.repositoryName)).relativeURL()
+                              .value(recent.repositoryName),
+                              .none).relativeURL()
     }
 }

--- a/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
@@ -25,13 +25,26 @@ enum BuildIndex {
 }
 
 
-#if DEBUG
 extension BuildIndex {
     struct Model {
         var packageName: String
         var stable: BuildGroup
         var latest: BuildGroup
         var beta: BuildGroup
+
+        init?(package: Package) {
+            // we consider certain attributes as essential and return nil (raising .notFound)
+            guard let name = package.name() else { return nil }
+            let (stable, beta, latest) = package.releases()
+
+            self.packageName = name
+            self.stable = .init(name: stable?.reference?.description ?? "n/a",
+                                builds: stable?.builds.map(Build.init) ?? [])
+            self.latest = .init(name: latest?.reference?.description ?? "n/a",
+                                builds: latest?.builds.map(Build.init) ?? [])
+            self.beta = .init(name: beta?.reference?.description ?? "n/a",
+                              builds: beta?.builds.map(Build.init) ?? [])
+        }
 
         struct BuildGroup {
             var name: String
@@ -54,6 +67,12 @@ extension BuildIndex {
             var platform: App.Build.Platform
             var status: App.Build.Status
 
+            init(_ build: App.Build) {
+                swiftVersion = build.swiftVersion
+                platform = build.platform
+                status = build.status
+            }
+
             var node: Node<HTML.BodyContext> {
                 .group(
                     .text("\(swiftVersion)"), " – ",
@@ -62,63 +81,5 @@ extension BuildIndex {
                 )
             }
         }
-
-        static var mock: Self {
-            .init(
-                packageName: "foobar",
-                stable: .init(
-                    name: "1.2.3",
-                    builds: [
-                        Build(swiftVersion: .init(5, 2, 4), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(5, 2, 4), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(5, 2, 4), platform: .tvos(""), status: .ok),
-                        Build(swiftVersion: .init(5, 1, 5), platform: .macos("x86_64"), status: .ok),
-                                Build(swiftVersion: .init(5, 1, 5), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(5, 1, 5), platform: .tvos(""), status: .ok),
-                        Build(swiftVersion: .init(5, 0, 3), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(5, 0, 3), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(5, 0, 3), platform: .tvos(""), status: .ok),
-                        Build(swiftVersion: .init(4, 2, 3), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(4, 2, 3), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(4, 2, 3), platform: .tvos(""), status: .ok),
-                    ]
-                ),
-                latest: .init(
-                    name: "main",
-                    builds: [
-                        Build(swiftVersion: .init(5, 2, 4), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(5, 2, 4), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(5, 2, 4), platform: .tvos(""), status: .ok),
-                        Build(swiftVersion: .init(5, 1, 5), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(5, 1, 5), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(5, 1, 5), platform: .tvos(""), status: .ok),
-                        Build(swiftVersion: .init(5, 0, 3), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(5, 0, 3), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(5, 0, 3), platform: .tvos(""), status: .ok),
-                        Build(swiftVersion: .init(4, 2, 3), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(4, 2, 3), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(4, 2, 3), platform: .tvos(""), status: .ok),
-                    ]
-                ),
-                beta: .init(
-                    name: "2.0.0-b1",
-                    builds: [
-                        Build(swiftVersion: .init(5, 2, 4), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(5, 2, 4), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(5, 2, 4), platform: .tvos(""), status: .ok),
-                        Build(swiftVersion: .init(5, 1, 5), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(5, 1, 5), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(5, 1, 5), platform: .tvos(""), status: .ok),
-                        Build(swiftVersion: .init(5, 0, 3), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(5, 0, 3), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(5, 0, 3), platform: .tvos(""), status: .ok),
-                        Build(swiftVersion: .init(4, 2, 3), platform: .macos("x86_64"), status: .ok),
-                        Build(swiftVersion: .init(4, 2, 3), platform: .ios(""), status: .ok),
-                        Build(swiftVersion: .init(4, 2, 3), platform: .tvos(""), status: .ok),
-                    ]
-                )
-            )
-        }
     }
 }
-#endif

--- a/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
@@ -1,0 +1,15 @@
+import Plot
+
+
+enum BuildIndex {
+
+    class View: PublicPage {
+
+        override func content() -> Node<HTML.BodyContext> {
+            .div(
+                .h1("Builds")
+            )
+        }
+    }
+
+}

--- a/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
@@ -5,11 +5,120 @@ enum BuildIndex {
 
     class View: PublicPage {
 
+        let model: Model
+
+        init(path: String, model: Model) {
+            self.model = model
+            super.init(path: path)
+        }
+
         override func content() -> Node<HTML.BodyContext> {
             .div(
-                .h1("Builds")
+                .h1("Builds for \(model.packageName)"),
+                model.stable.node("Stable"),
+                model.latest.node("Latest"),
+                model.beta.node("Beta")
             )
         }
     }
 
 }
+
+
+#if DEBUG
+extension BuildIndex {
+    struct Model {
+        var packageName: String
+        var stable: BuildGroup
+        var latest: BuildGroup
+        var beta: BuildGroup
+
+        struct BuildGroup {
+            var name: String
+            var builds: [Build]
+
+            func node(_ label: String) -> Node<HTML.BodyContext> {
+                .group(
+                    .h4("\(label): \(name)"),
+                    .ul(
+                        .forEach(builds) {
+                            .li($0.node)
+                        }
+                    )
+                )
+            }
+        }
+
+        struct Build {
+            var swiftVersion: App.SwiftVersion
+            var platform: App.Build.Platform
+            var status: App.Build.Status
+
+            var node: Node<HTML.BodyContext> {
+                .group(
+                    .text("\(swiftVersion)"), " – ",
+                    .text("\(platform.name)"), " – ",
+                    .text("\(status)")
+                )
+            }
+        }
+
+        static var mock: Self {
+            .init(
+                packageName: "foobar",
+                stable: .init(
+                    name: "1.2.3",
+                    builds: [
+                        Build(swiftVersion: .init(5, 2, 4), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(5, 2, 4), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(5, 2, 4), platform: .tvos(""), status: .ok),
+                        Build(swiftVersion: .init(5, 1, 5), platform: .macos("x86_64"), status: .ok),
+                                Build(swiftVersion: .init(5, 1, 5), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(5, 1, 5), platform: .tvos(""), status: .ok),
+                        Build(swiftVersion: .init(5, 0, 3), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(5, 0, 3), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(5, 0, 3), platform: .tvos(""), status: .ok),
+                        Build(swiftVersion: .init(4, 2, 3), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(4, 2, 3), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(4, 2, 3), platform: .tvos(""), status: .ok),
+                    ]
+                ),
+                latest: .init(
+                    name: "main",
+                    builds: [
+                        Build(swiftVersion: .init(5, 2, 4), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(5, 2, 4), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(5, 2, 4), platform: .tvos(""), status: .ok),
+                        Build(swiftVersion: .init(5, 1, 5), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(5, 1, 5), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(5, 1, 5), platform: .tvos(""), status: .ok),
+                        Build(swiftVersion: .init(5, 0, 3), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(5, 0, 3), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(5, 0, 3), platform: .tvos(""), status: .ok),
+                        Build(swiftVersion: .init(4, 2, 3), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(4, 2, 3), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(4, 2, 3), platform: .tvos(""), status: .ok),
+                    ]
+                ),
+                beta: .init(
+                    name: "2.0.0-b1",
+                    builds: [
+                        Build(swiftVersion: .init(5, 2, 4), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(5, 2, 4), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(5, 2, 4), platform: .tvos(""), status: .ok),
+                        Build(swiftVersion: .init(5, 1, 5), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(5, 1, 5), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(5, 1, 5), platform: .tvos(""), status: .ok),
+                        Build(swiftVersion: .init(5, 0, 3), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(5, 0, 3), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(5, 0, 3), platform: .tvos(""), status: .ok),
+                        Build(swiftVersion: .init(4, 2, 3), platform: .macos("x86_64"), status: .ok),
+                        Build(swiftVersion: .init(4, 2, 3), platform: .ios(""), status: .ok),
+                        Build(swiftVersion: .init(4, 2, 3), platform: .tvos(""), status: .ok),
+                    ]
+                )
+            )
+        }
+    }
+}
+#endif

--- a/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
@@ -37,13 +37,25 @@ extension BuildIndex {
             guard let name = package.name() else { return nil }
             let (stable, beta, latest) = package.releases()
 
+            // sort builds by swift version desc, platform name
+            let versionPlatform: (Build, Build) -> Bool = { lhs, rhs in
+                if lhs.swiftVersion != rhs.swiftVersion { return lhs.swiftVersion > rhs.swiftVersion }
+                return lhs.platform.name.rawValue < rhs.platform.name.rawValue
+            }
+
             self.packageName = name
             self.stable = .init(name: stable?.reference?.description ?? "n/a",
-                                builds: stable?.builds.map(Build.init) ?? [])
+                                builds: stable?.builds
+                                    .map(Build.init)
+                                    .sorted(by: versionPlatform) ?? [])
             self.latest = .init(name: latest?.reference?.description ?? "n/a",
-                                builds: latest?.builds.map(Build.init) ?? [])
+                                builds: latest?.builds
+                                    .map(Build.init)
+                                    .sorted(by: versionPlatform) ?? [])
             self.beta = .init(name: beta?.reference?.description ?? "n/a",
-                              builds: beta?.builds.map(Build.init) ?? [])
+                              builds: beta?.builds
+                                .map(Build.init)
+                                .sorted(by: versionPlatform) ?? [])
         }
 
         struct BuildGroup {

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -24,7 +24,8 @@ func routes(_ app: Application) throws {
     
     let packageController = PackageController()
     app.get(SiteURL.package(.key, .key, .none).pathComponents, use: packageController.show)
-    
+    app.get(SiteURL.package(.key, .key, .builds).pathComponents, use: packageController.builds)
+
     do {  // admin
         // sas: 2020-06-01: disable admin page until we have an auth mechanism
         //  app.get(Root.admin.pathComponents) { req in PublicPage.admin() }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -23,7 +23,7 @@ func routes(_ app: Application) throws {
     }
     
     let packageController = PackageController()
-    app.get(SiteURL.package(.key, .key).pathComponents, use: packageController.show)
+    app.get(SiteURL.package(.key, .key, .none).pathComponents, use: packageController.show)
     
     do {  // admin
         // sas: 2020-06-01: disable admin page until we have an auth mechanism

--- a/Tests/AppTests/SiteURLTests.swift
+++ b/Tests/AppTests/SiteURLTests.swift
@@ -13,7 +13,7 @@ class SiteURLTests: XCTestCase {
     }
     
     func test_pathComponents_with_parameter() throws {
-        let p = SiteURL.package(.key, .key).pathComponents
+        let p = SiteURL.package(.key, .key, .none).pathComponents
         XCTAssertEqual(p.map(\.description), [":owner", ":repository"])
     }
     
@@ -30,7 +30,7 @@ class SiteURLTests: XCTestCase {
     
     func test_relativeURL_with_parameters() throws {
         XCTAssertEqual(
-            SiteURL.package(.value("foo"), .value("bar")).relativeURL(),
+            SiteURL.package(.value("foo"), .value("bar"), .none).relativeURL(),
             "/foo/bar")
     }
     
@@ -58,7 +58,7 @@ class SiteURLTests: XCTestCase {
     
     func test_url_escaping() throws {
         Current.siteURL = { "https://indexsite.com" }
-        XCTAssertEqual(SiteURL.package(.value("foo bar"), .value("some repo")).absoluteURL(),
+        XCTAssertEqual(SiteURL.package(.value("foo bar"), .value("some repo"), .none).absoluteURL(),
                        "https://indexsite.com/foo%20bar/some%20repo")
     }
     
@@ -101,5 +101,11 @@ class SiteURLTests: XCTestCase {
         Current.siteURL = { "http://example.com" }
         XCTAssertEqual(SiteURL.apiBaseURL, "http://example.com/api")
     }
-    
+
+    func test_packageBuildsURL() throws {
+        XCTAssertEqual(SiteURL.package(.value("foo"), .value("bar"), .builds).path,
+                       "foo/bar/builds")
+        XCTAssertEqual(SiteURL.package(.key, .key, .builds).pathComponents.map(\.description),
+                       [":owner", ":repository", "builds"])
+    }
 }

--- a/restfiles/trigger-build-package-full.restfile
+++ b/restfiles/trigger-build-package-full.restfile
@@ -1,0 +1,280 @@
+variables:
+    # set here or via env variables:
+    # env base_url=... builder_token=... package=... rester ...
+    # base_url: http://localhost:8080/api
+    # builder_token: secr3t
+    # package: owner/repo
+
+requests:
+
+    post build ios 5.2:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: ios
+                    version: ""
+                swiftVersion:
+                    major: 5
+                    minor: 2
+                    patch: 4
+        validation:
+            status: 200
+
+    post build macos 5.2:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: macos
+                    version: "x86_64"
+                swiftVersion:
+                    major: 5
+                    minor: 2
+                    patch: 4
+        validation:
+            status: 200
+
+    post build tvos 5.2:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: tvos
+                    version: ""
+                swiftVersion:
+                    major: 5
+                    minor: 2
+                    patch: 4
+        validation:
+            status: 200
+
+    # post build watchos 5.2:
+    #     url: ${base_url}/api/packages/${package}/trigger-builds
+    #     method: POST
+    #     headers:
+    #         Authorization: Bearer ${builder_token}
+    #     body:
+    #         json:
+    #             platform:
+    #                 name: watchos
+    #                 version: "latest"
+    #             swiftVersion:
+    #                 major: ${major}
+    #                 minor: ${minor}
+    #                 patch: ${patch}
+    #     validation:
+    #         status: 200
+
+    post build ios 5.1:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: ios
+                    version: ""
+                swiftVersion:
+                    major: 5
+                    minor: 1
+                    patch: 5
+        validation:
+            status: 200
+
+    post build macos 5.1:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: macos
+                    version: "x86_64"
+                swiftVersion:
+                    major: 5
+                    minor: 1
+                    patch: 5
+        validation:
+            status: 200
+
+    post build tvos 5.1:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: tvos
+                    version: ""
+                swiftVersion:
+                    major: 5
+                    minor: 1
+                    patch: 5
+        validation:
+            status: 200
+
+    # post build watchos 5.1:
+    #     url: ${base_url}/api/packages/${package}/trigger-builds
+    #     method: POST
+    #     headers:
+    #         Authorization: Bearer ${builder_token}
+    #     body:
+    #         json:
+    #             platform:
+    #                 name: watchos
+    #                 version: "latest"
+    #             swiftVersion:
+    #                 major: ${major}
+    #                 minor: ${minor}
+    #                 patch: ${patch}
+    #     validation:
+    #         status: 200
+
+    post build ios 5.0:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: ios
+                    version: ""
+                swiftVersion:
+                    major: 5
+                    minor: 0
+                    patch: 3
+        validation:
+            status: 200
+
+    post build macos 5.0:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: macos
+                    version: "x86_64"
+                swiftVersion:
+                    major: 5
+                    minor: 0
+                    patch: 3
+        validation:
+            status: 200
+
+    post build tvos 5.0:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: tvos
+                    version: ""
+                swiftVersion:
+                    major: 5
+                    minor: 0
+                    patch: 3
+        validation:
+            status: 200
+
+    # post build watchos 5.0:
+    #     url: ${base_url}/api/packages/${package}/trigger-builds
+    #     method: POST
+    #     headers:
+    #         Authorization: Bearer ${builder_token}
+    #     body:
+    #         json:
+    #             platform:
+    #                 name: watchos
+    #                 version: "latest"
+    #             swiftVersion:
+    #                 major: ${major}
+    #                 minor: ${minor}
+    #                 patch: ${patch}
+    #     validation:
+    #         status: 200
+
+    post build ios 4.2:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: ios
+                    version: ""
+                swiftVersion:
+                    major: 4
+                    minor: 2
+                    patch: 3
+        validation:
+            status: 200
+
+    post build macos 4.2:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: macos
+                    version: "x86_64"
+                swiftVersion:
+                    major: 4
+                    minor: 2
+                    patch: 3
+        validation:
+            status: 200
+
+    post build tvos 4.2:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: tvos
+                    version: ""
+                swiftVersion:
+                    major: 4
+                    minor: 2
+                    patch: 3
+        validation:
+            status: 200
+
+    # post build watchos 4.2:
+    #     url: ${base_url}/api/packages/${package}/trigger-builds
+    #     method: POST
+    #     headers:
+    #         Authorization: Bearer ${builder_token}
+    #     body:
+    #         json:
+    #             platform:
+    #                 name: watchos
+    #                 version: "latest"
+    #             swiftVersion:
+    #                 major: ${major}
+    #                 minor: ${minor}
+    #                 patch: ${patch}
+    #     validation:
+    #         status: 200

--- a/restfiles/trigger-build-package-single.restfile
+++ b/restfiles/trigger-build-package-single.restfile
@@ -7,7 +7,7 @@ variables:
 
 requests:
 
-    post build:
+    post build ios:
         url: ${base_url}/api/packages/${package}/trigger-builds
         method: POST
         headers:
@@ -15,8 +15,8 @@ requests:
         body:
             json:
                 platform:
-                    name: unknown
-                    version: test
+                    name: ios
+                    version: ""
                 swiftVersion:
                     major: 5
                     minor: 2
@@ -25,3 +25,60 @@ requests:
         validation:
             status: 200
         log: json
+
+    post build macos:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: macos
+                    version: "x86_64"
+                swiftVersion:
+                    major: 5
+                    minor: 2
+                    patch: 4
+
+        validation:
+            status: 200
+        log: json
+
+    post build tvos:
+        url: ${base_url}/api/packages/${package}/trigger-builds
+        method: POST
+        headers:
+            Authorization: Bearer ${builder_token}
+        body:
+            json:
+                platform:
+                    name: tvos
+                    version: ""
+                swiftVersion:
+                    major: 5
+                    minor: 2
+                    patch: 4
+
+        validation:
+            status: 200
+        log: json
+
+    # post build watchos:
+    #     url: ${base_url}/api/packages/${package}/trigger-builds
+    #     method: POST
+    #     headers:
+    #         Authorization: Bearer ${builder_token}
+    #     body:
+    #         json:
+    #             platform:
+    #                 name: watchos
+    #                 version: "latest"
+    #             swiftVersion:
+    #                 major: 5
+    #                 minor: 2
+    #                 patch: 4
+
+    #     validation:
+    #         status: 200
+    #     log: json

--- a/restfiles/trigger-build-package-single.restfile
+++ b/restfiles/trigger-build-package-single.restfile
@@ -18,13 +18,11 @@ requests:
                     name: ios
                     version: ""
                 swiftVersion:
-                    major: 5
-                    minor: 2
-                    patch: 4
-
+                    major: ${major}
+                    minor: ${minor}
+                    patch: ${patch}
         validation:
             status: 200
-        log: json
 
     post build macos:
         url: ${base_url}/api/packages/${package}/trigger-builds
@@ -37,13 +35,11 @@ requests:
                     name: macos
                     version: "x86_64"
                 swiftVersion:
-                    major: 5
-                    minor: 2
-                    patch: 4
-
+                    major: ${major}
+                    minor: ${minor}
+                    patch: ${patch}
         validation:
             status: 200
-        log: json
 
     post build tvos:
         url: ${base_url}/api/packages/${package}/trigger-builds
@@ -56,13 +52,11 @@ requests:
                     name: tvos
                     version: ""
                 swiftVersion:
-                    major: 5
-                    minor: 2
-                    patch: 4
-
+                    major: ${major}
+                    minor: ${minor}
+                    patch: ${patch}
         validation:
             status: 200
-        log: json
 
     # post build watchos:
     #     url: ${base_url}/api/packages/${package}/trigger-builds
@@ -75,10 +69,8 @@ requests:
     #                 name: watchos
     #                 version: "latest"
     #             swiftVersion:
-    #                 major: 5
-    #                 minor: 2
-    #                 patch: 4
-
+    #                 major: ${major}
+    #                 minor: ${minor}
+    #                 patch: ${patch}
     #     validation:
     #         status: 200
-    #     log: json

--- a/restfiles/trigger-gitlab.restfile
+++ b/restfiles/trigger-gitlab.restfile
@@ -11,12 +11,12 @@ requests:
         body:
             form:
                 token: ${pipeline_token}
-                ref: swift-binary
+                ref: main
                 variables[API_BASEURL]: https://staging.swiftpackageindex.com/api
                 variables[BUILDER_TOKEN]: ${builder_token}
                 variables[CLONE_URL]: https://github.com/finestructure/Gala
-                variables[PLATFORM_NAME]: xcodebuilder
-                variables[PLATFORM_VERSION]: "v10.15"
+                variables[PLATFORM_NAME]: macos
+                variables[PLATFORM_VERSION]: x86_64
                 variables[SWIFT_MAJOR_VERSION]: 5
                 variables[SWIFT_MINOR_VERSION]: 2
                 variables[SWIFT_PATCH_VERSION]: 4


### PR DESCRIPTION
This adds a rudimentary `{owner}/{repo}/builds` page

https://staging.swiftpackageindex.com/tadija/AECoreDataUI/builds

I’ve just added the same sorting as in the Numbers docs - will re-deploy from this branch to see the results.