### PR TITLE
swift-5.3-DEVELOPMENT-SNAPSHOT-2020-07-04-a

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: swift:5.2.4-bionic
+      image: swiftlang/swift@sha256:5c038060f9feeb49ded30695e7062f0066a31e12feb80aba1a2779cd1fab6a73
     services:
       postgres:
         image: postgres:12.1-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM swift:5.2.4-bionic as build
+FROM swiftlang/swift@sha256:5c038060f9feeb49ded30695e7062f0066a31e12feb80aba1a2779cd1fab6a73 as build
 WORKDIR /build
 
 # First just resolve dependencies.
@@ -24,7 +24,7 @@ RUN swift build \
 # Run image
 # ================================
 # we need a swift base image so that we can run `swift dump-package`
-FROM swift:5.2.4-bionic
+FROM swiftlang/swift@sha256:5c038060f9feeb49ded30695e7062f0066a31e12feb80aba1a2779cd1fab6a73
 WORKDIR /run
 
 # install git so we can run clone/pull/etc

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ docker-push:
 
 test-docker:
 	@# run tests inside a docker container
-	docker run --rm -v "$(PWD)":/host -w /host --network="host" swift:5.2.4-bionic \
+	docker run --rm -v "$(PWD)":/host -w /host --network="host" swiftlang/swift@sha256:5c038060f9feeb49ded30695e7062f0066a31e12feb80aba1a2779cd1fab6a73 \
 	  bash -c "apt-get update && apt-get install -y unzip && make test"
 
 test-e2e: db-reset reconcile ingest analyze


### PR DESCRIPTION
Note that the tag is from the console:

```
✦ ❯ drun swiftlang/swift@sha256:5c038060f9feeb49ded30695e7062f0066a31e12feb80aba1a2779cd1fab6a73
 ################################################################
 #                                                              #
 # Swift Nightly Docker Image                           #
 # Tag: swift-5.3-DEVELOPMENT-SNAPSHOT-2020-07-04-a                     #
 #                                                              #
 ################################################################

root@cda30800f046:/host# 
```

but the image is `swiftlang/swift:nightly-5.3-bionic` - the sha is just to ensure we have a stable reference. It is from this morning (July 9, 5am-ish UTC), so there seems to be a bit of a lag between tag and build.