### PR TITLE
Update metrics

### DIFF
--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -346,14 +346,8 @@ func applyVersionDelta(on transaction: Database,
                        delta: (toAdd: [Version], toDelete: [Version])) -> EventLoopFuture<Void> {
     let delete = delta.toDelete.delete(on: transaction)
     let insert = delta.toAdd.create(on: transaction)
-    if delta.toAdd.isEmpty {
-        AppMetrics.analyzeVersionsAddedCount?.set(0)
-    }
     delta.toAdd.forEach {
         AppMetrics.analyzeVersionsAddedCount?.inc(1, .init($0.reference))
-    }
-    if delta.toDelete.isEmpty {
-        AppMetrics.analyzeVersionsDeletedCount?.set(0)
     }
     delta.toDelete.forEach {
         AppMetrics.analyzeVersionsDeletedCount?.inc(1, .init($0.reference))

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -346,11 +346,17 @@ func applyVersionDelta(on transaction: Database,
                        delta: (toAdd: [Version], toDelete: [Version])) -> EventLoopFuture<Void> {
     let delete = delta.toDelete.delete(on: transaction)
     let insert = delta.toAdd.create(on: transaction)
+    if delta.toAdd.isEmpty {
+        AppMetrics.analyzeVersionsAddedCount?.set(0)
+    }
     delta.toAdd.forEach {
-        AppMetrics.analyzeVersionsAddedTotal?.inc(1, .init($0.reference))
+        AppMetrics.analyzeVersionsAddedCount?.inc(1, .init($0.reference))
+    }
+    if delta.toDelete.isEmpty {
+        AppMetrics.analyzeVersionsDeletedCount?.set(0)
     }
     delta.toDelete.forEach {
-        AppMetrics.analyzeVersionsDeletedTotal?.inc(1, .init($0.reference))
+        AppMetrics.analyzeVersionsDeletedCount?.inc(1, .init($0.reference))
     }
     return delete.flatMap { insert }
 }

--- a/Sources/App/Core/AppMetrics.swift
+++ b/Sources/App/Core/AppMetrics.swift
@@ -64,12 +64,12 @@ enum AppMetrics {
         counter("spi_analyze_update_repository_failure_total", EmptyLabels.self)
     }
 
-    static var analyzeVersionsAddedTotal: PromCounter<Int, Labels.Version>? {
-        counter("spi_analyze_versions_added_total", Labels.Version.self)
+    static var analyzeVersionsAddedCount: PromGauge<Int, Labels.Version>? {
+        gauge("spi_analyze_versions_added_count", Labels.Version.self)
     }
 
-    static var analyzeVersionsDeletedTotal: PromCounter<Int, Labels.Version>? {
-        counter("spi_analyze_versions_deleted_total", Labels.Version.self)
+    static var analyzeVersionsDeletedCount: PromGauge<Int, Labels.Version>? {
+        gauge("spi_analyze_versions_deleted_count", Labels.Version.self)
     }
 
     static var buildCandidatesCount: PromGauge<Int, EmptyLabels>? {

--- a/Tests/AppTests/MetricsTests.swift
+++ b/Tests/AppTests/MetricsTests.swift
@@ -34,13 +34,13 @@ class MetricsTests: AppTestCase {
     func test_versions_added() throws {
         //setup
         let initialAddedBranch = try
-            XCTUnwrap(AppMetrics.analyzeVersionsAddedTotal?.get(.init("branch")))
+            XCTUnwrap(AppMetrics.analyzeVersionsAddedCount?.get(.init("branch")))
         let initialAddedTag = try
-            XCTUnwrap(AppMetrics.analyzeVersionsAddedTotal?.get(.init("tag")))
+            XCTUnwrap(AppMetrics.analyzeVersionsAddedCount?.get(.init("tag")))
         let initialDeletedBranch = try
-            XCTUnwrap(AppMetrics.analyzeVersionsDeletedTotal?.get(.init("branch")))
+            XCTUnwrap(AppMetrics.analyzeVersionsDeletedCount?.get(.init("branch")))
         let initialDeletedTag = try
-            XCTUnwrap(AppMetrics.analyzeVersionsDeletedTotal?.get(.init("tag")))
+            XCTUnwrap(AppMetrics.analyzeVersionsDeletedCount?.get(.init("tag")))
         let pkg = try savePackage(on: app.db, "1")
         let new = [
             try Version(package: pkg, reference: .branch("main")),
@@ -57,13 +57,13 @@ class MetricsTests: AppTestCase {
         try applyVersionDelta(on: app.db, delta: (toAdd: new, toDelete: del)).wait()
 
         // validation
-        XCTAssertEqual(AppMetrics.analyzeVersionsAddedTotal?.get(.init("branch")),
+        XCTAssertEqual(AppMetrics.analyzeVersionsAddedCount?.get(.init("branch")),
                        initialAddedBranch + 1)
-        XCTAssertEqual(AppMetrics.analyzeVersionsAddedTotal?.get(.init("tag")),
+        XCTAssertEqual(AppMetrics.analyzeVersionsAddedCount?.get(.init("tag")),
                        initialAddedTag + 2)
-        XCTAssertEqual(AppMetrics.analyzeVersionsDeletedTotal?.get(.init("branch")),
+        XCTAssertEqual(AppMetrics.analyzeVersionsDeletedCount?.get(.init("branch")),
                        initialDeletedBranch + 1)
-        XCTAssertEqual(AppMetrics.analyzeVersionsDeletedTotal?.get(.init("tag")),
+        XCTAssertEqual(AppMetrics.analyzeVersionsDeletedCount?.get(.init("tag")),
                        initialDeletedTag + 1)
     }
 


### PR DESCRIPTION
Make version metrics a gauge so they (hopefully - it's hard to test this without actual data) properly reset beween scrapes.

Merge after #791 