### PR TITLE
Package update

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/swift-server/async-http-client.git",
         "state": {
           "branch": null,
-          "revision": "037b70291941fe43de668066eb6fb802c5e181d2",
-          "version": "1.1.1"
+          "revision": "c9a9bf061d713c91ee9974fa8a6afe413acfd0e9",
+          "version": "1.2.0"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/vapor/console-kit.git",
         "state": {
           "branch": null,
-          "revision": "9b5842b47be1a3164a42811613dce09bf5bf1f91",
-          "version": "4.1.3"
+          "revision": "7cf8185ad62d50ae9777ce78bcfde8f5c9f900e2",
+          "version": "4.2.1"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-kit.git",
         "state": {
           "branch": null,
-          "revision": "ad5eef38c5168fdb4b77d5a73794a90e0ce3b9a5",
-          "version": "1.0.2"
+          "revision": "2227231901db2c4d73c0a92cc088447f2a41030d",
+          "version": "1.7.1"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/vapor/fluent-postgres-driver.git",
         "state": {
           "branch": null,
-          "revision": "cf8ec53b87606dc799a07a0754a297b32cf9f592",
-          "version": "2.0.0"
+          "revision": "f310f8843fafa3134cf89d81b8b3480f16967f37",
+          "version": "2.1.0"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/vapor/postgres-nio.git",
         "state": {
           "branch": null,
-          "revision": "25aa31fdd55ea119edee270ce4bd7bd4bd59fdf7",
-          "version": "1.1.0"
+          "revision": "70d63c54484f2cbeacf495096a657557f19665f2",
+          "version": "1.3.0"
         }
       },
       {
@@ -96,8 +96,8 @@
         "repositoryURL": "https://github.com/vapor/routing-kit.git",
         "state": {
           "branch": null,
-          "revision": "e7f2d5bd36dc65a9edb303541cb678515a7fece3",
-          "version": "4.1.0"
+          "revision": "4cf052b78aebaf1b23f2264ce04d57b4b6eb5254",
+          "version": "4.2.0"
         }
       },
       {
@@ -114,8 +114,8 @@
         "repositoryURL": "https://github.com/vapor/sql-kit.git",
         "state": {
           "branch": null,
-          "revision": "8b82edd5d918068f204e3ac4206d5d15f6740395",
-          "version": "3.5.0"
+          "revision": "ea9928b7f4a801b175a00b982034d9c54ecb6167",
+          "version": "3.7.0"
         }
       },
       {
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "74d7b91ceebc85daf387ebb206003f78813f71aa",
-          "version": "1.2.0"
+          "revision": "173f567a2dfec11d74588eea82cecea555bdc0bc",
+          "version": "1.4.0"
         }
       },
       {
@@ -159,8 +159,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "8a865bd15e69526cbdfcfd7c47698eb20b2ba951",
-          "version": "2.19.0"
+          "revision": "acf5465b5e7fb9aeda54a34d16fb44c31a399715",
+          "version": "2.20.2"
         }
       },
       {
@@ -168,8 +168,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-extras.git",
         "state": {
           "branch": null,
-          "revision": "7cd24c0efcf9700033f671b6a8eaa64a77dd0b72",
-          "version": "1.5.1"
+          "revision": "d525d3bbd1321fa928948065fd9a8dc109d5d45b",
+          "version": "1.6.0"
         }
       },
       {
@@ -177,8 +177,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio-http2.git",
         "state": {
           "branch": null,
-          "revision": "c76a9a5085bfc22882f8cff88189662af30806e8",
-          "version": "1.12.3"
+          "revision": "e9627350bdb85bde7e0dc69a29799e40961ced72",
+          "version": "1.13.0"
         }
       },
       {
@@ -186,8 +186,17 @@
         "repositoryURL": "https://github.com/apple/swift-nio-ssl.git",
         "state": {
           "branch": null,
-          "revision": "d381bc53edd9de88a75480a2b969bfc26d61ee76",
-          "version": "2.8.0"
+          "revision": "8a137b72a9339f295bc8bb95cd2fafe207f1df0d",
+          "version": "2.9.0"
+        }
+      },
+      {
+        "package": "swift-nio-transport-services",
+        "repositoryURL": "https://github.com/apple/swift-nio-transport-services.git",
+        "state": {
+          "branch": null,
+          "revision": "d40a5e34e5b35f4f961cb34aeb2e0a02f42a945f",
+          "version": "1.8.0"
         }
       },
       {
@@ -204,8 +213,8 @@
         "repositoryURL": "https://github.com/vapor/vapor.git",
         "state": {
           "branch": null,
-          "revision": "dc2aa1e02e04a47b67cb0dabed628fe844900f30",
-          "version": "4.14.0"
+          "revision": "7d1e0b162f61fd4b34c4a7e575cfaef14e65484a",
+          "version": "4.28.0"
         }
       },
       {
@@ -213,8 +222,8 @@
         "repositoryURL": "https://github.com/vapor/websocket-kit.git",
         "state": {
           "branch": null,
-          "revision": "021edd1ca55451ad15b3e84da6b4064e4b877b34",
-          "version": "2.1.0"
+          "revision": "b0736014be634475dac4c23843811257d86dcdc1",
+          "version": "2.1.1"
         }
       }
     ]

--- a/Sources/App/Core/Gitlab.swift
+++ b/Sources/App/Core/Gitlab.swift
@@ -70,6 +70,12 @@ extension Gitlab.Builder {
         return req
     }
 
+    struct PostDTO: Codable, Equatable {
+        var token: String
+        var ref: String
+        var variables: [String: String]
+    }
+
 }
 
 

--- a/Sources/App/Core/Gitlab.swift
+++ b/Sources/App/Core/Gitlab.swift
@@ -54,17 +54,18 @@ extension Gitlab.Builder {
         let uri: URI = .init(string: "\(projectURL)/trigger/pipeline")
         let req = client
             .post(uri) { req in
-                let data: [String: String] = [
-                    "token": pipelineToken,
-                    "ref": branch,
-                    "variables[API_BASEURL]": SiteURL.apiBaseURL,
-                    "variables[BUILD_PLATFORM]": platform.rawValue,
-                    "variables[BUILDER_TOKEN]": builderToken,
-                    "variables[CLONE_URL]": cloneURL,
-                    "variables[REFERENCE]": "\(reference)",
-                    "variables[SWIFT_VERSION]": "\(swiftVersion.major).\(swiftVersion.minor).\(swiftVersion.patch)",
-                    "variables[VERSION_ID]": versionID.uuidString,
-                ]
+                let data = PostDTO(
+                    token: pipelineToken,
+                    ref: branch,
+                    variables: [
+                        "API_BASEURL": SiteURL.apiBaseURL,
+                        "BUILD_PLATFORM": platform.rawValue,
+                        "BUILDER_TOKEN": builderToken,
+                        "CLONE_URL": cloneURL,
+                        "REFERENCE": "\(reference)",
+                        "SWIFT_VERSION": "\(swiftVersion.major).\(swiftVersion.minor).\(swiftVersion.patch)",
+                        "VERSION_ID": versionID.uuidString
+                    ])
                 try req.query.encode(data)
             }
         return req

--- a/Sources/App/Core/RecentPackage.swift
+++ b/Sources/App/Core/RecentPackage.swift
@@ -28,7 +28,7 @@ extension RecentPackage {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
-        return db.raw("REFRESH MATERIALIZED VIEW \(Self.schema)").run()
+        return db.raw("REFRESH MATERIALIZED VIEW \(raw: Self.schema)").run()
     }
     
     
@@ -37,7 +37,7 @@ extension RecentPackage {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
-        return db.raw("SELECT * FROM \(Self.schema) ORDER BY created_at DESC LIMIT \(bind: limit)")
+        return db.raw("SELECT * FROM \(raw: Self.schema) ORDER BY created_at DESC LIMIT \(bind: limit)")
             .all(decoding: RecentPackage.self)
     }
 }

--- a/Sources/App/Core/RecentRelease.swift
+++ b/Sources/App/Core/RecentRelease.swift
@@ -30,7 +30,7 @@ extension RecentRelease {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
-        return db.raw("REFRESH MATERIALIZED VIEW \(Self.schema)").run()
+        return db.raw("REFRESH MATERIALIZED VIEW \(raw: Self.schema)").run()
     }
     
     static func filterReleases(_ releases: [RecentRelease], by filter: Filter) -> [RecentRelease] {
@@ -52,7 +52,7 @@ extension RecentRelease {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
         
-        return db.raw("SELECT * FROM \(Self.schema) ORDER BY released_at DESC LIMIT \(bind: limit)")
+        return db.raw("SELECT * FROM \(raw: Self.schema) ORDER BY released_at DESC LIMIT \(bind: limit)")
             .all(decoding: RecentRelease.self)
             .map { filterReleases($0, by: filter) }
     }

--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -117,7 +117,7 @@ enum Search {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
-        return db.raw("REFRESH MATERIALIZED VIEW \(Self.schema)").run()
+        return db.raw("REFRESH MATERIALIZED VIEW \(raw: Self.schema)").run()
     }
 }
 

--- a/Sources/App/Core/Stats.swift
+++ b/Sources/App/Core/Stats.swift
@@ -20,7 +20,7 @@ extension Stats {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
-        return db.raw("REFRESH MATERIALIZED VIEW \(Self.schema)").run()
+        return db.raw("REFRESH MATERIALIZED VIEW \(raw: Self.schema)").run()
     }
     
     
@@ -28,7 +28,7 @@ extension Stats {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
-        return db.raw("SELECT * FROM \(Self.schema)")
+        return db.raw("SELECT * FROM \(raw: Self.schema)")
             .first(decoding: Stats.self)
     }
 }

--- a/Sources/App/Migrations/015/UpdateBuildUniqueIndex1.swift
+++ b/Sources/App/Migrations/015/UpdateBuildUniqueIndex1.swift
@@ -11,7 +11,7 @@ struct UpdateBuildUniqueIndex1: Migration {
         }
 
         return db.raw("""
-            CREATE UNIQUE INDEX "\(newIndexName)"
+            CREATE UNIQUE INDEX "\(raw: newIndexName)"
             ON builds (
                 version_id,
                 platform,
@@ -35,7 +35,7 @@ struct UpdateBuildUniqueIndex1: Migration {
             .unique(on: "version_id", "platform", "swift_version")
             .update()
             .flatMap {
-                db.raw(#"DROP INDEX "\#(self.newIndexName)""#).run()
+                db.raw(#"DROP INDEX "\#(raw: self.newIndexName)""#).run()
             }
     }
 }

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -113,18 +113,19 @@ class BuildTests: AppTestCase {
             called = true
             res.status = .created
             // validate request data
-            XCTAssertEqual(try? req.query.decode([String: String].self),
-                           .some([
-                            "token": "pipeline token",
-                            "ref": "main",
-                            "variables[API_BASEURL]": "http://example.com/api",
-                            "variables[BUILD_PLATFORM]": "macos-xcodebuild",
-                            "variables[BUILDER_TOKEN]": "builder token",
-                            "variables[CLONE_URL]": "1",
-                            "variables[REFERENCE]": "main",
-                            "variables[SWIFT_VERSION]": "5.2.4",
-                            "variables[VERSION_ID]": versionID.uuidString,
-                           ]))
+            XCTAssertEqual(try? req.query.decode(Gitlab.Builder.PostDTO.self),
+                           Gitlab.Builder.PostDTO(
+                            token: "pipeline token",
+                            ref: "main",
+                            variables: [
+                                "API_BASEURL": "http://example.com/api",
+                                "BUILD_PLATFORM": "macos-xcodebuild",
+                                "BUILDER_TOKEN": "builder token",
+                                "CLONE_URL": "1",
+                                "REFERENCE": "main",
+                                "SWIFT_VERSION": "5.2.4",
+                                "VERSION_ID": versionID.uuidString,
+                            ]))
         }
         
         // MUT

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -90,10 +90,10 @@ class BuildTriggerTests: AppTestCase {
         Current.siteURL = { "http://example.com" }
 
         let queue = DispatchQueue(label: "serial")
-        var queries = [[String: String]]()
+        var queries = [Gitlab.Builder.PostDTO]()
         let client = MockClient { req, res in
             queue.sync {
-                guard let query = try? req.query.decode([String: String].self) else { return }
+                guard let query = try? req.query.decode(Gitlab.Builder.PostDTO.self) else { return }
                 queries.append(query)
             }
         }
@@ -116,9 +116,9 @@ class BuildTriggerTests: AppTestCase {
         // validate
         // ensure Gitlab requests go out
         XCTAssertEqual(queries.count, 1)
-        XCTAssertEqual(queries.map { $0["variables[VERSION_ID]"] }, [versionId.uuidString])
-        XCTAssertEqual(queries.map { $0["variables[BUILD_PLATFORM]"] }, ["ios"])
-        XCTAssertEqual(queries.map { $0["variables[SWIFT_VERSION]"] }, ["4.2.3"])
+        XCTAssertEqual(queries.map { $0.variables["VERSION_ID"] }, [versionId.uuidString])
+        XCTAssertEqual(queries.map { $0.variables["BUILD_PLATFORM"] }, ["ios"])
+        XCTAssertEqual(queries.map { $0.variables["SWIFT_VERSION"] }, ["4.2.3"])
 
         // ensure the Build stubs is created to prevent re-selection
         let v = try Version.find(versionId, on: app.db).wait()
@@ -135,10 +135,10 @@ class BuildTriggerTests: AppTestCase {
         Current.siteURL = { "http://example.com" }
 
         let queue = DispatchQueue(label: "serial")
-        var queries = [[String: String]]()
+        var queries = [Gitlab.Builder.PostDTO]()
         let client = MockClient { req, res in
             queue.sync {
-                guard let query = try? req.query.decode([String: String].self) else { return }
+                guard let query = try? req.query.decode(Gitlab.Builder.PostDTO.self) else { return }
                 queries.append(query)
             }
         }
@@ -162,9 +162,9 @@ class BuildTriggerTests: AppTestCase {
         // validate
         // ensure Gitlab requests go out
         XCTAssertEqual(queries.count, 32)
-        XCTAssertEqual(queries.map { $0["variables[VERSION_ID]"] },
+        XCTAssertEqual(queries.map { $0.variables["VERSION_ID"] },
                        Array(repeating: versionId.uuidString, count: 32))
-        let buildPlatforms = queries.compactMap { $0["variables[BUILD_PLATFORM]"] }
+        let buildPlatforms = queries.compactMap { $0.variables["BUILD_PLATFORM"] }
         XCTAssertEqual(Dictionary(grouping: buildPlatforms, by: { $0 })
                         .mapValues(\.count),
                        ["ios": 5,
@@ -175,7 +175,7 @@ class BuildTriggerTests: AppTestCase {
                         "linux": 5,
                         "watchos": 5,
                         "tvos": 5])
-        let swiftVersions = queries.compactMap { $0["variables[SWIFT_VERSION]"] }
+        let swiftVersions = queries.compactMap { $0.variables["SWIFT_VERSION"] }
         XCTAssertEqual(Dictionary(grouping: swiftVersions, by: { $0 })
                         .mapValues(\.count),
                        ["4.2.3": 6,

--- a/Tests/AppTests/GitlabBuilderTests.swift
+++ b/Tests/AppTests/GitlabBuilderTests.swift
@@ -17,18 +17,19 @@ class GitlabBuilderTests: XCTestCase {
             // validate
             XCTAssert(req.url.query?.contains("variables%5BREFERENCE%5D=1.2.3") ?? false,
                       "expected to find percent encoded variables")
-            XCTAssertEqual(try? req.query.decode([String: String].self),
-                           .some([
-                            "token": "pipeline token",
-                            "ref": "main",
-                            "variables[API_BASEURL]": "http://example.com/api",
-                            "variables[BUILD_PLATFORM]": "macos-spm",
-                            "variables[BUILDER_TOKEN]": "builder token",
-                            "variables[CLONE_URL]": "https://github.com/daveverwer/LeftPad.git",
-                            "variables[REFERENCE]": "1.2.3",
-                            "variables[SWIFT_VERSION]": "5.2.4",
-                            "variables[VERSION_ID]": versionID.uuidString,
-                           ]))
+            XCTAssertEqual(try? req.query.decode(Gitlab.Builder.PostDTO.self),
+                           Gitlab.Builder.PostDTO(
+                            token: "pipeline token",
+                            ref: "main",
+                            variables: [
+                                "API_BASEURL": "http://example.com/api",
+                                "BUILD_PLATFORM": "macos-spm",
+                                "BUILDER_TOKEN": "builder token",
+                                "CLONE_URL": "https://github.com/daveverwer/LeftPad.git",
+                                "REFERENCE": "1.2.3",
+                                "SWIFT_VERSION": "5.2.4",
+                                "VERSION_ID": versionID.uuidString,
+                            ]))
         }
         
         // MUT
@@ -52,8 +53,8 @@ class GitlabBuilderTests: XCTestCase {
         let client = MockClient { req, res in
             called = true
             // validate
-            let swiftVersion = (try? req.query.decode([String: String].self))
-                .flatMap { $0["variables[SWIFT_VERSION]"] }
+            let swiftVersion = (try? req.query.decode(Gitlab.Builder.PostDTO.self))
+                .flatMap { $0.variables["SWIFT_VERSION"] }
             XCTAssertEqual(swiftVersion, "5.0.3")
         }
 

--- a/Tests/AppTests/GitlabBuilderTests.swift
+++ b/Tests/AppTests/GitlabBuilderTests.swift
@@ -15,6 +15,8 @@ class GitlabBuilderTests: XCTestCase {
         let client = MockClient { req, res in
             called = true
             // validate
+            XCTAssert(req.url.query?.contains("variables%5BREFERENCE%5D=1.2.3") ?? false,
+                      "expected to find percent encoded variables")
             XCTAssertEqual(try? req.query.decode([String: String].self),
                            .some([
                             "token": "pipeline token",

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -52,7 +52,7 @@ func _resetDb(_ app: Application) throws {
     }
     
     for table in tables {
-        try db.raw("TRUNCATE TABLE \(table) CASCADE").run().wait()
+        try db.raw("TRUNCATE TABLE \(raw: table) CASCADE").run().wait()
     }
 }
 


### PR DESCRIPTION
Fixes #648 

The reason I actually looked into this was that if we go with option 2 for the admin auth (JWT), we need to add that package and in the course of that we'd bump revisions on all the others (unless we pin them).

The admin API I think is going to be pretty important shortly after launch, because I suspect we may get a few requests to re-run builds and I don't want to fiddle around directly in the db too much.

Also, if it was _only_ about the admin API I wouldn't have bothered but we've gone quite long without package updates, so there's that as well.

Everything is back in working order now but there's a change to our outgoing build trigger request format. We used to send `variables%5BFOO%5D=bar` but now we're sending `variables[FOO]=bar`. Ironically, I _thought_ we've been sending the latter all along.

In any case, Gitlab seems to support both. Here's a trigger I ran with the `postTrigger` method now using the `PostDTO` struct to package up the data instead of `[String: String]` (which is percent encoded):

<img width="1287" alt="Screenshot 2020-08-18 at 11 51 08" src="https://user-images.githubusercontent.com/65520/90499575-feaf8780-e149-11ea-8b49-a148709ecce3.png">

Still working fine.

Now we still may want to hold off on merging this right now but I wanted to mention why I wrapped that up at this time and that it's influenced by how we're dealing with admin auth.