### PR TITLE
Log labels

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -69,7 +69,7 @@ build:
     docker-compose up -d db  # ensure db is up
     env VERSION=$VERSION docker-compose run migrate
 
-    echo Deploying with SITE_URL: ${SITE_URL} ...
+    echo Deploying VERSION $VERSION with SITE_URL: ${SITE_URL} ...
     env VERSION=$VERSION docker-compose up --build -d
     if [[ $? == 0 ]]; then
       rollbar succeeded

--- a/infrastructure/promtail/promtail.yaml
+++ b/infrastructure/promtail/promtail.yaml
@@ -9,10 +9,16 @@ clients:
   - url: http://loki:3100/loki/api/v1/push
 
 scrape_configs:
-- job_name: system
-  static_configs:
-  - targets:
-      - localhost
-    labels:
-      job: containers
-      __path__: /var/log/*/*.log
+  - job_name: system
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: containers
+          __path__: /var/log/*/*.log
+    pipeline_stages:
+      - docker: {}
+      - regex:
+          expression: "\\[component:\\s*(?P<component>\\w+)\\]"
+      - labels:
+          component:

--- a/infrastructure/promtail/promtail.yaml
+++ b/infrastructure/promtail/promtail.yaml
@@ -22,3 +22,5 @@ scrape_configs:
           expression: "\\[component:\\s*(?P<component>\\w+)\\]"
       - labels:
           component:
+      - drop:
+          expression: "query=\"{"


### PR DESCRIPTION
A couple of small tweaks to improve the dashboards, now that I've figured out the config settings:

- component filter

<img width="1108" alt="Screenshot 2020-11-25 at 09 50 33" src="https://user-images.githubusercontent.com/65520/100204162-d16e3480-2f03-11eb-824f-8c3c8b0913bc.png">

- annotations (blue vertical lines)

<img width="1177" alt="Screenshot 2020-11-25 at 09 49 41" src="https://user-images.githubusercontent.com/65520/100204177-d632e880-2f03-11eb-9a78-271a97f1de43.png">

With the additional `VERSION` string in the deployment logs, the annotation will also display which version was deployed.