### PR TITLE
Migrate logs command

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -119,6 +119,24 @@
         }
       },
       {
+        "package": "soto",
+        "repositoryURL": "https://github.com/soto-project/soto.git",
+        "state": {
+          "branch": null,
+          "revision": "05b0cb685dea6aefdfcd335d2eaff61eff84f058",
+          "version": "5.0.0-beta.1"
+        }
+      },
+      {
+        "package": "soto-core",
+        "repositoryURL": "https://github.com/soto-project/soto-core.git",
+        "state": {
+          "branch": null,
+          "revision": "c1e7f1873163f614a66697cead9b7afc4bd4c043",
+          "version": "5.0.0-beta.1"
+        }
+      },
+      {
         "package": "sql-kit",
         "repositoryURL": "https://github.com/vapor/sql-kit.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .package(name: "SnapshotTesting",
                  url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.7.2"),
         .package(url: "https://github.com/SwiftPackageIndex/SemanticVersion", from: "0.3.0"),
+        .package(url: "https://github.com/soto-project/soto.git", from: "5.0.0-alpha"),
     ],
     targets: [
         .target(name: "App", dependencies: [
@@ -26,7 +27,8 @@ let package = Package(
             "Plot",
             "Ink",
             "SemanticVersion",
-            "ShellOut"
+            "ShellOut",
+            .product(name: "SotoS3", package: "soto"),
         ]),
         .target(name: "Run", dependencies: ["App"]),
         .testTarget(name: "AppTests", dependencies: [

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -8,8 +8,9 @@ struct IngestCommand: Command {
     struct Signature: CommandSignature {
         @Option(name: "limit", short: "l")
         var limit: Int?
-        @Option(name: "id")
-        var id: UUID?
+
+        @Option(name: "id", help: "package id")
+        var id: Package.Id?
     }
     
     var help: String { "Run package ingestion (fetching repository metadata)" }

--- a/Sources/App/Commands/MigrateLogs.swift
+++ b/Sources/App/Commands/MigrateLogs.swift
@@ -1,4 +1,5 @@
 import Vapor
+import SotoS3
 
 
 struct MigrateLogsCommand: Command {
@@ -44,11 +45,63 @@ func migrateLogs(application: Application, limit: Int) -> EventLoopFuture<Void> 
 
 
 func migrateLogs(application: Application, builds: [Build]) -> EventLoopFuture<Void> {
-    application.eventLoopGroup.future()
+    builds.map { build in
+        guard let logs = build.logs else {
+            return application.eventLoopGroup.future()
+        }
+        let key = LogStore.Key()
+        return LogStore.save(logs: logs, key: key)
+            .map { key.url }
+            .flatMap {
+                build.logUrl = $0
+                return build.update(on: application.db)
+            }
+    }
+    .flatten(on: application.eventLoopGroup.next())
 }
 
 
 func fetchMigrationCandidates(application: Application, limit: Int) -> EventLoopFuture<[Build]> {
     // FIXME: implement
     application.eventLoopGroup.future([])
+}
+
+
+enum LogStore {
+    enum Error: Swift.Error {
+        case encodingError
+    }
+
+    static private let region: SotoS3.Region = .useast2
+    static private let bucket = "spi-build-logs"
+    static private let s3 = S3(client: client, region: region)
+
+    static private let client = AWSClient(
+        credentialProvider: .static(
+            accessKeyId: Environment.get("AWS_ACCESS_KEY_ID")!,
+            secretAccessKey: Environment.get("AWS_SECRET_ACCESS_KEY")!
+        ),
+        httpClientProvider: .createNew
+    )
+
+    static func save(logs: String, key: Key) -> EventLoopFuture<Void> {
+        guard let data = logs.data(using: .utf8) else {
+            return s3.eventLoopGroup.future(error: Error.encodingError)
+        }
+        let payload = AWSPayload.data(data)
+        let req = S3.PutObjectRequest(
+            acl: .publicRead,  // requires "Block all public access" to be "off"
+            body: payload,
+            bucket: bucket,
+            key: key.filename
+        )
+        return s3.putObject(req).transform(to: ())
+    }
+
+    struct Key {
+        let id = UUID()
+
+        var filename: String { "\(id.uuidString).log" }
+        var url: String { "https://\(LogStore.bucket).s3.\(LogStore.region.rawValue).\(LogStore.region.partition.dnsSuffix)/\(filename)" }
+    }
 }

--- a/Sources/App/Commands/MigrateLogs.swift
+++ b/Sources/App/Commands/MigrateLogs.swift
@@ -46,10 +46,12 @@ func migrateLogs(application: Application, limit: Int) -> EventLoopFuture<Void> 
 
 func migrateLogs(application: Application, builds: [Build]) -> EventLoopFuture<Void> {
     builds.map { build in
+        application.console.info("Fetching logs for build \(build.id!) ...")
         guard let logs = build.logs else {
             return application.eventLoopGroup.future()
         }
         let key = LogStore.Key()
+        application.console.info("Saving logs to \(key.url) ...")
         return LogStore.save(logs: logs, key: key)
             .map { key.url }
             .flatMap {
@@ -62,8 +64,10 @@ func migrateLogs(application: Application, builds: [Build]) -> EventLoopFuture<V
 
 
 func fetchMigrationCandidates(application: Application, limit: Int) -> EventLoopFuture<[Build]> {
-    // FIXME: implement
-    application.eventLoopGroup.future([])
+    Build.query(on: application.db)
+        .filter(\.$logUrl, .custom("like"), "https://gitlab.com%")
+        .limit(limit)
+        .all()
 }
 
 

--- a/Sources/App/Commands/MigrateLogs.swift
+++ b/Sources/App/Commands/MigrateLogs.swift
@@ -1,0 +1,54 @@
+import Vapor
+
+
+struct MigrateLogsCommand: Command {
+    let defaultLimit = 1
+
+    struct Signature: CommandSignature {
+        @Option(name: "limit", short: "l")
+        var limit: Int?
+
+        @Option(name: "id", help: "build id")
+        var id: Build.Id?
+    }
+
+    var help: String { "Migate logs to S3" }
+
+    func run(using context: CommandContext, signature: Signature) throws {
+        let limit = signature.limit ?? defaultLimit
+        if let id = signature.id {
+            context.console.info("Migrating logs (build id: \(id)) ...")
+            try migrateLogs(application: context.application, id: id).wait()
+        } else {
+            context.console.info("Migrating logs (limit: \(limit)) ...")
+            try migrateLogs(application: context.application, limit: limit).wait()
+        }
+    }
+
+}
+
+
+func migrateLogs(application: Application, id: Build.Id) -> EventLoopFuture<Void> {
+    Build.find(id, on: application.db)
+        .unwrap(or: Abort(.notFound))
+        .flatMap {
+            migrateLogs(application: application, builds: [$0])
+        }
+}
+
+
+func migrateLogs(application: Application, limit: Int) -> EventLoopFuture<Void> {
+    fetchMigrationCandidates(application: application, limit: limit)
+        .flatMap { migrateLogs(application: application, builds: $0)}
+}
+
+
+func migrateLogs(application: Application, builds: [Build]) -> EventLoopFuture<Void> {
+    application.eventLoopGroup.future()
+}
+
+
+func fetchMigrationCandidates(application: Application, limit: Int) -> EventLoopFuture<[Build]> {
+    // FIXME: implement
+    application.eventLoopGroup.future([])
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -92,6 +92,7 @@ public func configure(_ app: Application) throws {
     app.commands.use(IngestCommand(), as: "ingest")
     app.commands.use(ReconcileCommand(), as: "reconcile")
     app.commands.use(TriggerBuildsCommand(), as: "trigger-builds")
+    app.commands.use(MigrateLogsCommand(), as: "migrate-logs")
     
     // register routes
     try routes(app)


### PR DESCRIPTION
This is a temporary command for copying existing logs over to S3.

The idea is to run this in batches manually on the server until all builds are copied and then remove the command again entirely (esp including the Soto dependency).

Merge after #715 

I've tested this manually on a local copy (but copying to the live S3 bucket):

![EC01A36C-5BFA-4439-AE7C-A0F04191BEE3](https://user-images.githubusercontent.com/65520/93891383-a42abd80-fceb-11ea-8e68-6d5654c2753c.png)

![426DA878-C9DD-44A1-8D5B-4FD5FC147375](https://user-images.githubusercontent.com/65520/93891441-b4db3380-fceb-11ea-97c9-6b1cc5f7044a.png)
