### PR TITLE
Persist targets

### DIFF
--- a/Sources/App/Migrations/024/CreateTarget.swift
+++ b/Sources/App/Migrations/024/CreateTarget.swift
@@ -1,0 +1,20 @@
+import Fluent
+
+struct CreateTarget: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        return database.schema("targets")
+            // managed fields
+            .id()
+            .field("created_at", .datetime)
+            .field("updated_at", .datetime)
+
+            // data fields
+            .field("name", .string)
+
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        return database.schema("targets").delete()
+    }
+}

--- a/Sources/App/Migrations/024/CreateTarget.swift
+++ b/Sources/App/Migrations/024/CreateTarget.swift
@@ -8,6 +8,10 @@ struct CreateTarget: Migration {
             .field("created_at", .datetime)
             .field("updated_at", .datetime)
 
+            // reference fields
+            .field("version_id", .uuid,
+                   .references("versions", "id", onDelete: .cascade))
+
             // data fields
             .field("name", .string)
 

--- a/Sources/App/Models/Manifest.swift
+++ b/Sources/App/Models/Manifest.swift
@@ -37,6 +37,9 @@ struct Manifest: Decodable, Equatable {
         var name: String
         var type: `Type`
     }
+    struct Target: Decodable, Equatable {
+        var name: String
+    }
     struct ToolsVersion: Decodable, Equatable {
         enum CodingKeys: String, CodingKey {
             case version = "_version"
@@ -47,6 +50,7 @@ struct Manifest: Decodable, Equatable {
     var platforms: [Platform]?
     var products: [Product]
     var swiftLanguageVersions: [String]?
+    var targets: [Target]
     var toolsVersion: ToolsVersion?
 }
 

--- a/Sources/App/Models/Target.swift
+++ b/Sources/App/Models/Target.swift
@@ -1,0 +1,34 @@
+import Fluent
+import Vapor
+
+
+final class Target: Model, Content {
+    static let schema = "targets"
+
+    typealias Id = UUID
+
+    // managed fields
+
+    @ID(key: .id)
+    var id: Id?
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt: Date?
+
+    // data fields
+
+    @Field(key: "name")
+    var name: String
+
+    // initializers
+
+    init() { }
+
+    init(id: UUID? = nil,
+         name: String) {
+        self.name = name
+    }
+}

--- a/Sources/App/Models/Target.swift
+++ b/Sources/App/Models/Target.swift
@@ -18,6 +18,11 @@ final class Target: Model, Content {
     @Timestamp(key: "updated_at", on: .update)
     var updatedAt: Date?
 
+    // reference fields
+
+    @Parent(key: "version_id")
+    var version: Version
+
     // data fields
 
     @Field(key: "name")
@@ -28,7 +33,10 @@ final class Target: Model, Content {
     init() { }
 
     init(id: UUID? = nil,
-         name: String) {
+         version: Version,
+         name: String) throws {
+        self.id = id
+        self.$version.id = try version.requireID()
         self.name = name
     }
 }

--- a/Sources/App/Models/Version.swift
+++ b/Sources/App/Models/Version.swift
@@ -69,6 +69,9 @@ final class Version: Model, Content {
     @Children(for: \.$version)
     var products: [Product]
     
+    @Children(for: \.$version)
+    var targets: [Target]
+
     init() { }
     
     init(id: Id? = nil,

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -106,9 +106,12 @@ public func configure(_ app: Application) throws {
     do {  // Migration 022 - add is_archived to repositories
         app.migrations.add(UpdateRepositoryAddIsArchived())
     }
-    do {  // Migration 023 0 add releases to repositories and published_at and release_notes to versions
+    do {  // Migration 023 - add releases to repositories and published_at and release_notes to versions
         app.migrations.add(UpdateRepositoryAddReleases())
         app.migrations.add(UpdateVersionAddPublisedAtReleaseNotes())
+    }
+    do {  // Migration 024 - add targets table
+        app.migrations.add(CreateTarget())
     }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -583,6 +583,7 @@ class AnalyzerTests: AppTestCase {
                                             .init(platformName: .macos, version: "10.10")],
                                 products: [],
                                 swiftLanguageVersions: ["1", "2", "3.0.0"],
+                                targets: [],
                                 toolsVersion: .init(version: "5.0.0"))
         
         // MUT
@@ -618,6 +619,7 @@ class AnalyzerTests: AppTestCase {
         let m = Manifest(name: "1",
                          products: [.init(name: "p1", type: .library),
                                     .init(name: "p2", type: .executable)],
+                         targets: [],
                          toolsVersion: .init(version: "5.0.0"))
         try p.save(on: app.db).wait()
         try v.save(on: app.db).wait()

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -49,10 +49,36 @@ class AnalyzerTests: AppTestCase {
                 return ["2.0.0", "2.1.0"].joined(separator: "\n")
             }
             if cmd.string == "swift package dump-package" && path.hasSuffix("foo-1") {
-                return #"{ "name": "foo-1", "products": [{"name":"p1","type":{"executable": null}}] }"#
+                return #"""
+                    {
+                      "name": "foo-1",
+                      "products": [
+                        {
+                          "name": "p1",
+                          "type": {
+                            "executable": null
+                          }
+                        }
+                      ],
+                      "targets": []
+                    }
+                    """#
             }
             if cmd.string == "swift package dump-package" && path.hasSuffix("foo-2") {
-                return #"{ "name": "foo-2", "products": [{"name":"p2","type":{"library": []}}] }"#
+                return #"""
+                    {
+                      "name": "foo-2",
+                      "products": [
+                        {
+                          "name": "p2",
+                          "type": {
+                            "library": []
+                          }
+                        }
+                      ],
+                      "targets": []
+                    }
+                    """#
             }
             
             // Git.revisionInfo (per ref - default branch & tags)
@@ -159,7 +185,20 @@ class AnalyzerTests: AppTestCase {
                 return ["1.0.0", "1.1.1"].joined(separator: "\n")
             }
             if cmd.string.hasSuffix("package dump-package") {
-                return #"{ "name": "foo-1", "products": [{"name":"p1","type":{"executable": null}}] }"#
+                return #"""
+                    {
+                      "name": "foo-1",
+                      "products": [
+                        {
+                          "name": "p1",
+                          "type": {
+                            "executable": null
+                          }
+                        }
+                      ],
+                      "targets": []
+                    }
+                    """#
             }
 
             // New Git.revisionInfo (per ref - default branch & tags)
@@ -215,7 +254,7 @@ class AnalyzerTests: AppTestCase {
             }
             // second package succeeds
             if cmd.string.hasSuffix("swift package dump-package") && path.hasSuffix("foo-2") {
-                return #"{ "name": "SPI-Server", "products": [] }"#
+                return #"{ "name": "SPI-Server", "products": [], "targets": [] }"#
             }
             if cmd.string.hasPrefix(#"git log -n1 --format=format:"%H-%ct""#) { return "sha-0" }
             if cmd.string == "git rev-list --count HEAD" { return "12" }
@@ -514,7 +553,7 @@ class AnalyzerTests: AppTestCase {
                 commands.append(cmd.string)
             }
             if cmd.string.hasSuffix("swift package dump-package") {
-                return #"{ "name": "SPI-Server", "products": [] }"#
+                return #"{ "name": "SPI-Server", "products": [], "targets": [] }"#
             }
             return ""
         }
@@ -543,7 +582,7 @@ class AnalyzerTests: AppTestCase {
                 commands.append(cmd.string)
             }
             if cmd.string.hasSuffix("swift package dump-package") {
-                return #"{ "name": "SPI-Server", "products": [] }"#
+                return #"{ "name": "SPI-Server", "products": [], "targets": [] }"#
             }
             return ""
         }
@@ -664,7 +703,26 @@ class AnalyzerTests: AppTestCase {
                 return ["1.0.0", "2.0.0"].joined(separator: "\n")
             }
             if cmd.string.hasSuffix("swift package dump-package") {
-                return #"{ "name": "foo", "products": [{"name":"p1","type":{"executable": null}}, {"name":"p2","type":{"executable": null}}] }"#
+                return #"""
+                    {
+                      "name": "foo",
+                      "products": [
+                        {
+                          "name": "p1",
+                          "type": {
+                            "executable": null
+                          }
+                        },
+                        {
+                          "name": "p2",
+                          "type": {
+                            "executable": null
+                          }
+                        }
+                      ],
+                      "targets": []
+                    }
+                    """#
             }
             if cmd.string.hasPrefix(#"git log -n1 --format=format:"%H-%ct""#) { return "sha-0" }
             if cmd.string == "git rev-list --count HEAD" { return "12" }

--- a/Tests/AppTests/ManifestTests.swift
+++ b/Tests/AppTests/ManifestTests.swift
@@ -41,11 +41,14 @@ class ManifestTests: XCTestCase {
         let data = try loadData(for: "manifest-1.json")
         let m = try JSONDecoder().decode(Manifest.self, from: data)
         XCTAssertEqual(m.name, "SPI-Server")
-        XCTAssertEqual(m.toolsVersion, .init(version: "5.2.0"))
         XCTAssertEqual(m.platforms, [.init(platformName: .macos, version: "10.15")])
         XCTAssertEqual(m.products, [.init(name: "Some Product",
                                           type: .library)])
         XCTAssertEqual(m.swiftLanguageVersions, ["4", "4.2", "5"])
+        XCTAssertEqual(m.targets, [.init(name: "App"),
+                                   .init(name: "Run"),
+                                   .init(name: "AppTests")])
+        XCTAssertEqual(m.toolsVersion, .init(version: "5.2.0"))
     }
 
     func test_decode_products_complex() throws {

--- a/Tests/AppTests/Mocks/Manifest+mock.swift
+++ b/Tests/AppTests/Mocks/Manifest+mock.swift
@@ -3,7 +3,7 @@
 
 extension Manifest {
     static var mock: Self {
-        .init(name: "MockManifest", products: [.mock])
+        .init(name: "MockManifest", products: [.mock], targets: [])
     }
 }
 

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -31,7 +31,7 @@ final class PackageTests: AppTestCase {
             let pkg = Package()  // avoid using init with default argument in order to test db default
             pkg.url = "1"
             try pkg.save(on: app.db).wait()
-            let readBack = try XCTUnwrap(try Package.query(on: app.db).first().wait())
+            let readBack = try XCTUnwrap(Package.query(on: app.db).first().wait())
             XCTAssertEqual(readBack.status, .new)
         }
         do {  // with status

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -122,7 +122,7 @@ class PipelineTests: AppTestCase {
         Current.fetchPackageList = { _ in self.future(urls.asURLs) }
         Current.shell.run = { cmd, path in
             if cmd.string.hasSuffix("swift package dump-package") {
-                return #"{ "name": "Mock", "products": [] }"#
+                return #"{ "name": "Mock", "products": [], "targets": [] }"#
             }
             if cmd.string.hasPrefix(#"git log -n1 --format=format:"%H-%ct""#) { return "sha-0" }
             if cmd.string == "git rev-list --count HEAD" { return "12" }

--- a/Tests/AppTests/TargetTests.swift
+++ b/Tests/AppTests/TargetTests.swift
@@ -8,13 +8,36 @@ import XCTVapor
 final class TargetTests: AppTestCase {
 
     func test_save() throws {
-        let t = Target(name: "target")
+        // setup
+        let v = Version()
+        try v.save(on: app.db).wait()
+        let t = try Target(version: v, name: "target")
+
+        // MUT
         try t.save(on: app.db).wait()
+
+        // validate
         let readBack = try XCTUnwrap(Target.query(on: app.db).first().wait())
         XCTAssertNotNil(readBack.id)
+        XCTAssertEqual(readBack.$version.id, v.id)
         XCTAssertNotNil(readBack.createdAt)
         XCTAssertNotNil(readBack.updatedAt)
         XCTAssertEqual(readBack.name, "target")
+    }
+
+    func test_delete_cascade() throws {
+        // setup
+        let v = Version()
+        try v.save(on: app.db).wait()
+        let t = try Target(version: v, name: "target")
+        try t.save(on: app.db).wait()
+        XCTAssertNotNil(try Target.query(on: app.db).first().wait())
+
+        // MUT
+        try v.delete(on: app.db).wait()
+
+        // validate
+        XCTAssertNil(try Target.query(on: app.db).first().wait())
     }
 
 }

--- a/Tests/AppTests/TargetTests.swift
+++ b/Tests/AppTests/TargetTests.swift
@@ -1,0 +1,20 @@
+@testable import App
+
+import Fluent
+import Vapor
+import XCTVapor
+
+
+final class TargetTests: AppTestCase {
+
+    func test_save() throws {
+        let t = Target(name: "target")
+        try t.save(on: app.db).wait()
+        let readBack = try XCTUnwrap(Target.query(on: app.db).first().wait())
+        XCTAssertNotNil(readBack.id)
+        XCTAssertNotNil(readBack.createdAt)
+        XCTAssertNotNil(readBack.updatedAt)
+        XCTAssertEqual(readBack.name, "target")
+    }
+
+}

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -241,7 +241,7 @@ class TwitterTests: AppTestCase {
         Current.fetchPackageList = { _ in self.future([url.url]) }
         Current.shell.run = { cmd, path in
             if cmd.string.hasSuffix("swift package dump-package") {
-                return #"{ "name": "Mock", "products": [] }"#
+                return #"{ "name": "Mock", "products": [], "targets": [] }"#
             }
             if cmd.string == "git tag" {
                 return tag }


### PR DESCRIPTION
This decodes target from package dumps and saves them to the new `targets` table. Like `products`, to which `targets` are siblings, these are 1-N related to `versions`.

One problem here is that because `targets` are tied to versions we will not populate them unless we encounter a new version for existing packages.

I'll add a new task to explore if we can somehow populate them independently. This might be difficult.

⚠️ NB: Schema change ⚠️

Fixes #870 