### PR TITLE
Reworded the file names in the FAQ.

### DIFF
--- a/Resources/Markdown/faq.md
+++ b/Resources/Markdown/faq.md
@@ -109,9 +109,9 @@ If you are considering shipping your app to the App Store, you should be aware t
 
 <h3 id="contributing">Can I contribute?</h3>
 
-Absolutely. The Swift Package Index is [open-source](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server), and we’d love it if you wanted to help us make it better. Please see [CONTRIBUTING.md](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/blob/main/CONTRIBUTING.md) for more information.
+Absolutely. The Swift Package Index is [open-source](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server), and we’d love it if you wanted to help us make it better. Please see the [guide to contributing](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/blob/main/CONTRIBUTING.md) for more information.
 
-All participation in this project, whether it be contributing code or discussions in issues are subject to our code of conduct. Please read [CODE_OF_CONDUCT.md](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/blob/main/CODE_OF_CONDUCT.md) for more information.
+All participation in this project, whether it be contributing code or discussions in issues are subject to our code of conduct. Please read the [code of conduct](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/blob/main/CODE_OF_CONDUCT.md) for more information.
 
 ---
 


### PR DESCRIPTION
The CODE_OF_CONDUCT was being rendered like this:

<img width="279" alt="Screenshot 2020-09-22 at 18 43 44@2x" src="https://user-images.githubusercontent.com/5180/93922330-a865d380-fd09-11ea-8520-449e83cfd0f1.png">

I know I could have escaped it, but I decided to rewrite them to not include the file names instead.