### PR TITLE
Disallow individual build pages from robots.txt.

### DIFF
--- a/Public/robots.txt
+++ b/Public/robots.txt
@@ -1,6 +1,6 @@
 # All robots allowed
 User-agent: *
-Disallow:
+Disallow: /builds/*
 
 # Sitemap files
 Sitemap: https://swiftpackageindex.com/sitemap.xml


### PR DESCRIPTION
This keeps the builds overview pages visible, but stops the pages with build logs.