### PR TITLE
Better tweets: only new versions and announce new packages

### DIFF
--- a/Sources/App/Core/Twitter.swift
+++ b/Sources/App/Core/Twitter.swift
@@ -80,12 +80,12 @@ extension Twitter {
                       url: url)
     }
 
-    static func versionUpdateMessage(repositoryOwner: String,
-                                     repositoryName: String,
+    static func versionUpdateMessage(packageName: String,
+                                     repositoryOwner: String,
                                      url: String,
                                      version: SemanticVersion,
                                      summary: String?) -> String {
-        createMessage(preamble: "\(repositoryOwner) just released \(repositoryName) v\(version)",
+        createMessage(preamble: "\(repositoryOwner) just released \(packageName) v\(version)",
                       summary: summary,
                       url: url)
     }
@@ -107,8 +107,8 @@ extension Twitter {
                                         repositoryOwner: owner,
                                         url: url,
                                         summary: repo?.summary ?? "")
-                    : versionUpdateMessage(repositoryOwner: owner,
-                                           repositoryName: repoName,
+                    : versionUpdateMessage(packageName: packageName,
+                                           repositoryOwner: owner,
                                            url: url,
                                            version: semVer,
                                            summary: repo?.summary ?? "")

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -77,6 +77,9 @@ extension Package {
         case ingestion
         case analysis
     }
+
+    var isNew: Bool { processingStage == nil || processingStage == .some(.reconciliation) }
+
 }
 
 

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -78,7 +78,7 @@ extension Package {
         case analysis
     }
 
-    var isNew: Bool { processingStage == nil || processingStage == .some(.reconciliation) }
+    var isNew: Bool { processingStage != .analysis }
 
 }
 

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -198,11 +198,11 @@ class AnalyzerTests: AppTestCase {
         Current.shell.run = { cmd, path in
             if cmd.string == "git tag" { return "1.0.0" }
             // first package fails
-            if cmd.string == "/swift-5.3/usr/bin/swift package dump-package" && path.hasSuffix("foo-1") {
+            if cmd.string.hasSuffix("swift package dump-package") && path.hasSuffix("foo-1") {
                 return "bad data"
             }
             // second package succeeds
-            if cmd.string == "/swift-5.3/usr/bin/swift package dump-package" && path.hasSuffix("foo-2") {
+            if cmd.string.hasSuffix("swift package dump-package") && path.hasSuffix("foo-2") {
                 return #"{ "name": "SPI-Server", "products": [] }"#
             }
             if cmd.string.hasPrefix(#"git log -n1 --format=format:"%H-%ct""#) { return "sha-0" }
@@ -437,7 +437,7 @@ class AnalyzerTests: AppTestCase {
             queue.sync {
                 commands.append(cmd.string)
             }
-            if cmd.string == "/swift-5.3/usr/bin/swift package dump-package" {
+            if cmd.string.hasSuffix("swift package dump-package") {
                 return #"{ "name": "SPI-Server", "products": [] }"#
             }
             return ""
@@ -466,7 +466,7 @@ class AnalyzerTests: AppTestCase {
             queue.sync {
                 commands.append(cmd.string)
             }
-            if cmd.string == "/swift-5.3/usr/bin/swift package dump-package" {
+            if cmd.string.hasSuffix("swift package dump-package") {
                 return #"{ "name": "SPI-Server", "products": [] }"#
             }
             return ""
@@ -581,7 +581,7 @@ class AnalyzerTests: AppTestCase {
             if cmd.string == "git tag" {
                 return ["1.0.0", "2.0.0"].joined(separator: "\n")
             }
-            if cmd.string == "/swift-5.3/usr/bin/swift package dump-package" {
+            if cmd.string.hasSuffix("swift package dump-package") {
                 return #"{ "name": "foo", "products": [{"name":"p1","type":{"executable": null}}, {"name":"p2","type":{"executable": null}}] }"#
             }
             if cmd.string.hasPrefix(#"git log -n1 --format=format:"%H-%ct""#) { return "sha-0" }

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -103,7 +103,7 @@ class PipelineTests: AppTestCase {
         Current.fetchMetadata = { _, pkg in self.future(.mock(for: pkg)) }
         Current.fetchPackageList = { _ in self.future(urls.asURLs) }
         Current.shell.run = { cmd, path in
-            if cmd.string == "/swift-5.3/usr/bin/swift package dump-package" {
+            if cmd.string.hasSuffix("swift package dump-package") {
                 return #"{ "name": "Mock", "products": [] }"#
             }
             if cmd.string.hasPrefix(#"git log -n1 --format=format:"%H-%ct""#) { return "sha-0" }

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -155,7 +155,7 @@ class TwitterTests: AppTestCase {
     func test_postToFirehose_only_latest() throws {
         // ensure we only tweet about latest versions
         // setup
-        let pkg = Package(url: "1".asGithubUrl.url, processingStage: .ingestion)
+        let pkg = Package(url: "1".asGithubUrl.url, processingStage: .analysis)
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg,
                        summary: "This is a test package",

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -9,13 +9,13 @@ class TwitterTests: AppTestCase {
     func test_versionUpdateMessage() throws {
         XCTAssertEqual(
             Twitter.versionUpdateMessage(
+                packageName: "packageName",
                 repositoryOwner: "owner",
-                repositoryName: "repoName",
                 url: "http://localhost:8080/owner/SuperAwesomePackage",
                 version: .init(2, 6, 4),
                 summary: "This is a test package"),
             """
-            owner just released repoName v2.6.4 – This is a test package
+            owner just released packageName v2.6.4 – This is a test package
 
             http://localhost:8080/owner/SuperAwesomePackage
             """
@@ -24,13 +24,13 @@ class TwitterTests: AppTestCase {
         // no summary
         XCTAssertEqual(
             Twitter.versionUpdateMessage(
+                packageName: "packageName",
                 repositoryOwner: "owner",
-                repositoryName: "repoName",
                 url: "http://localhost:8080/owner/SuperAwesomePackage",
                 version: .init(2, 6, 4),
                 summary: nil),
             """
-            owner just released repoName v2.6.4
+            owner just released packageName v2.6.4
 
             http://localhost:8080/owner/SuperAwesomePackage
             """
@@ -39,8 +39,8 @@ class TwitterTests: AppTestCase {
 
     func test_versionUpdateMessage_trimming() throws {
         let msg = Twitter.versionUpdateMessage(
+            packageName: "packageName",
             repositoryOwner: "owner",
-            repositoryName: "repoName",
             url: "http://localhost:8080/owner/SuperAwesomePackage",
             version: .init(2, 6, 4),
             summary: String(repeating: "x", count: 280)
@@ -48,7 +48,7 @@ class TwitterTests: AppTestCase {
 
         XCTAssertEqual(msg.count, 260)
         XCTAssertEqual(msg, """
-            owner just released repoName v2.6.4 – xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…
+            owner just released packageName v2.6.4 – xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx…
 
             http://localhost:8080/owner/SuperAwesomePackage
             """)
@@ -85,7 +85,7 @@ class TwitterTests: AppTestCase {
 
         // validate
         XCTAssertEqual(res, """
-        owner just released repoName v1.2.3 – This is a test package
+        owner just released MyPackage v1.2.3 – This is a test package
 
         http://localhost:8080/owner/repoName
         """)


### PR DESCRIPTION
Fixes #794  (only tweet about latest versions) and also tweets differently for new packages entirely (also fixing #794, in a different way):

<img width="458" alt="Screenshot 2020-11-20 at 08 36 11" src="https://user-images.githubusercontent.com/65520/99772894-eade3d80-2b0b-11eb-816e-09297bbf75bb.png">
