### PR TITLE
Invalid byte sequence

### DIFF
--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -63,7 +63,7 @@ final class Build: Model, Content {
         self.$version.id = versionId
         self.buildCommand = buildCommand
         self.jobUrl = jobUrl
-        self.logs = logs
+        self.logs = logs?.replacingOccurrences(of: "\0", with: "")
         self.logUrl = logUrl
         self.platform = platform
         self.status = status

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -31,8 +31,9 @@ class BuildTests: AppTestCase {
             XCTAssertEqual(b.logs, "logs")
             XCTAssertEqual(b.logUrl, "https://example.com/logs/1")
             XCTAssertEqual(b.platform, .linux)
-            XCTAssertEqual(b.$version.id, v.id)
             XCTAssertEqual(b.status, .ok)
+            XCTAssertEqual(b.swiftVersion, .init(5, 2, 0))
+            XCTAssertEqual(b.$version.id, v.id)
         }
     }
     
@@ -53,11 +54,7 @@ class BuildTests: AppTestCase {
 
         do {  // validate
             let b = try XCTUnwrap(Build.find(b.id, on: app.db).wait())
-            XCTAssertEqual(b.buildCommand, #"xcrun xcodebuild -scheme "Foo""#)
             XCTAssertEqual(b.logs, "")
-            XCTAssertEqual(b.platform, .linux)
-            XCTAssertEqual(b.$version.id, v.id)
-            XCTAssertEqual(b.status, .ok)
         }
     }
 

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -36,6 +36,31 @@ class BuildTests: AppTestCase {
         }
     }
     
+    func test_save_invalid_byte_sequence() throws {
+        // setup
+        let pkg = try savePackage(on: app.db, "1")
+        let v = try Version(package: pkg)
+        try v.save(on: app.db).wait()
+        let b = try Build(version: v,
+                          buildCommand: #"xcrun xcodebuild -scheme "Foo""#,
+                          logs: "\0",
+                          platform: .linux,
+                          status: .ok,
+                          swiftVersion: .init(5, 2, 0))
+
+        // MUT
+        try b.save(on: app.db).wait()
+
+        do {  // validate
+            let b = try XCTUnwrap(Build.find(b.id, on: app.db).wait())
+            XCTAssertEqual(b.buildCommand, #"xcrun xcodebuild -scheme "Foo""#)
+            XCTAssertEqual(b.logs, "")
+            XCTAssertEqual(b.platform, .linux)
+            XCTAssertEqual(b.$version.id, v.id)
+            XCTAssertEqual(b.status, .ok)
+        }
+    }
+
     func test_delete_cascade() throws {
         // Ensure deleting a version also deletes the builds
         // setup


### PR DESCRIPTION
Errors have started again immediately after merging the nightly that adds back `swift-atomics`. This should fix it until we remove the logs from the db.