### PR TITLE
Fix tempdir path

### DIFF
--- a/Tests/AppTests/Helpers/TempDir.swift
+++ b/Tests/AppTests/Helpers/TempDir.swift
@@ -9,7 +9,7 @@ class TempDir {
         self.fileManager = fileManager
         let tempDir = fileManager.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
-        path = tempDir.absoluteString
+        path = tempDir.path
         try fileManager.createDirectory(atPath: path, withIntermediateDirectories: true, attributes: nil)
         precondition(fileManager.fileExists(atPath: path), "failed to create temp dir")
     }


### PR DESCRIPTION
This was creating a stray `file:var…` directory in the project directory instead of in `/var/…`