### PR TITLE
Refactor function signatures

### DIFF
--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -106,7 +106,7 @@ func analyze(application: Application, packages: [Package]) -> EventLoopFuture<V
     }
     
     let statusOps = packageResults
-        .map(extractPackages)
+        .map(\.packages)
         .flatMap { updatePackages(application: application,
                                   results: $0,
                                   stage: .analysis) }
@@ -578,13 +578,14 @@ func onNewVersions(client: Client,
 }
 
 
-/// Helper to extract the nested `Package` results from the result tuple.
-/// - Parameter results: input results `(Package, [(Version, Manifest)])` inside the array of `Result`
-/// - Returns: unpacked array of `Result<Package, Error>`
-func extractPackages(_ results: [Result<(Package, [(Version, Manifest)]), Error>]) -> [Result<Package, Error>] {
-    results.map { result in
-        result.map { pkg, _ in
-            pkg
+private extension Array where Element == Result<(Package,[(Version, Manifest)]), Error> {
+    /// Helper to extract the nested `Package` results from the result tuple.
+    /// - Returns: unpacked array of `Result<Package, Error>`
+    var packages: [Result<Package, Error>]  {
+        map { result in
+            result.map { pkg, _ in
+                pkg
+            }
         }
     }
 }

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -524,9 +524,8 @@ func updateLatestVersions(on database: Database,
 /// - Parameters:
 ///   - database: `Database` object
 ///   - package: package to update
-/// - Returns: `Package` future
-func updateLatestVersions(on database: Database,
-                          package: Package) -> EventLoopFuture<Package> {
+/// - Returns: future
+func updateLatestVersions(on database: Database, package: Package) -> EventLoopFuture<Void> {
     package
         .$versions.load(on: database)
         .flatMap {
@@ -552,7 +551,6 @@ func updateLatestVersions(on database: Database,
             return (updates + resets)
                 .map { $0.save(on: database) }
                 .flatten(on: database.eventLoop)
-                .map { package }
         }
 }
 

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -496,15 +496,9 @@ func createProducts(on database: Database, version: Version, manifest: Manifest)
 /// - Returns: results future
 func updateLatestVersions(on database: Database,
                           packages: [Result<Package, Error>]) -> EventLoopFuture<[Result<Package, Error>]> {
-    let ops = packages.map { result -> EventLoopFuture<Package> in
-        switch result {
-            case let .success(pkg):
-                return updateLatestVersions(on: database, package: pkg)
-            case let .failure(error):
-                return database.eventLoop.future(error: error)
-        }
+    packages.whenAllComplete(on: database.eventLoop) {
+        updateLatestVersions(on: database, package: $0)
     }
-    return EventLoopFuture.whenAllComplete(ops, on: database.eventLoop)
 }
 
 

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -492,15 +492,12 @@ func createProducts(on database: Database,
 ///   - manifest: `Manifest` data
 /// - Returns: future
 func createProducts(on database: Database, version: Version, manifest: Manifest) -> EventLoopFuture<Void> {
-    let products = manifest.products.compactMap { p -> Product? in
-        let type: Product.`Type`
-        switch p.type {
-            case .executable: type = .executable
-            case .library:    type = .library
-        }
+    let products = manifest.products.compactMap { manifestProduct -> Product? in
         // Using `try?` here because the only way this could error is version.id being nil
         // - that should never happen and even in the pathological case we can skip the product
-        return try? Product(version: version, type: type, name: p.name)
+        return try? Product(version: version,
+                            type: .init(manifestProductType: manifestProduct.type),
+                            name: manifestProduct.name)
     }
     return products.create(on: database)
 }

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -3,9 +3,9 @@ import PostgresNIO
 import Vapor
 
 
-func updatePackage(application: Application,
-                   results: [Result<Package, Error>],
-                   stage: Package.ProcessingStage) -> EventLoopFuture<Void> {
+func updatePackages(application: Application,
+                    results: [Result<Package, Error>],
+                    stage: Package.ProcessingStage) -> EventLoopFuture<Void> {
     let updates = results.map { result -> EventLoopFuture<Void> in
         switch result {
             case .success(let pkg):

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -70,7 +70,7 @@ func ingest(application: Application, packages: [Package]) -> EventLoopFuture<Vo
     AppMetrics.ingestCandidatesCount?.set(packages.count)
     let metadata = fetchMetadata(client: application.client, packages: packages)
     let updates = metadata.flatMap { updateRepositories(on: application.db, metadata: $0) }
-    return updates.flatMap { updatePackage(application: application, results: $0, stage: .ingestion) }
+    return updates.flatMap { updatePackages(application: application, results: $0, stage: .ingestion) }
 }
 
 

--- a/Sources/App/Core/Extensions/Array+ext.swift
+++ b/Sources/App/Core/Extensions/Array+ext.swift
@@ -1,0 +1,18 @@
+import NIO
+
+
+extension Array {
+    func whenAllComplete<T>(on eventLoop: EventLoop,
+                            transform: (T) -> EventLoopFuture<T>) -> EventLoopFuture<[Result<T, Error>]>
+    where Element == Result<T, Error> {
+        let ops = map { result -> EventLoopFuture<T> in
+            switch result {
+                case let .success(value):
+                    return transform(value)
+                case let .failure(error):
+                    return eventLoop.future(error: error)
+            }
+        }
+        return EventLoopFuture.whenAllComplete(ops, on: eventLoop)
+    }
+}

--- a/Sources/App/Core/Extensions/Array+ext.swift
+++ b/Sources/App/Core/Extensions/Array+ext.swift
@@ -2,10 +2,10 @@ import NIO
 
 
 extension Array {
-    func whenAllComplete<T>(on eventLoop: EventLoop,
-                            transform: (T) -> EventLoopFuture<T>) -> EventLoopFuture<[Result<T, Error>]>
+    func whenAllComplete<T, U>(on eventLoop: EventLoop,
+                               transform: (T) -> EventLoopFuture<U>) -> EventLoopFuture<[Result<U, Error>]>
     where Element == Result<T, Error> {
-        let ops = map { result -> EventLoopFuture<T> in
+        let ops = map { result -> EventLoopFuture<U> in
             switch result {
                 case let .success(value):
                     return transform(value)

--- a/Sources/App/Core/Extensions/Array+ext.swift
+++ b/Sources/App/Core/Extensions/Array+ext.swift
@@ -18,6 +18,11 @@ extension Array {
         }
     }
 
+    /// Returns a new `EventLoopFuture` that succeeds when all `Result<T, Error>` elements transformed into `EventLoopFuture<U>` elements have completed.
+    /// - Parameters:
+    ///   - eventLoop: The `EventLoop` on which the new `EventLoopFuture` callbacks will fire.
+    ///   - transform: The transformation to be applied to the `Array`'s elements
+    /// - Returns: A new `Array` with the results of the transformation, wrapped in `Result`s.
     func whenAllComplete<T, U>(on eventLoop: EventLoop,
                                transform: (T) -> EventLoopFuture<U>) -> EventLoopFuture<[Result<U, Error>]> where Element == Result<T, Error> {
         EventLoopFuture.whenAllComplete(
@@ -25,4 +30,5 @@ extension Array {
             on: eventLoop
         )
     }
+
 }

--- a/Sources/App/Core/Extensions/Array+ext.swift
+++ b/Sources/App/Core/Extensions/Array+ext.swift
@@ -3,13 +3,13 @@ import NIO
 
 extension Array {
 
-    /// Map `Result<T, Error>` elements with the given `transform` to `EventLoopFuture<U>`by transforming the sucess case and passing through the `Error` in case of failures.
+    /// Map `Result<T, E>` elements with the given `transform` to `EventLoopFuture<U>`by transforming the sucess case and passing through the error `E` in case of failures.
     /// - Parameters:
     ///   - eventLoop: event loop
     ///   - transform: transformation
     /// - Returns: array of futures
-    func map<T, U>(on eventLoop: EventLoop,
-                   transform: (T) -> EventLoopFuture<U>) -> [EventLoopFuture<U>] where Element == Result<T, Error> {
+    func map<T, U, E>(on eventLoop: EventLoop,
+                      transform: (T) -> EventLoopFuture<U>) -> [EventLoopFuture<U>] where Element == Result<T, E> {
         map { result in
             switch result {
                 case .success(let v): return transform(v)

--- a/Sources/App/Models/Product.swift
+++ b/Sources/App/Models/Product.swift
@@ -49,6 +49,15 @@ extension Product {
     enum `Type`: String, Codable {
         case executable
         case library
+
+        init(manifestProductType: Manifest.Product.`Type`) {
+            switch manifestProductType {
+                case .executable:
+                    self = .executable
+                case .library:
+                    self = .library
+            }
+        }
     }
     
     var isLibrary: Bool { return type == .library }

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -689,7 +689,7 @@ class AnalyzerTests: AppTestCase {
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/577
         // setup
         let pkgId = UUID()
-        var pkg = Package(id: pkgId, url: "1")
+        let pkg = Package(id: pkgId, url: "1")
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
         // existing "latest release" version
@@ -703,7 +703,7 @@ class AnalyzerTests: AppTestCase {
         try pkg.$repositories.load(on: app.db).wait()
 
         // MUT
-        pkg = try updateLatestVersions(on: app.db, package: pkg).wait()
+        try updateLatestVersions(on: app.db, package: pkg).wait()
 
         // validate
         do {  // refetch package to ensure changes are persisted

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -473,14 +473,14 @@ class AnalyzerTests: AppTestCase {
         let version = try Version(id: UUID(), package: pkg, reference: .tag(.init(0, 4, 2)))
         try version.save(on: app.db).wait()
         
-        let versions: [Result<(Package, [Version]), Error>] = [
+        let packageAndVersions: [Result<(Package, [Version]), Error>] = [
             // feed in one error to see it passed through
             .failure(AppError.invalidPackageUrl(nil, "some reason")),
             .success((pkg, [version]))
         ]
         
         // MUT
-        let results = getManifests(logger: app.logger, versions: versions)
+        let results = getManifests(logger: app.logger, packageAndVersions: packageAndVersions)
         
         // validation
         XCTAssertEqual(commands, [
@@ -562,7 +562,7 @@ class AnalyzerTests: AppTestCase {
         ]
         
         // MUT
-        try updatePackage(application: app, results: results, stage: .analysis).wait()
+        try updatePackages(application: app, results: results, stage: .analysis).wait()
         
         // validate
         do {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -552,6 +552,7 @@ class AnalyzerTests: AppTestCase {
         // validation
         let products = try Product.query(on: app.db).sort(\.$createdAt).all().wait()
         XCTAssertEqual(products.map(\.name), ["p1", "p2"])
+        XCTAssertEqual(products.map(\.type), [.library, .executable])
     }
     
     func test_updatePackage() throws {

--- a/Tests/AppTests/ArrayExtensionTests.swift
+++ b/Tests/AppTests/ArrayExtensionTests.swift
@@ -1,0 +1,79 @@
+@testable import App
+import NIO
+import XCTest
+
+
+class ArrayExtensionTests: XCTestCase {
+
+    func test_map_Result_to_EventLoopFuture() throws {
+        // setup
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let results = [0, 1, 2].map { Result<Int, Error>.success($0) }
+
+        // MUT
+        let mapped = results.map(on: elg.next()) {
+            elg.future(String($0))
+        }
+
+        // validate
+        let res = try mapped.flatten(on: elg.next()).wait()
+        XCTAssertEqual(res, ["0", "1", "2"])
+    }
+
+    func test_map_Result_to_EventLoopFuture_with_errors() throws {
+        // setup
+        enum MyError: Error, Equatable { case failed }
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let results: [Result<Int, Error>] = [
+            .success(0),
+            .failure(MyError.failed as Error),
+            .success(2)
+        ]
+
+        // MUT
+        let mapped = results.map(on: elg.next()) {
+            elg.future(String($0))
+        }
+
+        // validate
+        XCTAssertEqual(try mapped[0].wait(), "0")
+        XCTAssertThrowsError(try mapped[1].wait()) {
+            XCTAssertEqual($0 as? MyError, MyError.failed)
+        }
+        XCTAssertEqual(try mapped[2].wait(), "2")
+    }
+
+    func test_whenAllComplete() throws {
+        // setup
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let results = [0, 1, 2].map { Result<Int, Error>.success($0) }
+
+        // MUT
+        let res = try results.whenAllComplete(on: elg.next()) {
+            elg.future(String($0))
+        }.wait()
+
+        // validate
+        XCTAssertEqual(res.compactMap { try? $0.get() }, ["0", "1", "2"])
+    }
+
+    func test_whenAllComplete_with_errors() throws {
+        // setup
+        enum MyError: Error { case failed }
+        let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let results: [Result<Int, Error>] = [
+            .success(0),
+            .failure(MyError.failed as Error),
+            .success(2)
+        ]
+
+        // MUT
+        let res = try results.whenAllComplete(on: elg.next()) {
+            elg.future(String($0))
+        }.wait()
+
+        // validate
+        XCTAssertEqual(res.compactMap { try? $0.get() }, ["0", "2"])
+    }
+
+}

--- a/Tests/AppTests/ArrayExtensionTests.swift
+++ b/Tests/AppTests/ArrayExtensionTests.swift
@@ -24,9 +24,9 @@ class ArrayExtensionTests: XCTestCase {
         // setup
         enum MyError: Error, Equatable { case failed }
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let results: [Result<Int, Error>] = [
+        let results: [Result<Int, MyError>] = [
             .success(0),
-            .failure(MyError.failed as Error),
+            .failure(MyError.failed),
             .success(2)
         ]
 
@@ -63,7 +63,7 @@ class ArrayExtensionTests: XCTestCase {
         let elg = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let results: [Result<Int, Error>] = [
             .success(0),
-            .failure(MyError.failed as Error),
+            .failure(MyError.failed),
             .success(2)
         ]
 

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -150,7 +150,7 @@ class IngestorTests: AppTestCase {
         ]
         
         // MUT
-        try updatePackage(application: app, results: results, stage: .ingestion).wait()
+        try updatePackages(application: app, results: results, stage: .ingestion).wait()
         
         // validate
         do {
@@ -171,7 +171,7 @@ class IngestorTests: AppTestCase {
         let results: [Result<Package, Error>] = [ .success(pkgs[0]), .success(pkgs[1])]
         
         // MUT
-        try updatePackage(application: app, results: results, stage: .ingestion).wait()
+        try updatePackages(application: app, results: results, stage: .ingestion).wait()
         
         // validate
         do {

--- a/Tests/AppTests/Mocks/Manifest+mock.swift
+++ b/Tests/AppTests/Mocks/Manifest+mock.swift
@@ -1,0 +1,14 @@
+@testable import App
+
+
+extension Manifest {
+    static var mock: Self {
+        .init(name: "MockManifest", products: [.mock])
+    }
+}
+
+extension Manifest.Product {
+    static var mock: Self {
+        .init(name: "MockProduct", type: .library)
+    }
+}

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -294,7 +294,7 @@ final class PackageTests: AppTestCase {
     func test_updateLatestVersions() throws {
         // setup
         func t(_ seconds: TimeInterval) -> Date { Date(timeIntervalSince1970: seconds) }
-        var pkg = Package(id: UUID(), url: "1")
+        let pkg = Package(id: UUID(), url: "1")
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
         try Version(package: pkg, commitDate: t(2), packageName: "foo", reference: .branch("main"))
@@ -308,7 +308,7 @@ final class PackageTests: AppTestCase {
         try pkg.$repositories.load(on: app.db).wait()
 
         // MUT
-        pkg = try updateLatestVersions(on: app.db, package: pkg).wait()
+        try updateLatestVersions(on: app.db, package: pkg).wait()
 
         // validate
         let versions = pkg.versions.sorted(by: { $0.createdAt! < $1.createdAt! })
@@ -322,7 +322,7 @@ final class PackageTests: AppTestCase {
         // is correctly reset.
         // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/188
         // setup
-        var pkg = Package(id: UUID(), url: "1")
+        let pkg = Package(id: UUID(), url: "1")
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
         try Version(package: pkg,
@@ -345,7 +345,7 @@ final class PackageTests: AppTestCase {
         try pkg.$repositories.load(on: app.db).wait()
 
         // MUT
-        pkg = try updateLatestVersions(on: app.db, package: pkg).wait()
+        try updateLatestVersions(on: app.db, package: pkg).wait()
 
         // validate
         let versions = pkg.versions.sorted(by: { $0.createdAt! < $1.createdAt! })

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -101,10 +101,9 @@ class TwitterTests: AppTestCase {
         }
 
         // MUT
-        try onNewVersions(client: app.client,
-                          logger: app.logger,
-                          transaction: app.db,
-                          versions: [v1, v2, v3]).wait()
+        try Twitter.postToFirehose(client: app.client,
+                                   database: app.db,
+                                   versions: [v1, v2, v3]).wait()
 
         // validate
         XCTAssertEqual(posted, 2)


### PR DESCRIPTION
Refactoring things to make #794 possible. It also brings `onNewVersion` to the top of the pipeline rather than burying it inside `reconcileVersions` which wasn't great in hindsight.

Left to do:

- [x] add tests for `Array.whenAllComplete`
- [x] add/update docstrings for added/updated analyzer functions