### PR TITLE
Copy db dump to S3 OSXFuse mounted dir

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -131,6 +131,11 @@ smoke-test:
     TARFILE=spi_${ENV}_$(date +%Y-%m-%d).tgz
     ./scripts/db_backup.sh $TARFILE
     ./scripts/convert_to_db_dump.sh $TARFILE
+    # copy file to S3
+    S3_BACKUP_DIR=/Users/spi/Desktop/spi-db-backups
+    # mount s3fs just in case (ignoring errors when it's already mounted)
+    s3fs spi-db-backups ${S3_BACKUP_DIR} -o passwd_file=/Users/spi/.passwd-s3fs || true
+    cp $TARFILE ${S3_BACKUP_DIR}/
 
 db-backup (scheduled):  # PROD: auto-backup on schedule
   rules:


### PR DESCRIPTION
Server side setup (already in place):

```
brew cask install osxfuse
brew install s3fs
echo ${awskey}:${awssecret} > ~/.passwd-s3fs
chmod 0600 ~/.passwd-s3fs
mkdir ~/Desktop/spi-db-backups
s3fs spi-db-backups ~/Desktop/spi-db-backups -o passwd_file=/Users/spi/.passwd-s3fs
```

The bucket name is `spi-db-backups`