### PR TITLE
Allow local port numbers to be customised when exporting database backups

### DIFF
--- a/scripts/dump-dev-db.sh
+++ b/scripts/dump-dev-db.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # This command assumes the dev db to be available on port 7432 on localhost, via an ssh tunnel:
 # ssh -i <your private key> -L 7432:db:5432 -p 2222 root@173.255.229.82
-pg_dump --no-owner -Fc -h localhost -p 7432 -U spi_dev spi_dev > spi_dev_$(date +%Y-%m-%d).dump
+PORT=${SPI_STAGING_DB_PORT:-'7432'}
+pg_dump --no-owner -Fc -h localhost -p $PORT -U spi_dev spi_dev > spi_dev_$(date +%Y-%m-%d).dump

--- a/scripts/dump-prod-db.sh
+++ b/scripts/dump-prod-db.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # This command assumes the prod db to be available on port 7432 on localhost, via an ssh tunnel:
 # ssh -i <your private key> -L 7432:db:5432 -p 2222 root@173.255.229.82
-pg_dump --no-owner -Fc -h localhost -p 7432 -U spi_prod spi_prod > spi_prod_$(date +%Y-%m-%d).dump
+PORT=${SPI_PRODUCTION_DB_PORT:-'7432'}
+pg_dump --no-owner -Fc -h localhost -p $PORT -U spi_prod spi_prod > spi_prod_$(date +%Y-%m-%d).dump


### PR DESCRIPTION
This should have no impact if you don't have the environment variables set, but I'm making some changes to my local config so I can have both databases connected at the same time and this change would be helpful to me.

