### PR TITLE
Remove logs column

### DIFF
--- a/Sources/App/Controllers/API/API+DTOs.swift
+++ b/Sources/App/Controllers/API/API+DTOs.swift
@@ -7,7 +7,6 @@ extension API {
     struct PostCreateBuildDTO: Codable {
         var buildCommand: String?
         var jobUrl: String?
-        var logs: String?
         var logUrl: String?
         var platform: Build.Platform
         var status: Build.Status

--- a/Sources/App/Migrations/017/UpdateBuildRemoveLogs.swift
+++ b/Sources/App/Migrations/017/UpdateBuildRemoveLogs.swift
@@ -1,0 +1,16 @@
+import Fluent
+
+
+struct UpdateBuildRemoveLogs: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("builds")
+            .deleteField("logs")
+            .update()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("builds")
+            .field("logs", .string)
+            .update()
+    }
+}

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -32,10 +32,6 @@ final class Build: Model, Content {
     @Field(key: "job_url")
     var jobUrl: String?
 
-    @available(*, deprecated)
-    @Field(key: "logs")
-    var logs: String?
-
     @Field(key: "log_url")
     var logUrl: String?
 
@@ -54,7 +50,6 @@ final class Build: Model, Content {
          versionId: Version.Id,
          buildCommand: String? = nil,
          jobUrl: String? = nil,
-         logs: String? = nil,
          logUrl: String? = nil,
          platform: Platform,
          status: Status,
@@ -63,7 +58,6 @@ final class Build: Model, Content {
         self.$version.id = versionId
         self.buildCommand = buildCommand
         self.jobUrl = jobUrl
-        self.logs = logs?.replacingOccurrences(of: "\0", with: "")
         self.logUrl = logUrl
         self.platform = platform
         self.status = status
@@ -74,7 +68,6 @@ final class Build: Model, Content {
          version: Version,
          buildCommand: String? = nil,
          jobUrl: String? = nil,
-         logs: String? = nil,
          logUrl: String? = nil,
          platform: Platform,
          status: Status,
@@ -83,7 +76,6 @@ final class Build: Model, Content {
                   versionId: try version.requireID(),
                   buildCommand: buildCommand,
                   jobUrl: jobUrl,
-                  logs: logs,
                   logUrl: logUrl,
                   platform: platform,
                   status: status,
@@ -94,7 +86,6 @@ final class Build: Model, Content {
         try self.init(version: version,
                       buildCommand: dto.buildCommand,
                       jobUrl: dto.jobUrl,
-                      logs: dto.logs,
                       logUrl: dto.logUrl,
                       platform: dto.platform,
                       status: dto.status,

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -85,6 +85,9 @@ public func configure(_ app: Application) throws {
     do {  // Migration 016 - add job_url field to builds
         app.migrations.add(UpdateBuildAddJobUrl())
     }
+    do {  // Migration 017 - remove logs field from builds
+        app.migrations.add(UpdateBuildRemoveLogs())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -45,7 +45,6 @@ func routes(_ app: Application) throws {
         app.group(User.TokenAuthenticator(), User.guardMiddleware()) { protected in
             let builds = API.BuildController()
             protected.on(.POST, SiteURL.api(.versions(.key, .builds)).pathComponents,
-                         body: .collect(maxSize: 100_000),
                          use: builds.create)
             protected.post(SiteURL.api(.versions(.key, .triggerBuild)).pathComponents,
                            use: builds.trigger)

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -35,27 +35,6 @@ class BuildTests: AppTestCase {
         }
     }
     
-    func test_save_invalid_byte_sequence() throws {
-        // setup
-        let pkg = try savePackage(on: app.db, "1")
-        let v = try Version(package: pkg)
-        try v.save(on: app.db).wait()
-        let b = try Build(version: v,
-                          buildCommand: #"xcrun xcodebuild -scheme "Foo""#,
-                          logs: "\0",
-                          platform: .linux,
-                          status: .ok,
-                          swiftVersion: .init(5, 2, 0))
-
-        // MUT
-        try b.save(on: app.db).wait()
-
-        do {  // validate
-            let b = try XCTUnwrap(Build.find(b.id, on: app.db).wait())
-            XCTAssertEqual(b.logs, "")
-        }
-    }
-
     func test_delete_cascade() throws {
         // Ensure deleting a version also deletes the builds
         // setup

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -15,7 +15,6 @@ class BuildTests: AppTestCase {
         let b = try Build(version: v,
                           buildCommand: #"xcrun xcodebuild -scheme "Foo""#,
                           jobUrl: "https://example.com/jobs/1",
-                          logs: "logs",
                           logUrl: "https://example.com/logs/1",
                           platform: .linux,
                           status: .ok,
@@ -28,7 +27,6 @@ class BuildTests: AppTestCase {
             let b = try XCTUnwrap(Build.find(b.id, on: app.db).wait())
             XCTAssertEqual(b.buildCommand, #"xcrun xcodebuild -scheme "Foo""#)
             XCTAssertEqual(b.jobUrl, "https://example.com/jobs/1")
-            XCTAssertEqual(b.logs, "logs")
             XCTAssertEqual(b.logUrl, "https://example.com/logs/1")
             XCTAssertEqual(b.platform, .linux)
             XCTAssertEqual(b.status, .ok)


### PR DESCRIPTION
This completes the S3 migration on the server side.

I've run the migration locally against a prod copy and it's nearly instant - so there's no disruption to expect. We may need to run a vacuum to free up space on the db, although that might be automatic. We can just check the backup size in the morning.

⚠️ Schema change: tag as 2.3.0 when the time comes ⚠️