### PR TITLE
Ensure we don't re-ingest ingestion stage records

### DIFF
--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -241,8 +241,14 @@ private extension QueryBuilder where Model == Package {
                 fatalError("reconciliation stage does not select candidates")
             case .ingestion:
                 return group(.or) {
-                    $0.filter(\.$processingStage == .reconciliation)
-                        .filter(\.$updatedAt < Current.date().addingTimeInterval(-Constants.reIngestionDeadtime))
+                    $0
+                        .filter(\.$processingStage == .reconciliation)
+                        .group(.and) {
+                            $0
+                                .filter(\.$processingStage == .analysis)
+                                .filter(\.$updatedAt < Current.date().addingTimeInterval(-Constants.reIngestionDeadtime)
+                                )
+                        }
                 }
             case .analysis:
                 return filter(\.$processingStage == .ingestion)


### PR DESCRIPTION
This wasn't a problem in the past but it sets their "new" status to "ok", which messes up tweeting about new packages. I believe what's happening is that ingestion cycles around faster than analysis and gets a second pass before the tweets get a chance to go out while `status` is `new`.

This ensures we only look at `analysis` stage records on the refresh cycle.

Merge after #808 