### PR TITLE
Add trigger downscaling

### DIFF
--- a/Sources/App/Commands/BuildTrigger.swift
+++ b/Sources/App/Commands/BuildTrigger.swift
@@ -48,6 +48,10 @@ func triggerBuilds(on database: Database,
         logger.info("Build trigger override switch OFF - no builds are being triggered")
         return database.eventLoop.future()
     }
+    guard Current.random(0...1) <= Current.buildTriggerDownscaling() else {
+        logger.info("Build trigger downscaling in effect - skipping builds")
+        return database.eventLoop.future()
+    }
     return Current.getStatusCount(client, .pending)
         .flatMap { count -> EventLoopFuture<Void> in
             // check if we have capacity to schedule more builds

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -29,10 +29,10 @@ extension AppEnvironment {
         allowBuildTriggers: {
             Environment.get("ALLOW_BUILD_TRIGGERS")
                 .flatMap { value -> Bool? in
-                    switch value {
-                        case "1": return true
-                        case "0": return false
-                        default: return Bool(value.lowercased())
+                    switch value.lowercased() {
+                        case "1", "yes", "true": return true
+                        case "0", "no", "false": return false
+                        default: return Bool(value)
                     }
                 }
                 ?? Constants.defaultAllowBuildTriggering

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -5,6 +5,7 @@ import Vapor
 struct AppEnvironment {
     var allowBuildTriggers: () -> Bool
     var builderToken: () -> String?
+    var buildTriggerDownscaling: () -> Double
     var date: () -> Date
     var fetchPackageList: (_ client: Client) throws -> EventLoopFuture<[URL]>
     var fetchMetadata: (_ client: Client, _ package: Package) -> EventLoopFuture<Github.Metadata>
@@ -15,6 +16,7 @@ struct AppEnvironment {
     var gitlabApiToken: () -> String?
     var gitlabPipelineToken: () -> String?
     var gitlabPipelineLimit: () -> Int
+    var random: (_ range: ClosedRange<Double>) -> Double
     var reportError: (_ client: Client, _ level: AppError.Level, _ error: Error) -> EventLoopFuture<Void>
     var rollbarToken: () -> String?
     var rollbarLogLevel: () -> AppError.Level
@@ -36,6 +38,11 @@ extension AppEnvironment {
                 ?? Constants.defaultAllowBuildTriggering
         },
         builderToken: { Environment.get("BUILDER_TOKEN") },
+        buildTriggerDownscaling: {
+            Environment.get("BUILD_TRIGGER_DOWNSCALING")
+                .flatMap(Double.init)
+                ?? 1.0
+        },
         date: Date.init,
         fetchPackageList: liveFetchPackageList,
         fetchMetadata: Github.fetchMetadata(client:package:),
@@ -55,6 +62,7 @@ extension AppEnvironment {
             Environment.get("GITLAB_PIPELINE_LIMIT").flatMap(Int.init)
             ?? Constants.defaultGitlabPipelineLimit
         },
+        random: Double.random,
         reportError: AppError.report,
         rollbarToken: { Environment.get("ROLLBAR_TOKEN") },
         rollbarLogLevel: {

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -7,6 +7,7 @@ extension AppEnvironment {
     static let mock: Self = .init(
         allowBuildTriggers: { true },
         builderToken: { nil },
+        buildTriggerDownscaling: { 1.0 },
         date: Date.init,
         fetchPackageList: { _ in
             .just(value: ["https://github.com/finestructure/Gala",
@@ -19,6 +20,7 @@ extension AppEnvironment {
         gitlabApiToken: { nil },
         gitlabPipelineToken: { nil },
         gitlabPipelineLimit: { Constants.defaultGitlabPipelineLimit },
+        random: Double.random,
         reportError: { _, _, _ in .just(value: ()) },
         rollbarToken: { nil },
         rollbarLogLevel: { .critical },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,17 @@ services:
     ]
     restart: always
 
+  trigger_builds:
+    image: registry.gitlab.com/finestructure/swiftpackageindex:${VERSION}
+    <<: *shared
+    depends_on:
+      - migrate
+    entrypoint: ["/bin/bash"]
+    command: ["-c", "--",
+      "trap : TERM INT; while true; do ./Run trigger-builds --env ${ENV} --limit ${BUILD_TRIGGER_LIMIT:-1}; sleep ${BUILD_TRIGGER_SLEEP:-60}; done"
+    ]
+    restart: always
+  
   migrate:
     image: registry.gitlab.com/finestructure/swiftpackageindex:${VERSION}
     <<: *shared

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ x-shared: &shared
   environment:
     # set these variables via the environment or a `.env` file, which
     # docker-compose reads and uses to populate variables
+    ALLOW_BUILD_TRIGGERS: ${ALLOW_BUILD_TRIGGERS}
+    BUILD_TRIGGER_DOWNSCALING: ${BUILD_TRIGGER_DOWNSCALING}
     BUILDER_TOKEN: ${BUILDER_TOKEN}
     CHECKOUTS_DIR: ${CHECKOUTS_DIR}
     DATABASE_HOST: ${DATABASE_HOST}


### PR DESCRIPTION
Fixes #598 

With this we're good to go.

I've set ALLOW_BUILD_TRIGGERS to true on staging and false on prod for now and BUILD_TRIGGER_DOWNSCALING to 0.2 on staging.

Once we deploy this, staging should start picking up builds at a 20% rate. Since this is kicking off every minute we should quickly see builds going in and also the downscaling taking effect.

Production wouldn't yet process any builds due to the override being off.

When we're happy with that, I'd propose to make the following changes and redeploy to make it take effect:

staging:

BUILD_TRIGGER_DOWNSCALING: 0.05

prod:

ALLOW_BUILD_TRIGGERS: true

That'll throttle staging back and open up processing on production.