### PR TITLE
Fix docker login on spi-dev

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,9 +11,7 @@ services:
 
 
 before_script:
-  # clumsy retry because `before_script` doesn't support more complex syntax
-  - login="docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY"
-  - $login || sleep 3 && $login || sleep 3 && login
+  - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
 
     
 stages:


### PR DESCRIPTION
The retry change in the `before_script` stage seems to have broken login on `spi-dev` (and prod, but we haven't tagged since then).

This reverts that change.