### PR TITLE
loki 2.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,9 +137,6 @@ services:
     build: ./infrastructure/loki
     command: -config.file=/loki.yaml
     restart: always
-    # TODO: remove
-    ports:
-      - 3100:3100
 
   promtail:
     build: ./infrastructure/promtail

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -118,6 +118,8 @@ services:
       - "2222:22"
     restart: always
 
+  # logging & monitoring visualiser
+
   grafana:
     image: grafana/grafana:7.3.1
     environment:
@@ -129,10 +131,15 @@ services:
     ports:
       - 3000:3000
 
+  # logging
+
   loki:
-    image: grafana/loki:1.5.0
-    command: -config.file=/etc/loki/local-config.yaml
+    build: ./infrastructure/loki
+    command: -config.file=/loki.yaml
     restart: always
+    # TODO: remove
+    ports:
+      - 3100:3100
 
   promtail:
     build: ./infrastructure/promtail
@@ -140,6 +147,8 @@ services:
       - /var/lib/docker/containers:/var/log
     command: -config.file=/promtail.yaml
     restart: always
+
+  # monitoring
 
   prometheus:
     build: ./infrastructure/prometheus

--- a/infrastructure/loki/Dockerfile
+++ b/infrastructure/loki/Dockerfile
@@ -1,0 +1,3 @@
+FROM grafana/loki:2.0.0
+
+COPY loki.yaml /loki.yaml

--- a/infrastructure/loki/loki.yaml
+++ b/infrastructure/loki/loki.yaml
@@ -1,0 +1,64 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+ingester:
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
+  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
+  chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
+  chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
+  max_transfer_retries: 0     # Chunk transfers disabled
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /tmp/loki/boltdb-shipper-active
+    cache_location: /tmp/loki/boltdb-shipper-cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    shared_store: filesystem
+  filesystem:
+    directory: /tmp/loki/chunks
+
+compactor:
+  working_directory: /tmp/loki/boltdb-shipper-compactor
+  shared_store: filesystem
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 168h
+
+chunk_store_config:
+  max_look_back_period: 0s
+
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0s
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /tmp/loki/rules
+  rule_path: /tmp/loki/rules-temp
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true

--- a/infrastructure/loki/loki.yaml
+++ b/infrastructure/loki/loki.yaml
@@ -48,8 +48,8 @@ chunk_store_config:
   max_look_back_period: 0s
 
 table_manager:
-  retention_deletes_enabled: false
-  retention_period: 0s
+  retention_deletes_enabled: true
+  retention_period: 168h
 
 ruler:
   storage:

--- a/infrastructure/loki/loki.yaml
+++ b/infrastructure/loki/loki.yaml
@@ -45,7 +45,7 @@ limits_config:
   reject_old_samples_max_age: 168h
 
 chunk_store_config:
-  max_look_back_period: 0s
+  max_look_back_period: 168h
 
 table_manager:
   retention_deletes_enabled: true

--- a/infrastructure/promtail/Dockerfile
+++ b/infrastructure/promtail/Dockerfile
@@ -1,3 +1,3 @@
-FROM grafana/promtail:1.5.0
+FROM grafana/promtail:2.0.0
 
 COPY promtail.yaml /promtail.yaml


### PR DESCRIPTION
I've already test-deployed this to dev. This should give us a (configurable) 7-day (168h) history of logs, across restarts (as shown in the screenshot).

I've added a couple of notes, because when I previously observed that it doesn't keep history, I believe the main issue was that I didn't notice the default 1000 line limit on logs. So it might have just been an artifact of how I used the log viewer, to a degree. What's certainly new is the log history of 168h (but see below).

The top diagram shows that we're keeping logs across restarts (and you can see nicely how the "log peaks" align with the increased output from the analyser every 5mins).

What we still need to test properly is the log history. There's a lot going on in the config and I'm not 100% I set the correct values in all the places.

<img width="1177" alt="Screenshot 2020-11-23 at 14 42 03" src="https://user-images.githubusercontent.com/65520/99969255-7ec53900-2d9a-11eb-98fe-95649b91c457.png">
