### PR TITLE
Revert "Delete local tags, making room for upstream tag moves"

### DIFF
--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -120,10 +120,6 @@ func pullOrClone(application: Application, package: Package) -> EventLoopFuture<
             }
             // git reset --hard to deal with stray .DS_Store files on macOS
             try Current.shell.run(command: .init(string: "git reset --hard"), at: cacheDir)
-            // delete local tags
-            // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/693
-            try Current.shell.run(command: .init(string: "git tag | xargs git tag -d"),
-                                  at: cacheDir)
             try Current.shell.run(command: .init(string: "git clean -fdx"), at: cacheDir)
             try Current.shell.run(command: .init(string: "git fetch"), at: cacheDir)
             let branch = package.repository?.defaultBranch ?? "master"

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -82,7 +82,7 @@ class AnalyzerTests: AppTestCase {
         // validation
         let outDir = try XCTUnwrap(checkoutDir)
         XCTAssert(outDir.hasSuffix("SPI-checkouts"), "unexpected checkout dir, was: \(outDir)")
-        XCTAssertEqual(commands.count, 33)
+        XCTAssertEqual(commands.count, 32)
         // We need to sort the issued commands, because macOS and Linux have stable but different
         // sort orders o.O
         assertSnapshot(matching: commands.sorted(), as: .dump)
@@ -261,7 +261,7 @@ class AnalyzerTests: AppTestCase {
         // validation (not in detail, this is just to ensure command count is as expected)
         // Test setup is identical to `test_basic_analysis` except for the Manifest JSON,
         // which we intentionally broke. Command count must remain the same.
-        XCTAssertEqual(commands.count, 33, "was: \(dump(commands))")
+        XCTAssertEqual(commands.count, 32, "was: \(dump(commands))")
         // 2 packages with 2 tags + 1 default branch each -> 6 versions
         XCTAssertEqual(try Version.query(on: app.db).count().wait(), 6)
     }
@@ -291,7 +291,6 @@ class AnalyzerTests: AppTestCase {
             #"rm "-f" ".../github.com-foo-1/.git/HEAD.lock""#,
             #"rm "-f" ".../github.com-foo-1/.git/index.lock""#,
             #"git reset --hard"#,
-            #"git tag | xargs git tag -d"#,
             #"git clean -fdx"#,
             #"git fetch"#,
             #"git checkout "main" --quiet"#,

--- a/Tests/AppTests/__Snapshots__/AnalyzerTests/test_analyze.1.txt
+++ b/Tests/AppTests/__Snapshots__/AnalyzerTests/test_analyze.1.txt
@@ -1,4 +1,4 @@
-▿ 33 elements
+▿ 32 elements
   ▿ 'git checkout "1.0.0" --quiet' at path: '.../github.com-foo-1'
     - command: "git checkout \"1.0.0\" --quiet"
     - path: ".../github.com-foo-1"
@@ -85,9 +85,6 @@
     - path: ".../github.com-foo-2"
   ▿ 'git tag' at path: '.../github.com-foo-2'
     - command: "git tag"
-    - path: ".../github.com-foo-2"
-  ▿ 'git tag | xargs git tag -d' at path: '.../github.com-foo-2'
-    - command: "git tag | xargs git tag -d"
     - path: ".../github.com-foo-2"
   ▿ 'swift package dump-package' at path: '.../github.com-foo-2'
     - command: "swift package dump-package"

--- a/Tests/AppTests/__Snapshots__/AnalyzerTests/test_issue_498.1.txt
+++ b/Tests/AppTests/__Snapshots__/AnalyzerTests/test_issue_498.1.txt
@@ -1,8 +1,7 @@
-▿ 9 elements
+▿ 8 elements
   - "rm \"-f\" \"${checkouts}/github.com-foo-1/.git/HEAD.lock\""
   - "rm \"-f\" \"${checkouts}/github.com-foo-1/.git/index.lock\""
   - "git reset --hard"
-  - "git tag | xargs git tag -d"
   - "git clean -fdx"
   - "git fetch"
   - "git checkout \"master\" --quiet"

--- a/Tests/AppTests/__Snapshots__/AnalyzerTests/test_issue_70.1.txt
+++ b/Tests/AppTests/__Snapshots__/AnalyzerTests/test_issue_70.1.txt
@@ -1,8 +1,7 @@
-▿ 8 elements
+▿ 7 elements
   - "rm \"-f\" \".../github.com-foo-1/.git/HEAD.lock\""
   - "rm \"-f\" \".../github.com-foo-1/.git/index.lock\""
   - "git reset --hard"
-  - "git tag | xargs git tag -d"
   - "git clean -fdx"
   - "git fetch"
   - "git checkout \"master\" --quiet"


### PR DESCRIPTION
This reverts commit ff0013966850110ff85fce98e10687ac6ebece6f. (merged via #695)

I'm re-opening #693 as well. We need to find another way to fix this, because this PR caused hangs in the analyzer (#698) for reasons that aren't understood right now. 