### PR TITLE
Change unique index on builds to ignore patch version

### DIFF
--- a/Sources/App/Migrations/015/UpdateBuildUniqueIndex1.swift
+++ b/Sources/App/Migrations/015/UpdateBuildUniqueIndex1.swift
@@ -35,7 +35,7 @@ struct UpdateBuildUniqueIndex1: Migration {
             .unique(on: "version_id", "platform", "swift_version")
             .update()
             .flatMap {
-                db.raw(#"DROP INDEX "\#(newIndexName)""#).run()
+                db.raw(#"DROP INDEX "\#(self.newIndexName)""#).run()
             }
     }
 }

--- a/Sources/App/Migrations/015/UpdateBuildUniqueIndex1.swift
+++ b/Sources/App/Migrations/015/UpdateBuildUniqueIndex1.swift
@@ -1,0 +1,41 @@
+import Fluent
+import SQLKit
+
+
+struct UpdateBuildUniqueIndex1: Migration {
+    let newIndexName = "uq:builds.version_id+builds.platform+builds.swift_version+v2"
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        return db.raw("""
+            CREATE UNIQUE INDEX "\(newIndexName)"
+            ON builds (
+                version_id,
+                platform,
+                (swift_version->'major'),
+                (swift_version->'minor')
+            )
+            """).run()
+            .flatMap {
+                database.schema("builds")
+                    .deleteUnique(on: "version_id", "platform", "swift_version")
+                    .update()
+            }
+    }
+    
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        return database.schema("builds")
+            .unique(on: "version_id", "platform", "swift_version")
+            .update()
+            .flatMap {
+                db.raw(#"DROP INDEX "\#(newIndexName)""#).run()
+            }
+    }
+}

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -155,7 +155,8 @@ extension Build {
                 // ... find the existing build
                 return Build.query(on: database)
                     .filter(\.$platform == self.platform)
-                    .filter(\.$swiftVersion == self.swiftVersion)
+                    .filter(.sql(raw: "(swift_version->'major')::int = \(self.swiftVersion.major)"))
+                    .filter(.sql(raw: "(swift_version->'minor')::int = \(self.swiftVersion.minor)"))
                     .filter(\.$version.$id == self.$version.id)
                     .all()
                     // ... delete it

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -79,6 +79,9 @@ public func configure(_ app: Application) throws {
     do {  // Migration 014 - add latest
         app.migrations.add(UpdateVersionAddLatest())
     }
+    do {  // Migration 015 -
+        app.migrations.add(UpdateBuildUniqueIndex1())
+    }
     
     app.commands.use(AnalyzerCommand(), as: "analyze")
     app.commands.use(BuildTriggerCommand(), as: "trigger-builds")

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -162,7 +162,8 @@ class BuildTests: AppTestCase {
             XCTAssertEqual(b.status, .ok)
             XCTAssertEqual(b.swiftVersion, .init(5, 2, 0))
         }
-        
+
+        // MUT
         // next insert is update
         try Build(version: v,
                   platform: .linux,
@@ -177,6 +178,23 @@ class BuildTests: AppTestCase {
             XCTAssertEqual(b.platform, .linux)
             XCTAssertEqual(b.status, .failed)
             XCTAssertEqual(b.swiftVersion, .init(5, 2, 0))
+        }
+
+        // MUT
+        // insert with different patch version updates as well
+        try Build(version: v,
+                  platform: .linux,
+                  status: .failed,
+                  swiftVersion: .init(5, 2, 4))
+            .upsert(on: app.db).wait()
+
+        // validate
+        do {
+            XCTAssertEqual(try Build.query(on: app.db).count().wait(), 1)
+            let b = try XCTUnwrap(try Build.query(on: app.db).first().wait())
+            XCTAssertEqual(b.platform, .linux)
+            XCTAssertEqual(b.status, .failed)
+            XCTAssertEqual(b.swiftVersion, .init(5, 2, 4))
         }
     }
 

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -411,7 +411,6 @@ final class PackageTests: AppTestCase {
         try makeBuild(.failed, .macosXcodebuild, .init(5, 0, 1))
         // 5.1 - no data - unknown
         // 5.2 - ok
-        try makeBuild(.failed, .macosXcodebuild, .init(5, 2, 0))
         try makeBuild(.ok, .macosXcodebuild, .init(5, 2, 2))
         // 5.3 - ok
         try makeBuild(.failed, .ios, .init(5, 3, 0))


### PR DESCRIPTION
Fixes #590 

I've already applied an equivalent temporary index

```
CREATE UNIQUE INDEX "temp_1"
            ON builds (
                version_id,
                platform,
                (swift_version->'major'),
                (swift_version->'minor')
            );
```

on both dev and prod dbs to ensure that the migration will succeed.

Once this is merged and deployed I'll remove those indexes again.

⚠️ Schema change, deploy as 1.8.0 ⚠️