### PR TITLE
Db backup

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -128,13 +128,9 @@ smoke-test:
   tags:
     - ceres
   script: |
-    FILENAME=spi_prod_$(date "+%Y-%m-%dT%H:%M:%S").dump
-    echo Backing up database to file ${FILENAME}
-    echo Note: This requires the appropriate SSH tunnel to be active on the runner
-    env PGPASSWORD=${DATABASE_PASSWORD} pg_dump --no-owner -Fc -h localhost -p 7432 -U spi_prod spi_prod > ${FILENAME}
-    echo "Moving backup file to ${DB_BACKUP_DIR}"
-    mv ${FILENAME} ${DB_BACKUP_DIR}
-
+    TARFILE=spi_${ENV}_$(date +%Y-%m-%d).tgz
+    ./scripts/db_backup.sh $TARFILE
+    ./scripts/convert_to_db_dump.sh $TARFILE
 
 db-backup (scheduled):  # PROD: auto-backup on schedule
   rules:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,12 +126,8 @@ smoke-test:
 .backup-common: &backup-common
   stage: build
   tags:
-    - spi-prod
-    - db-backup
+    - spi-prod-backup
   script: |
-    echo $PWD
-    whoami
-    which docker
     TARFILE=spi_${ENV}_$(date +%Y-%m-%d).tgz
     ./scripts/db_backup.sh $TARFILE
     ./scripts/convert_to_db_dump.sh $TARFILE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -126,7 +126,7 @@ smoke-test:
 .backup-common: &backup-common
   stage: build
   tags:
-    - ceres
+    - spi-prod
   script: |
     TARFILE=spi_${ENV}_$(date +%Y-%m-%d).tgz
     ./scripts/db_backup.sh $TARFILE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,10 @@ services:
   - docker:stable-dind
 
 
+before_script:
+  - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+
+
 stages:
   - build
   - deploy
@@ -25,8 +29,6 @@ build:
   stage: build
   tags:
     - ceres
-  before_script:
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   script: |
     VERSION=${CI_COMMIT_TAG:-$CI_COMMIT_SHA}
     echo 'let appVersion = "'${VERSION}'"' > ./Sources/App/Core/AppVersion.swift
@@ -44,8 +46,6 @@ build:
 .deploy-common: &deploy-common
   stage: deploy
   image: docker/compose:1.25.5
-  before_script:
-    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   script: |
     set -eu
     VERSION=${CI_COMMIT_TAG:-$CI_COMMIT_SHA}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,10 +10,6 @@ services:
   - docker:stable-dind
 
 
-before_script:
-  - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-
-    
 stages:
   - build
   - deploy
@@ -29,6 +25,8 @@ build:
   stage: build
   tags:
     - ceres
+  before_script:
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   script: |
     VERSION=${CI_COMMIT_TAG:-$CI_COMMIT_SHA}
     echo 'let appVersion = "'${VERSION}'"' > ./Sources/App/Core/AppVersion.swift
@@ -46,6 +44,8 @@ build:
 .deploy-common: &deploy-common
   stage: deploy
   image: docker/compose:1.25.5
+  before_script:
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
   script: |
     set -eu
     VERSION=${CI_COMMIT_TAG:-$CI_COMMIT_SHA}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,6 +129,9 @@ smoke-test:
     - spi-prod
     - db-backup
   script: |
+    echo $PWD
+    whoami
+    which docker
     TARFILE=spi_${ENV}_$(date +%Y-%m-%d).tgz
     ./scripts/db_backup.sh $TARFILE
     ./scripts/convert_to_db_dump.sh $TARFILE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -127,6 +127,7 @@ smoke-test:
   stage: build
   tags:
     - spi-prod
+    - db-backup
   script: |
     TARFILE=spi_${ENV}_$(date +%Y-%m-%d).tgz
     ./scripts/db_backup.sh $TARFILE

--- a/scripts/convert_to_db_dump.sh
+++ b/scripts/convert_to_db_dump.sh
@@ -11,12 +11,12 @@ DUMPFILE=$(basename $TARFILE).dump
 
 tar xvfz $TARFILE
 
-docker run --rm --name backup-db -d -v "$PWD/db_data:/var/lib/postgresql/data" -p 9432:5432 postgres:12.1-alpine
+/usr/local/bin/docker run --rm --name backup-db -d -v "$PWD/db_data:/var/lib/postgresql/data" -p 9432:5432 postgres:12.1-alpine
 
 echo "Exporting ..."
 
 RETRIES=20
-until env PGPASSWORD=${DATABASE_PASSWORD} pg_dump --no-owner -Fc -h localhost -p 9432 -U spi_${ENV} spi_${ENV} > $DUMPFILE || [ $RETRIES -eq 0 ]; do
+until env PGPASSWORD=${DATABASE_PASSWORD} /usr/local/bin/pg_dump --no-owner -Fc -h localhost -p 9432 -U spi_${ENV} spi_${ENV} > $DUMPFILE || [ $RETRIES -eq 0 ]; do
     echo "Waiting for postgres server, $((RETRIES-=1)) remaining attempts..."
     sleep 2
 done

--- a/scripts/convert_to_db_dump.sh
+++ b/scripts/convert_to_db_dump.sh
@@ -4,10 +4,15 @@ set -eu
 
 TARFILE=$1
 DUMPFILE=$(basename $TARFILE).dump
+PG_IMAGE=postgres:12.1-alpine
 
 [[ -n $DATABASE_PASSWORD ]]  || (echo "DATABASE_PASSWORD not set" && exit 1)
 [[ -n $DB_BACKUP_DIR ]]      || (echo "DB_BACKUP_DIR not set" && exit 1)
 [[ -n $ENV ]]                || (echo "ENV not set" && exit 1)
+
+# Create docker network (ignoring "already exists") in order to
+# discover database at hostname "backup-db"
+docker network create backup || true
 
 echo "Unpacking ..."
 
@@ -15,14 +20,25 @@ tar xfz $TARFILE
 
 echo "Launching backup db ..."
 
-docker run --rm --name backup-db -d -v "$PWD/db_data:/var/lib/postgresql/data" -p 9432:5432 postgres:12.1-alpine
+docker run --rm --name backup-db -d \
+    -v "$PWD/db_data:/var/lib/postgresql/data" \
+    --network backup \
+    $PG_IMAGE
 
 echo "Exporting to $DUMPFILE ..."
 
 RETRIES=30
-until env PGPASSWORD=${DATABASE_PASSWORD} pg_dump --no-owner -Fc -h localhost -p 9432 -U spi_${ENV} spi_${ENV} > $DUMPFILE || [ $RETRIES -eq 0 ]; do
+until docker run --rm --name pg_dump \
+    -v "$PWD":/host \
+    --network backup \
+    --env PGPASSWORD=${DATABASE_PASSWORD} \
+    $PG_IMAGE \
+    pg_dump --no-owner -Fc -f /host/$DUMPFILE \
+        -h backup-db -U spi_${ENV} spi_${ENV} \
+    || [ $RETRIES -eq 0 ]; do
     echo "Waiting for postgres server, $((RETRIES-=1)) remaining attempts..."
     sleep 5
+    echo "Retrying ..."
 done
 
 echo "Moving file"

--- a/scripts/convert_to_db_dump.sh
+++ b/scripts/convert_to_db_dump.sh
@@ -19,10 +19,10 @@ docker run --rm --name backup-db -d -v "$PWD/db_data:/var/lib/postgresql/data" -
 
 echo "Exporting to $DUMPFILE ..."
 
-RETRIES=20
+RETRIES=30
 until env PGPASSWORD=${DATABASE_PASSWORD} pg_dump --no-owner -Fc -h localhost -p 9432 -U spi_${ENV} spi_${ENV} > $DUMPFILE || [ $RETRIES -eq 0 ]; do
     echo "Waiting for postgres server, $((RETRIES-=1)) remaining attempts..."
-    sleep 2
+    sleep 5
 done
 
 echo "Moving file"

--- a/scripts/convert_to_db_dump.sh
+++ b/scripts/convert_to_db_dump.sh
@@ -3,7 +3,7 @@
 set -eu
 
 TARFILE=$1
-DUMPFILE=$(basename $TARFILE).dump
+DUMPFILE=$(basename $TARFILE .tgz).dump
 PG_IMAGE=postgres:12.1-alpine
 
 [[ -n $DATABASE_PASSWORD ]]  || (echo "DATABASE_PASSWORD not set" && exit 1)
@@ -31,7 +31,7 @@ RETRIES=30
 until docker run --rm --name pg_dump \
     -v "$PWD":/host \
     --network backup \
-    --env PGPASSWORD=${DATABASE_PASSWORD} \
+    --env PGPASSWORD=$DATABASE_PASSWORD \
     $PG_IMAGE \
     pg_dump --no-owner -Fc -f /host/$DUMPFILE \
         -h backup-db -U spi_${ENV} spi_${ENV} \
@@ -42,7 +42,7 @@ until docker run --rm --name pg_dump \
 done
 
 echo "Moving file"
-mv $DUMPFILE ${DB_BACKUP_DIR}
+mv $DUMPFILE $DB_BACKUP_DIR
 
 echo "Cleaning up"
 rm $TARFILE

--- a/scripts/convert_to_db_dump.sh
+++ b/scripts/convert_to_db_dump.sh
@@ -9,11 +9,15 @@ DUMPFILE=$(basename $TARFILE).dump
 [[ -n $DB_BACKUP_DIR ]]      || (echo "DB_BACKUP_DIR not set" && exit 1)
 [[ -n $ENV ]]                || (echo "ENV not set" && exit 1)
 
-tar xvfz $TARFILE
+echo "Unpacking ..."
+
+tar xfz $TARFILE
+
+echo "Launching backup db ..."
 
 docker run --rm --name backup-db -d -v "$PWD/db_data:/var/lib/postgresql/data" -p 9432:5432 postgres:12.1-alpine
 
-echo "Exporting ..."
+echo "Exporting to $DUMPFILE ..."
 
 RETRIES=20
 until env PGPASSWORD=${DATABASE_PASSWORD} pg_dump --no-owner -Fc -h localhost -p 9432 -U spi_${ENV} spi_${ENV} > $DUMPFILE || [ $RETRIES -eq 0 ]; do

--- a/scripts/convert_to_db_dump.sh
+++ b/scripts/convert_to_db_dump.sh
@@ -11,12 +11,12 @@ DUMPFILE=$(basename $TARFILE).dump
 
 tar xvfz $TARFILE
 
-/usr/local/bin/docker run --rm --name backup-db -d -v "$PWD/db_data:/var/lib/postgresql/data" -p 9432:5432 postgres:12.1-alpine
+docker run --rm --name backup-db -d -v "$PWD/db_data:/var/lib/postgresql/data" -p 9432:5432 postgres:12.1-alpine
 
 echo "Exporting ..."
 
 RETRIES=20
-until env PGPASSWORD=${DATABASE_PASSWORD} /usr/local/bin/pg_dump --no-owner -Fc -h localhost -p 9432 -U spi_${ENV} spi_${ENV} > $DUMPFILE || [ $RETRIES -eq 0 ]; do
+until env PGPASSWORD=${DATABASE_PASSWORD} pg_dump --no-owner -Fc -h localhost -p 9432 -U spi_${ENV} spi_${ENV} > $DUMPFILE || [ $RETRIES -eq 0 ]; do
     echo "Waiting for postgres server, $((RETRIES-=1)) remaining attempts..."
     sleep 2
 done

--- a/scripts/convert_to_db_dump.sh
+++ b/scripts/convert_to_db_dump.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+set -eu
+
+TARFILE=$1
+DUMPFILE=$(basename $TARFILE).dump
+
+[[ -n $DATABASE_PASSWORD ]]  || (echo "DATABASE_PASSWORD not set" && exit 1)
+[[ -n $DB_BACKUP_DIR ]]      || (echo "DB_BACKUP_DIR not set" && exit 1)
+[[ -n $ENV ]]                || (echo "ENV not set" && exit 1)
+
+tar xvfz $TARFILE
+
+docker run --rm --name backup-db -d -v "$PWD/db_data:/var/lib/postgresql/data" -p 9432:5432 postgres:12.1-alpine
+
+echo "Exporting ..."
+
+RETRIES=20
+until env PGPASSWORD=${DATABASE_PASSWORD} pg_dump --no-owner -Fc -h localhost -p 9432 -U spi_${ENV} spi_${ENV} > $DUMPFILE || [ $RETRIES -eq 0 ]; do
+    echo "Waiting for postgres server, $((RETRIES-=1)) remaining attempts..."
+    sleep 2
+done
+
+echo "Moving file"
+mv $DUMPFILE ${DB_BACKUP_DIR}
+
+echo "Cleaning up"
+rm $TARFILE
+rm -rf db_data
+docker rm -f backup-db

--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -6,7 +6,7 @@ TARFILE=$1
 
 echo "Backing up database to $PWD/$TARFILE"
 
-/usr/local/bin/docker run --rm \
+docker run --rm \
     -v $PWD:/host \
     -v spi_db_data:/db_data \
     -w /host \

--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -eu
+set -u
 
 TARFILE=$1
 
@@ -14,3 +14,6 @@ docker run --rm \
     tar cfz $TARFILE /db_data
 
 echo "done."
+
+# don't let tar errors or warnings bubble up
+exit 0

--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -4,11 +4,13 @@ set -eu
 
 TARFILE=$1
 
-echo "Backing up database to $PWD/$TARFILE"
+echo "Backing up database to $PWD/$TARFILE ..."
 
 docker run --rm \
     -v $PWD:/host \
     -v spi_db_data:/db_data \
     -w /host \
     ubuntu \
-    tar cvfz $TARFILE /db_data
+    tar cfz $TARFILE /db_data
+
+echo "done."

--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+TARFILE=$1
+
+echo "Backing up database to $PWD/$TARFILE"
+
+docker run --rm -it \
+    -v $PWD:/host \
+    -v spi_db_data:/db_data \
+    -w /host \
+    ubuntu \
+    tar cvfz $TARFILE /db_data

--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -6,7 +6,7 @@ TARFILE=$1
 
 echo "Backing up database to $PWD/$TARFILE"
 
-docker run --rm -it \
+docker run --rm \
     -v $PWD:/host \
     -v spi_db_data:/db_data \
     -w /host \

--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -6,7 +6,7 @@ TARFILE=$1
 
 echo "Backing up database to $PWD/$TARFILE"
 
-docker run --rm \
+/usr/local/bin/docker run --rm \
     -v $PWD:/host \
     -v spi_db_data:/db_data \
     -w /host \


### PR DESCRIPTION
Fixes #663 

This uses a runner to dump the db file system into a tar file and then starts up a new db process with that tar file as its db and exports it via pg_dump. This avoids the downtime on the prod db and seems to work file despite the raw file based copy.

What it currently doesn't do is ship the backup somewhere online - it simply copies the dump file to ~/Desktop/DB-Backups on prod.

NB: These dump files can be used locally exactly the same way we used to do it before we launched builds.

We should move these not only to keep them safe but also to avoid cluttering up prod. Just not sure where that should be at the moment.