### PR TITLE
Align canonical versions with builder versions

### DIFF
--- a/Sources/App/Core/SwiftVersion+Build.swift
+++ b/Sources/App/Core/SwiftVersion+Build.swift
@@ -1,8 +1,8 @@
 extension SwiftVersion {
-    static let v4_2: Self = .init(4, 2, 0)
-    static let v5_0: Self = .init(5, 0, 0)
-    static let v5_1: Self = .init(5, 1, 0)
-    static let v5_2: Self = .init(5, 2, 0)
+    static let v4_2: Self = .init(4, 2, 3)
+    static let v5_0: Self = .init(5, 0, 3)
+    static let v5_1: Self = .init(5, 1, 5)
+    static let v5_2: Self = .init(5, 2, 4)
     static let v5_3: Self = .init(5, 3, 0)
 
     /// Currently supported swift versions for building

--- a/Tests/AppTests/GitlabBuilderTests.swift
+++ b/Tests/AppTests/GitlabBuilderTests.swift
@@ -52,7 +52,7 @@ class GitlabBuilderTests: XCTestCase {
             // validate
             let swiftVersion = (try? req.query.decode([String: String].self))
                 .flatMap { $0["variables[SWIFT_VERSION]"] }
-            XCTAssertEqual(swiftVersion, "5.0.0")
+            XCTAssertEqual(swiftVersion, "5.0.3")
         }
 
         // MUT


### PR DESCRIPTION
The proper fix for #590 is to make the upsert match wider but until we’ve decided to proceed that way, this is a sensible fix to ensure both ends (server and builder) refer to the same thing when referring to “Swift 5.2” etc.