### PR TITLE
Show s3 logs

### DIFF
--- a/Sources/App/Controllers/BuildController.swift
+++ b/Sources/App/Controllers/BuildController.swift
@@ -5,32 +5,14 @@ import Vapor
 
 struct BuildController {
 
-    @available(*, deprecated)
-    func _show(req: Request) throws -> EventLoopFuture<HTML> {
+    func show(req: Request) throws -> EventLoopFuture<HTML> {
         guard let id = req.parameters.get("id"),
               let buildId = UUID.init(uuidString: id)
         else { return req.eventLoop.future(error: Abort(.notFound)) }
 
         return Build.query(on: req.db, buildId: buildId)
-            .map(BuildShow.Model.init(build:))
-            .unwrap(or: Abort(.notFound))
-            .map {
-                BuildShow.View(path: req.url.path, model: $0).document()
-            }
-    }
-
-    func showS3(req: Request) throws -> EventLoopFuture<HTML> {
-        guard let id = req.parameters.get("id"),
-              let buildId = UUID.init(uuidString: id)
-        else { return req.eventLoop.future(error: Abort(.notFound)) }
-
-        return Build.query(on: req.db, buildId: buildId)
-            .flatMap { build -> EventLoopFuture<(Build, String?)> in
-                guard let logUrl = build.logUrl else {
-                    return req.eventLoop.future((build, nil))
-                }
-                return req.client.get(URI(string: logUrl))
-                    .map { $0.body?.asString() }
+            .flatMap { build in
+                Build.fetchLogs(client: req.client, logUrl: build.logUrl)
                     .map { (build, $0) }
             }
             .map(BuildShow.Model.init(build:logs:))

--- a/Sources/App/Controllers/BuildController.swift
+++ b/Sources/App/Controllers/BuildController.swift
@@ -5,13 +5,35 @@ import Vapor
 
 struct BuildController {
 
-    func show(req: Request) throws -> EventLoopFuture<HTML> {
+    @available(*, deprecated)
+    func _show(req: Request) throws -> EventLoopFuture<HTML> {
         guard let id = req.parameters.get("id"),
               let buildId = UUID.init(uuidString: id)
         else { return req.eventLoop.future(error: Abort(.notFound)) }
 
         return Build.query(on: req.db, buildId: buildId)
             .map(BuildShow.Model.init(build:))
+            .unwrap(or: Abort(.notFound))
+            .map {
+                BuildShow.View(path: req.url.path, model: $0).document()
+            }
+    }
+
+    func showS3(req: Request) throws -> EventLoopFuture<HTML> {
+        guard let id = req.parameters.get("id"),
+              let buildId = UUID.init(uuidString: id)
+        else { return req.eventLoop.future(error: Abort(.notFound)) }
+
+        return Build.query(on: req.db, buildId: buildId)
+            .flatMap { build -> EventLoopFuture<(Build, String?)> in
+                guard let logUrl = build.logUrl else {
+                    return req.eventLoop.future((build, nil))
+                }
+                return req.client.get(URI(string: logUrl))
+                    .map { $0.body?.asString() }
+                    .map { (build, $0) }
+            }
+            .map(BuildShow.Model.init(build:logs:))
             .unwrap(or: Abort(.notFound))
             .map {
                 BuildShow.View(path: req.url.path, model: $0).document()

--- a/Sources/App/Core/Extensions/ByteBuffer+asString.swift
+++ b/Sources/App/Core/Extensions/ByteBuffer+asString.swift
@@ -1,0 +1,10 @@
+import Vapor
+
+
+extension ByteBuffer {
+
+    func asString() -> String? {
+        getString(at: readerIndex, length: readableBytes)
+    }
+
+}

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -232,6 +232,21 @@ extension Build {
 }
 
 
+// MARK: Fetch build logs
+
+extension Build {
+
+    static func fetchLogs(client: Client, logUrl: String?) -> EventLoopFuture<String?> {
+        guard let logUrl = logUrl else {
+            return client.eventLoop.future(nil)
+        }
+        return client.get(URI(string: logUrl))
+            .map { $0.body?.asString() }
+    }
+
+}
+
+
 // MARK: - Array extension
 
 extension Array where Element == Build {

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -32,6 +32,7 @@ final class Build: Model, Content {
     @Field(key: "job_url")
     var jobUrl: String?
 
+    @available(*, deprecated)
     @Field(key: "logs")
     var logs: String?
 

--- a/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
@@ -46,8 +46,8 @@ extension BuildShow {
 
         init?(build: App.Build, logs: String?) {
             guard let swiftVersion = build.swiftVersion.compatibility else { return nil }
-            self.init(buildCommand: build.buildCommand ?? "build command unavailable",
-                      logs: logs ?? "no logs recorded",
+            self.init(buildCommand: build.buildCommand ?? "Build command unavailable",
+                      logs: logs ?? build.status.logsUnavailableDescription,
                       platform: build.platform,
                       status: build.status,
                       swiftVersion: swiftVersion)
@@ -78,6 +78,20 @@ extension BuildShow {
             }
         }
 
+    }
+}
+
+
+private extension Build.Status {
+    var logsUnavailableDescription: String {
+        switch self {
+            case .ok:
+                return "Build SUCCEEDED (detailed logs unavailable)"
+            case .failed:
+                return "Build FAILED (detailed logs unavailable)"
+            case .pending:
+                return "Build PENDING"
+        }
     }
 }
 

--- a/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
@@ -7,24 +7,6 @@ extension BuildShow {
         var buildInfo: BuildInfo
         var versionId: Version.Id
 
-        @available(*, deprecated)
-        init?(build: App.Build) {
-            guard
-                let packageName = build.version.package.name(),
-                let repository = build.version.package.repository,
-                let repositoryOwner = repository.owner,
-                let repositoryName = repository.name,
-                let buildInfo = BuildInfo(build),
-                let version = build.$version.value,
-                let versionId = version.id
-            else { return nil }
-            self.init(buildInfo: buildInfo,
-                      packageName: packageName,
-                      repositoryOwner: repositoryOwner,
-                      repositoryName: repositoryName,
-                      versionId: versionId)
-        }
-
         init?(build: App.Build, logs: String?) {
             guard
                 let packageName = build.version.package.name(),
@@ -61,16 +43,6 @@ extension BuildShow {
         var platform: App.Build.Platform
         var status: App.Build.Status
         var swiftVersion: SwiftVersion
-
-        @available(*, deprecated)
-        init?(_ build: App.Build) {
-            guard let swiftVersion = build.swiftVersion.compatibility else { return nil }
-            self.init(buildCommand: build.buildCommand ?? "build command unavailable",
-                      logs: build.logs ?? "no logs recorded",
-                      platform: build.platform,
-                      status: build.status,
-                      swiftVersion: swiftVersion)
-        }
 
         init?(build: App.Build, logs: String?) {
             guard let swiftVersion = build.swiftVersion.compatibility else { return nil }

--- a/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
@@ -86,11 +86,11 @@ private extension Build.Status {
     var logsUnavailableDescription: String {
         switch self {
             case .ok:
-                return "Build SUCCEEDED (detailed logs unavailable)"
+                return "This build succeeded, but detailed logs are not available. Logs are only retained for a few months after a build, and they may have expired, or the request to fetch them may have failed."
             case .failed:
-                return "Build FAILED (detailed logs unavailable)"
+                return "This build failed, but detailed logs are not available. Logs are only retained for a few months after a build, and they may have expired, or the request to fetch them may have failed."
             case .pending:
-                return "Build PENDING"
+                return "This build is pending execution, and logs are not yet available."
         }
     }
 }

--- a/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
@@ -7,6 +7,7 @@ extension BuildShow {
         var buildInfo: BuildInfo
         var versionId: Version.Id
 
+        @available(*, deprecated)
         init?(build: App.Build) {
             guard
                 let packageName = build.version.package.name(),
@@ -14,6 +15,23 @@ extension BuildShow {
                 let repositoryOwner = repository.owner,
                 let repositoryName = repository.name,
                 let buildInfo = BuildInfo(build),
+                let version = build.$version.value,
+                let versionId = version.id
+            else { return nil }
+            self.init(buildInfo: buildInfo,
+                      packageName: packageName,
+                      repositoryOwner: repositoryOwner,
+                      repositoryName: repositoryName,
+                      versionId: versionId)
+        }
+
+        init?(build: App.Build, logs: String?) {
+            guard
+                let packageName = build.version.package.name(),
+                let repository = build.version.package.repository,
+                let repositoryOwner = repository.owner,
+                let repositoryName = repository.name,
+                let buildInfo = BuildInfo(build: build, logs: logs),
                 let version = build.$version.value,
                 let versionId = version.id
             else { return nil }
@@ -44,10 +62,20 @@ extension BuildShow {
         var status: App.Build.Status
         var swiftVersion: SwiftVersion
 
+        @available(*, deprecated)
         init?(_ build: App.Build) {
             guard let swiftVersion = build.swiftVersion.compatibility else { return nil }
             self.init(buildCommand: build.buildCommand ?? "build command unavailable",
                       logs: build.logs ?? "no logs recorded",
+                      platform: build.platform,
+                      status: build.status,
+                      swiftVersion: swiftVersion)
+        }
+
+        init?(build: App.Build, logs: String?) {
+            guard let swiftVersion = build.swiftVersion.compatibility else { return nil }
+            self.init(buildCommand: build.buildCommand ?? "build command unavailable",
+                      logs: logs ?? "no logs recorded",
                       platform: build.platform,
                       status: build.status,
                       swiftVersion: swiftVersion)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -31,7 +31,8 @@ func routes(_ app: Application) throws {
     app.get(SiteURL.package(.key, .key, .builds).pathComponents, use: packageController.builds)
 
     let buildController = BuildController()
-    app.get(SiteURL.builds(.key).pathComponents, use: buildController.show)
+    app.get(SiteURL.builds(.key).pathComponents, use: buildController._show)
+    app.get(SiteURL.builds(.key).pathComponents + ["s3"], use: buildController.showS3)
 
     do {  // api
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -31,8 +31,7 @@ func routes(_ app: Application) throws {
     app.get(SiteURL.package(.key, .key, .builds).pathComponents, use: packageController.builds)
 
     let buildController = BuildController()
-    app.get(SiteURL.builds(.key).pathComponents, use: buildController._show)
-    app.get(SiteURL.builds(.key).pathComponents + ["s3"], use: buildController.showS3)
+    app.get(SiteURL.builds(.key).pathComponents, use: buildController.show)
 
     do {  // api
 

--- a/Tests/AppTests/BuildShowModelTests.swift
+++ b/Tests/AppTests/BuildShowModelTests.swift
@@ -39,7 +39,11 @@ class BuildShowModelTests: AppTestCase {
 
         // MUT
         let m = try Build.query(on: app.db, buildId: buildId)
-            .map(BuildShow.Model.init(build:))
+            .flatMap { build in
+                Build.fetchLogs(client: self.app.client, logUrl: build.logUrl)
+                    .map { (build, $0) }
+            }
+            .map(BuildShow.Model.init(build:logs:))
             .wait()
 
         // validate


### PR DESCRIPTION
Logs on `dev` and `prod` are now all available on S3 and should display just as before with these changes.

Now live on staging:

https://staging.swiftpackageindex.com/builds/765B4D30-471A-4B41-AC9D-EAD5AC4521F9

<img width="1163" alt="Screenshot 2020-09-25 at 11 00 01" src="https://user-images.githubusercontent.com/65520/94248108-4df19080-ff1e-11ea-9e9d-684ab8b4bb75.png">
