### PR TITLE
Fix double digit releases

### DIFF
--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -100,7 +100,8 @@ extension Package {
     static func findPreRelease(_ versions: [Version], after release: Reference?) -> Version? {
         versions
             .filter { $0.reference?.semVer != nil }
-            .sorted { $0.reference!.semVer! > $1.reference!.semVer! }
+            .filter { $0.commitDate != nil }
+            .sorted { $0.commitDate! > $1.commitDate! }
             .first {
                 // pick first version that is a prerelease *and* no older (in terms of SemVer)
                 // than the latest release

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -102,11 +102,11 @@ extension Package {
             .filter { $0.reference?.semVer != nil }
             .sorted { $0.reference!.semVer! > $1.reference!.semVer! }
             .first {
-            // pick first version that is a prerelease *and* no older (in terms of SemVer)
-            // than the latest release
-            ($0.reference?.semVer?.isPreRelease ?? false)
-                && ($0.reference?.semVer ?? SemanticVersion(0, 0, 0)
-                        >= release?.semVer ?? SemanticVersion(0, 0, 0))
+                // pick first version that is a prerelease *and* no older (in terms of SemVer)
+                // than the latest release
+                ($0.reference?.semVer?.isPreRelease ?? false)
+                    && ($0.reference?.semVer ?? SemanticVersion(0, 0, 0)
+                            >= release?.semVer ?? SemanticVersion(0, 0, 0))
             }
     }
 

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -244,6 +244,26 @@ final class PackageTests: AppTestCase {
         )
     }
 
+    func test_findPreRelease_double_digit_build() throws {
+        // Test pre-release sorting of betas with double digit build numbers,
+        // e.g. 2.0.0-b11 should come after 2.0.0-b9
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/706
+        // setup
+        let p = try savePackage(on: app.db, "1")
+        func t(_ seconds: TimeInterval) -> Date { Date(timeIntervalSince1970: seconds) }
+
+        // MUT & validation
+        XCTAssertEqual(
+            Package.findPreRelease([
+                try .init(package: p, commitDate: t(0), reference: .tag(2, 0, 0, "b9")),
+                try .init(package: p, commitDate: t(1), reference: .tag(2, 0, 0, "b10")),
+                try .init(package: p, commitDate: t(2), reference: .tag(2, 0, 0, "b11")),
+            ],
+            after: nil)?.reference,
+            .tag(2, 0, 0, "b11")
+        )
+    }
+
     func test_findSignificantReleases_old_beta() throws {
         // Test to ensure outdated betas aren't picked up as latest versions
         // setup

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -238,7 +238,7 @@ final class PackageTests: AppTestCase {
                 try .init(package: p, commitDate: t(3), reference: .tag(3, 0, 0)),
                 try .init(package: p, commitDate: t(2), reference: .tag(3, 0, 0, "b1")),
                 try .init(package: p, commitDate: t(0), reference: .tag(1, 2, 3)),
-                try .init(package: p,commitDate: t(1), reference: .tag(2, 0, 0)),
+                try .init(package: p, commitDate: t(1), reference: .tag(2, 0, 0)),
             ],
             after: .tag(3, 0, 0))?.reference,
             nil

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -220,13 +220,14 @@ final class PackageTests: AppTestCase {
     func test_findPreRelease() throws {
         // setup
         let p = try savePackage(on: app.db, "1")
+        func t(_ seconds: TimeInterval) -> Date { Date(timeIntervalSince1970: seconds) }
 
         // MUT & validation
         XCTAssertEqual(
             Package.findPreRelease([
-                try .init(package: p, reference: .tag(3, 0, 0, "b1")),
-                try .init(package: p, reference: .tag(1, 2, 3)),
-                try .init(package: p, reference: .tag(2, 0, 0)),
+                try .init(package: p, commitDate: t(2), reference: .tag(3, 0, 0, "b1")),
+                try .init(package: p, commitDate: t(0), reference: .tag(1, 2, 3)),
+                try .init(package: p, commitDate: t(1), reference: .tag(2, 0, 0)),
             ],
             after: .tag(2, 0, 0))?.reference,
             .tag(3, 0, 0, "b1")
@@ -234,10 +235,10 @@ final class PackageTests: AppTestCase {
         // ensure a beta doesn't come after its release
         XCTAssertEqual(
             Package.findPreRelease([
-                try .init(package: p, reference: .tag(3, 0, 0)),
-                try .init(package: p, reference: .tag(3, 0, 0, "b1")),
-                try .init(package: p, reference: .tag(1, 2, 3)),
-                try .init(package: p, reference: .tag(2, 0, 0)),
+                try .init(package: p, commitDate: t(3), reference: .tag(3, 0, 0)),
+                try .init(package: p, commitDate: t(2), reference: .tag(3, 0, 0, "b1")),
+                try .init(package: p, commitDate: t(0), reference: .tag(1, 2, 3)),
+                try .init(package: p,commitDate: t(1), reference: .tag(2, 0, 0)),
             ],
             after: .tag(3, 0, 0))?.reference,
             nil
@@ -292,14 +293,15 @@ final class PackageTests: AppTestCase {
 
     func test_updateLatestVersions() throws {
         // setup
+        func t(_ seconds: TimeInterval) -> Date { Date(timeIntervalSince1970: seconds) }
         var pkg = Package(id: UUID(), url: "1")
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
-        try Version(package: pkg, packageName: "foo", reference: .branch("main"))
+        try Version(package: pkg, commitDate: t(2), packageName: "foo", reference: .branch("main"))
             .save(on: app.db).wait()
-        try Version(package: pkg, packageName: "foo", reference: .tag(1, 2, 3))
+        try Version(package: pkg, commitDate: t(0), packageName: "foo", reference: .tag(1, 2, 3))
             .save(on: app.db).wait()
-        try Version(package: pkg, packageName: "foo", reference: .tag(2, 0, 0, "rc1"))
+        try Version(package: pkg, commitDate: t(1), packageName: "foo", reference: .tag(2, 0, 0, "rc1"))
             .save(on: app.db).wait()
         // load repositories (this will have happened already at the point where
         // updateLatestVersions is being used and therefore it doesn't reload it)


### PR DESCRIPTION
Fixes #706 

Requires an analysis pass to fix up the pre-releases (because we save the latest significant releases during analysis).

Here's today's prod dump running locally after new analysis:

<img width="874" alt="Screenshot 2020-09-08 at 08 31 21" src="https://user-images.githubusercontent.com/65520/92441167-03e27e00-f1ae-11ea-9432-c6802b9fe858.png">
