### PR TITLE
improve logging

### DIFF
--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -65,7 +65,8 @@ func analyze(application: Application, limit: Int) -> EventLoopFuture<Void> {
 ///   - application: `Application` object for database, client, and logger access
 ///   - packages: packages to be analysed
 /// - Returns: future
-func analyze(application: Application, packages: [Package]) -> EventLoopFuture<Void> {
+func analyze(application: Application,
+             packages: [Package]) -> EventLoopFuture<Void> {
     AppMetrics.analyzeCandidatesCount?.set(packages.count)
     // get or create directory
     let checkoutDir = Current.fileManager.checkoutsDirectory()
@@ -111,7 +112,9 @@ func analyze(application: Application, packages: [Package]) -> EventLoopFuture<V
     
     let statusOps = packageResults
         .map(\.packages)
-        .flatMap { updatePackages(application: application,
+        .flatMap { updatePackages(client: application.client,
+                                  database: application.db,
+                                  logger: application.logger,
                                   results: $0,
                                   stage: .analysis) }
     

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -20,7 +20,7 @@ struct AnalyzeCommand: Command {
 
         let client = context.application.client
         let db = context.application.db
-        let logger = Logger(label: "analyzer")
+        let logger = Logger(label: "analyze")
         let threadPool = context.application.threadPool
 
         if let id = signature.id {

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -24,7 +24,7 @@ struct AnalyzeCommand: Command {
         let threadPool = context.application.threadPool
 
         if let id = signature.id {
-            context.console.info("Analyzing (id: \(id)) ...")
+            logger.info("Analyzing (id: \(id)) ...")
             try analyze(client: client,
                         database: db,
                         logger: logger,
@@ -32,7 +32,7 @@ struct AnalyzeCommand: Command {
                         id: id)
                 .wait()
         } else {
-            context.console.info("Analyzing (limit: \(limit)) ...")
+            logger.info("Analyzing (limit: \(limit)) ...")
             try analyze(client: client,
                         database: db,
                         logger: logger,

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -17,24 +17,33 @@ struct AnalyzeCommand: Command {
     
     func run(using context: CommandContext, signature: Signature) throws {
         let limit = signature.limit ?? defaultLimit
+
+        let client = context.application.client
+        let db = context.application.db
+        let logger = Logger(label: "analyzer")
+        let threadPool = context.application.threadPool
+
         if let id = signature.id {
             context.console.info("Analyzing (id: \(id)) ...")
-            try analyze(client: context.application.client,
-                        database: context.application.db,
-                        logger: context.application.logger,
-                        threadPool: context.application.threadPool,
-                        id: id).wait()
+            try analyze(client: client,
+                        database: db,
+                        logger: logger,
+                        threadPool: threadPool,
+                        id: id)
+                .wait()
         } else {
             context.console.info("Analyzing (limit: \(limit)) ...")
-            try analyze(client: context.application.client,
-                        database: context.application.db,
-                        logger: context.application.logger,
-                        threadPool: context.application.threadPool,
-                        limit: limit).wait()
+            try analyze(client: client,
+                        database: db,
+                        logger: logger,
+                        threadPool: threadPool,
+                        limit: limit)
+                .wait()
         }
-        try AppMetrics.push(client: context.application.client,
-                            logger: context.application.logger,
-                            jobName: "analyze").wait()
+        try AppMetrics.push(client: client,
+                            logger: logger,
+                            jobName: "analyze")
+            .wait()
     }
 }
 

--- a/Sources/App/Commands/Analyzer.swift
+++ b/Sources/App/Commands/Analyzer.swift
@@ -20,7 +20,7 @@ struct AnalyzeCommand: Command {
 
         let client = context.application.client
         let db = context.application.db
-        let logger = Logger(label: "analyze")
+        let logger = Logger(component: "analyze")
         let threadPool = context.application.threadPool
 
         if let id = signature.id {

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -23,11 +23,11 @@ struct IngestCommand: Command {
         let logger = Logger(label: "ingestor")
 
         if let id = signature.id {
-            context.console.info("Ingesting (id: \(id)) ...")
+            logger.info("Ingesting (id: \(id)) ...")
             try ingest(client: client, database: db, logger: logger, id: id)
                 .wait()
         } else {
-            context.console.info("Ingesting (limit: \(limit)) ...")
+            logger.info("Ingesting (limit: \(limit)) ...")
             try ingest(client: client, database: db, logger: logger, limit: limit)
                 .wait()
         }

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -20,7 +20,7 @@ struct IngestCommand: Command {
 
         let client = context.application.client
         let db = context.application.db
-        let logger = Logger(label: "ingest")
+        let logger = Logger(component: "ingest")
 
         if let id = signature.id {
             logger.info("Ingesting (id: \(id)) ...")

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -17,17 +17,22 @@ struct IngestCommand: Command {
     
     func run(using context: CommandContext, signature: Signature) throws {
         let limit = signature.limit ?? defaultLimit
+
+        let client = context.application.client
+        let db = context.application.db
+        let logger = Logger(label: "ingestor")
+
         if let id = signature.id {
             context.console.info("Ingesting (id: \(id)) ...")
-            try ingest(application: context.application, id: id)
+            try ingest(client: client, database: db, logger: logger, id: id)
                 .wait()
         } else {
             context.console.info("Ingesting (limit: \(limit)) ...")
-            try ingest(application: context.application, limit: limit)
+            try ingest(client: client, database: db, logger: logger, limit: limit)
                 .wait()
         }
-        try AppMetrics.push(client: context.application.client,
-                            logger: context.application.logger,
+        try AppMetrics.push(client: client,
+                            logger: logger,
                             jobName: "ingest").wait()
     }
 }
@@ -35,45 +40,66 @@ struct IngestCommand: Command {
 
 /// Ingest given `Package` identified by its `Id`.
 /// - Parameters:
-///   - application: `Application` object for database, client, and logger access
+///   - client: `Client` object
+///   - database: `Database` object
+///   - logger: `Logger` object
 ///   - id: package id
 /// - Returns: future
-func ingest(application: Application, id: Package.Id) -> EventLoopFuture<Void> {
-    Package.query(on: application.db)
+func ingest(client: Client,
+            database: Database,
+            logger: Logger,
+            id: Package.Id) -> EventLoopFuture<Void> {
+    Package.query(on: database)
         .with(\.$repositories)
         .filter(\.$id == id)
         .first()
         .unwrap(or: Abort(.notFound))
         .map { [$0] }
         .flatMap { packages in
-            ingest(application: application, packages: packages)
+            ingest(client: client,
+                   database: database,
+                   logger: logger,
+                   packages: packages)
         }
 }
 
 
 /// Ingest a number of `Package`s, selected from a candidate list with a given limit.
 /// - Parameters:
-///   - application: `Application` object for database, client, and logger access
+///   - client: `Client` object
+///   - database: `Database` object
+///   - logger: `Logger` object
 ///   - limit: number of `Package`s to select from the candidate list
 /// - Returns: future
-func ingest(application: Application, limit: Int) -> EventLoopFuture<Void> {
-    Package.fetchCandidates(application.db, for: .ingestion, limit: limit)
-        .flatMap { ingest(application: application, packages: $0) }
+func ingest(client: Client,
+            database: Database,
+            logger: Logger,
+            limit: Int) -> EventLoopFuture<Void> {
+    Package.fetchCandidates(database, for: .ingestion, limit: limit)
+        .flatMap { ingest(client: client,
+                          database: database,
+                          logger: logger,
+                          packages: $0) }
 }
 
 
 /// Main ingestion function. Fetched package metadata from hosting provider and updates `Repositoy` and `Package`s.
 /// - Parameters:
-///   - application: `Application` object for database, client, and logger access
+///   - client: `Client` object
+///   - database: `Database` object
+///   - logger: `Logger` object
 ///   - packages: packages to be ingested
 /// - Returns: future
-func ingest(application: Application, packages: [Package]) -> EventLoopFuture<Void> {
+func ingest(client: Client,
+            database: Database,
+            logger: Logger,
+            packages: [Package]) -> EventLoopFuture<Void> {
     AppMetrics.ingestCandidatesCount?.set(packages.count)
-    let metadata = fetchMetadata(client: application.client, packages: packages)
-    let updates = metadata.flatMap { updateRepositories(on: application.db, metadata: $0) }
-    return updates.flatMap { updatePackages(client: application.client,
-                                            database: application.db,
-                                            logger: application.logger,
+    let metadata = fetchMetadata(client: client, packages: packages)
+    let updates = metadata.flatMap { updateRepositories(on: database, metadata: $0) }
+    return updates.flatMap { updatePackages(client: client,
+                                            database: database,
+                                            logger: logger,
                                             results: $0,
                                             stage: .ingestion) }
 }

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -71,7 +71,11 @@ func ingest(application: Application, packages: [Package]) -> EventLoopFuture<Vo
     AppMetrics.ingestCandidatesCount?.set(packages.count)
     let metadata = fetchMetadata(client: application.client, packages: packages)
     let updates = metadata.flatMap { updateRepositories(on: application.db, metadata: $0) }
-    return updates.flatMap { updatePackages(application: application, results: $0, stage: .ingestion) }
+    return updates.flatMap { updatePackages(client: application.client,
+                                            database: application.db,
+                                            logger: application.logger,
+                                            results: $0,
+                                            stage: .ingestion) }
 }
 
 

--- a/Sources/App/Commands/Ingestor.swift
+++ b/Sources/App/Commands/Ingestor.swift
@@ -20,7 +20,7 @@ struct IngestCommand: Command {
 
         let client = context.application.client
         let db = context.application.db
-        let logger = Logger(label: "ingestor")
+        let logger = Logger(label: "ingest")
 
         if let id = signature.id {
             logger.info("Ingesting (id: \(id)) ...")

--- a/Sources/App/Commands/Reconciler.swift
+++ b/Sources/App/Commands/Reconciler.swift
@@ -8,7 +8,7 @@ struct ReconcileCommand: Command {
     var help: String { "Reconcile package list with server" }
     
     func run(using context: CommandContext, signature: Signature) throws {
-        let logger = Logger(label: "reconcile")
+        let logger = Logger(component: "reconcile")
 
         logger.info("Reconciling ...")
         let request = try reconcile(client: context.application.client,

--- a/Sources/App/Commands/Reconciler.swift
+++ b/Sources/App/Commands/Reconciler.swift
@@ -8,7 +8,9 @@ struct ReconcileCommand: Command {
     var help: String { "Reconcile package list with server" }
     
     func run(using context: CommandContext, signature: Signature) throws {
-        context.console.info("Reconciling ...")
+        let logger = Logger(label: "reconciler")
+
+        logger.info("Reconciling ...")
         let request = try reconcile(client: context.application.client,
                                     database: context.application.db)
         try request.wait()

--- a/Sources/App/Commands/Reconciler.swift
+++ b/Sources/App/Commands/Reconciler.swift
@@ -8,7 +8,7 @@ struct ReconcileCommand: Command {
     var help: String { "Reconcile package list with server" }
     
     func run(using context: CommandContext, signature: Signature) throws {
-        let logger = Logger(label: "reconciler")
+        let logger = Logger(label: "reconcile")
 
         logger.info("Reconciling ...")
         let request = try reconcile(client: context.application.client,

--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -25,7 +25,7 @@ struct TriggerBuildsCommand: Command {
     func run(using context: CommandContext, signature: Signature) throws {
         let limit = signature.limit ?? defaultLimit
         let force = signature.force
-        let logger = Logger(label: "trigger-builds")
+        let logger = Logger(component: "trigger-builds")
 
         let parameter: Parameter
         if let id = signature.id {

--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -25,7 +25,7 @@ struct TriggerBuildsCommand: Command {
     func run(using context: CommandContext, signature: Signature) throws {
         let limit = signature.limit ?? defaultLimit
         let force = signature.force
-        let logger = context.application.logger
+        let logger = Logger(label: "trigger-builds")
 
         let parameter: Parameter
         if let id = signature.id {

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -78,7 +78,11 @@ extension API {
                             Command.Response(status: "ok", rows: limit)
                         }
                 case .analyze:
-                    return analyze(application: req.application, limit: limit)
+                    return analyze(client: req.application.client,
+                                   database: req.application.db,
+                                   logger: req.application.logger,
+                                   threadPool: req.application.threadPool,
+                                   limit: limit)
                         .map {
                             Command.Response(status: "ok", rows: limit)
                         }

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -73,7 +73,10 @@ extension API {
                                 .map { Command.Response.init(status: "ok", rows: $0) }
                         }
                 case .ingest:
-                    return ingest(application: req.application, limit: limit)
+                    return ingest(client: req.application.client,
+                                  database: req.application.db,
+                                  logger: req.application.logger,
+                                  limit: limit)
                         .map {
                             Command.Response(status: "ok", rows: limit)
                         }

--- a/Sources/App/Core/Extensions/Logger+ext.swift
+++ b/Sources/App/Core/Extensions/Logger+ext.swift
@@ -1,0 +1,9 @@
+import Logging
+
+
+extension Logger {
+    init(component: String) {
+        self.init(label: component)
+        self[metadataKey: "component"] = .string(component)
+    }
+}

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -571,7 +571,11 @@ class AnalyzerTests: AppTestCase {
         ]
         
         // MUT
-        try updatePackages(application: app, results: results, stage: .analysis).wait()
+        try updatePackages(client: app.client,
+                           database: app.db,
+                           logger: app.logger,
+                           results: results,
+                           stage: .analysis).wait()
         
         // validate
         do {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -300,7 +300,10 @@ class AnalyzerTests: AppTestCase {
         let pkgs = Package.fetchCandidates(app.db, for: .analysis, limit: 10)
         
         // MUT
-        let res = try pkgs.flatMap { refreshCheckouts(application: self.app, packages: $0) }.wait()
+        let res = try pkgs.flatMap { refreshCheckouts(eventLoop: self.app.eventLoopGroup.next(),
+                                                      logger: self.app.logger,
+                                                      threadPool: self.app.threadPool,
+                                                      packages: $0) }.wait()
         
         // validation
         XCTAssertEqual(res.count, 2)
@@ -631,7 +634,10 @@ class AnalyzerTests: AppTestCase {
         }
         
         // MUT
-        let res = try pkgs.flatMap { refreshCheckouts(application: self.app, packages: $0) }.wait()
+        let res = try pkgs.flatMap { refreshCheckouts(eventLoop: self.app.eventLoopGroup.next(),
+                                                      logger: self.app.logger,
+                                                      threadPool: self.app.threadPool,
+                                                      packages: $0) }.wait()
         
         // validation
         XCTAssertEqual(res.map(\.isSuccess), [true])
@@ -664,7 +670,10 @@ class AnalyzerTests: AppTestCase {
         }
 
         // MUT
-        let res = try pkgs.flatMap { refreshCheckouts(application: self.app, packages: $0) }.wait()
+        let res = try pkgs.flatMap { refreshCheckouts(eventLoop: self.app.eventLoopGroup.next(),
+                                                      logger: self.app.logger,
+                                                      threadPool: self.app.threadPool,
+                                                      packages: $0) }.wait()
 
         // validation
         XCTAssertEqual(res.map(\.isSuccess), [true])

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -284,7 +284,10 @@ class AnalyzerTests: AppTestCase {
         }
         
         // MUT
-        _ = try refreshCheckout(application: app, package: pkg).wait()
+        _ = try refreshCheckout(eventLoop: app.eventLoopGroup.next(),
+                                logger: app.logger,
+                                threadPool: app.threadPool,
+                                package: pkg).wait()
         
         // validate
         assertSnapshot(matching: commands, as: .dump)
@@ -737,7 +740,10 @@ class AnalyzerTests: AppTestCase {
         }
 
         // MUT
-        _ = try refreshCheckout(application: app, package: pkg).wait()
+        _ = try refreshCheckout(eventLoop: app.eventLoopGroup.next(),
+                                logger: app.logger,
+                                threadPool: app.threadPool,
+                                package: pkg).wait()
 
         // validate
         assertSnapshot(matching: commands, as: .dump)

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -347,7 +347,7 @@ class AnalyzerTests: AppTestCase {
         
         // MUT
         let results: [Result<Package, Error>] =
-            try updateRepositories(application: app, packages: packages).wait()
+            try updateRepositories(on: app.db, packages: packages).wait()
         
         // validate
         XCTAssertEqual(results.count, 2)

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -77,7 +77,11 @@ class AnalyzerTests: AppTestCase {
         }
         
         // MUT
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         
         // validation
         let outDir = try XCTUnwrap(checkoutDir)
@@ -175,7 +179,11 @@ class AnalyzerTests: AppTestCase {
         }
 
         // MUT
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
 
         // validate versions
         let p = try XCTUnwrap(Package.find(pkgId, on: app.db).wait())
@@ -213,7 +221,11 @@ class AnalyzerTests: AppTestCase {
         }
         
         // MUT
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         
         // assert packages have been updated
         let packages = try Package.query(on: app.db).sort(\.$createdAt).all().wait()
@@ -256,7 +268,11 @@ class AnalyzerTests: AppTestCase {
         }
         
         // MUT
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         
         // validation (not in detail, this is just to ensure command count is as expected)
         // Test setup is identical to `test_basic_analysis` except for the Manifest JSON,
@@ -606,7 +622,11 @@ class AnalyzerTests: AppTestCase {
         }
         
         // MUT
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         
         // validation
         // 1 version for the default branch + 2 for the tags each = 6 versions

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -64,7 +64,11 @@ class ErrorReportingTests: AppTestCase {
         }
         
         // MUT
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         
         // validation
         XCTAssertNotNil(reportedError)
@@ -76,7 +80,11 @@ class ErrorReportingTests: AppTestCase {
         try savePackages(on: app.db, ["1", "2"], processingStage: .ingestion)
         
         // MUT
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         
         // validation
         let packages = try Package.query(on: app.db).sort(\.$url).all().wait()

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -37,7 +37,7 @@ class ErrorReportingTests: AppTestCase {
         }
         
         // MUT
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
         
         // validation
         XCTAssertEqual(reportedError, AppError.invalidPackageUrl(nil, "foo"))

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -17,7 +17,7 @@ class IngestorTests: AppTestCase {
         let lastUpdate = Date()
         
         // MUT
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
         
         // validate
         let repos = try Repository.query(on: app.db).all().wait()
@@ -196,7 +196,7 @@ class IngestorTests: AppTestCase {
         let packages = try savePackages(on: app.db, testUrls, processingStage: .reconciliation)
         
         // MUT
-        try ingest(application: app, limit: testUrls.count).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: testUrls.count).wait()
         
         // validate
         let repos = try Repository.query(on: app.db).all().wait()
@@ -241,7 +241,7 @@ class IngestorTests: AppTestCase {
         let lastUpdate = Date()
         
         // MUT
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
         
         // validate
         let repos = try Repository.query(on: app.db).all().wait()
@@ -292,7 +292,7 @@ class IngestorTests: AppTestCase {
         let lastUpdate = Date()
         
         // MUT
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
         
         // validate repositories (single element pointing to first package)
         let repos = try Repository.query(on: app.db).all().wait()

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -150,7 +150,11 @@ class IngestorTests: AppTestCase {
         ]
         
         // MUT
-        try updatePackages(application: app, results: results, stage: .ingestion).wait()
+        try updatePackages(client: app.client,
+                           database: app.db,
+                           logger: app.logger,
+                           results: results,
+                           stage: .ingestion).wait()
         
         // validate
         do {
@@ -171,7 +175,11 @@ class IngestorTests: AppTestCase {
         let results: [Result<Package, Error>] = [ .success(pkgs[0]), .success(pkgs[1])]
         
         // MUT
-        try updatePackages(application: app, results: results, stage: .ingestion).wait()
+        try updatePackages(client: app.client,
+                           database: app.db,
+                           logger: app.logger,
+                           results: results,
+                           stage: .ingestion).wait()
         
         // validate
         do {

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -805,7 +805,11 @@ final class PackageTests: AppTestCase {
         }
 
         // run analysis to progress package through pipeline
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
 
         // MUT & validate
         do {
@@ -828,7 +832,11 @@ final class PackageTests: AppTestCase {
             XCTAssertFalse(pkg.isNew)
         }
 
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         do {
             let pkg = try XCTUnwrap(Package.query(on: app.db).first().wait())
             XCTAssertFalse(pkg.isNew)

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -796,7 +796,7 @@ final class PackageTests: AppTestCase {
         }
 
         // run ingestion to progress package through pipeline
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
 
         // MUT & validate
         do {
@@ -826,7 +826,7 @@ final class PackageTests: AppTestCase {
         }
 
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime) }
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
         do {
             let pkg = try XCTUnwrap(Package.query(on: app.db).first().wait())
             XCTAssertFalse(pkg.isNew)

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -143,7 +143,7 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - second stage
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
         
         do { // validate
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
@@ -183,7 +183,7 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - ingest again
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
         
         do {  // validate - only new package moves to .ingestion stage
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
@@ -214,7 +214,7 @@ class PipelineTests: AppTestCase {
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime) }
         
         // MUT - ingest yet again
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
         
         do {  // validate - now all three packages should have been updated
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -154,7 +154,11 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - third stage
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         
         do { // validate
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
@@ -191,7 +195,11 @@ class PipelineTests: AppTestCase {
         
         // MUT - analyze again
         let lastAnalysis = Current.date()
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         
         do {  // validate - only new package moves to .ingestion stage
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
@@ -217,7 +225,11 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - re-run analysis to complete the sequence
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         
         do {  // validate - only new package moves to .ingestion stage
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -223,7 +223,7 @@ class TwitterTests: AppTestCase {
         }
         // run first two processing steps
         try reconcile(client: app.client, database: app.db).wait()
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
 
         // MUT - analyze, triggering the tweet
         try analyze(client: app.client,
@@ -240,7 +240,7 @@ class TwitterTests: AppTestCase {
         message = nil
         try reconcile(client: app.client, database: app.db).wait()
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime) }
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
 
         // MUT - analyze, triggering tweets if any
         try analyze(client: app.client,
@@ -256,7 +256,7 @@ class TwitterTests: AppTestCase {
         tag = "2.0.0"
         // fast forward our clock by the deadtime interval again (*2) and re-ingest
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime * 2) }
-        try ingest(application: app, limit: 10).wait()
+        try ingest(client: app.client, database: app.db, logger: app.logger, limit: 10).wait()
 
         // MUT - analyze again
         try analyze(client: app.client,

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -226,7 +226,11 @@ class TwitterTests: AppTestCase {
         try ingest(application: app, limit: 10).wait()
 
         // MUT - analyze, triggering the tweet
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
         do {
             let msg = try XCTUnwrap(message)
             XCTAssertTrue(msg.hasPrefix("📦 foo just added a new package, Mock"), "was \(msg)")
@@ -239,7 +243,11 @@ class TwitterTests: AppTestCase {
         try ingest(application: app, limit: 10).wait()
 
         // MUT - analyze, triggering tweets if any
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
 
         // validate - there are no new tweets to send
         XCTAssertNil(message)
@@ -251,7 +259,11 @@ class TwitterTests: AppTestCase {
         try ingest(application: app, limit: 10).wait()
 
         // MUT - analyze again
-        try analyze(application: app, limit: 10).wait()
+        try analyze(client: app.client,
+                    database: app.db,
+                    logger: app.logger,
+                    threadPool: app.threadPool,
+                    limit: 10).wait()
 
         // validate
         let msg = try XCTUnwrap(message)


### PR DESCRIPTION
This got big but it's essentially just splitting the single `application` argument on lots of functions into the constituents that are actually needed - something I've been wanting to clean up anyway.

Unfortunately, the console logger only logs the label for <= trace levels. However, we can attach component metadata that then gets appended to the logs, like so:

```
[ INFO ] Analyzing (limit: 1) ... [component: analyze]
[ INFO ] Checkout directory: /Users/sas/Projects/spi-server/SPI-checkouts [component: analyze]
```