### PR TITLE
Package collection api

### DIFF
--- a/Sources/App/Controllers/API/API+PackageCollectionController.swift
+++ b/Sources/App/Controllers/API/API+PackageCollectionController.swift
@@ -7,6 +7,7 @@ extension API {
     struct PackageCollectionController {
 
         func generate(req: Request) throws -> EventLoopFuture<PackageCollection> {
+            // First try decoding "owner" type DTO
             if let dto = try? req.content.decode(PostPackageCollectionOwnerDTO.self) {
                 return PackageCollection.generate(
                     db: req.db,
@@ -18,7 +19,12 @@ extension API {
                     revision: dto.revision
                 )
             }
+
+            // Then try if it's "packageURLs" based
             let dto = try req.content.decode(PostPackageCollectionPackageUrlsDTO.self)
+            guard dto.packageUrls.count <= 20 else {
+                throw Abort(.badRequest)
+            }
             return PackageCollection.generate(
                 db: req.db,
                 packageURLs: dto.packageUrls,

--- a/Sources/App/Controllers/API/API+PackageCollectionController.swift
+++ b/Sources/App/Controllers/API/API+PackageCollectionController.swift
@@ -1,0 +1,29 @@
+import Fluent
+import Vapor
+
+
+extension API {
+
+    struct PackageCollectionController {
+
+        func get(req: Request) throws -> EventLoopFuture<PackageCollection> {
+            guard let owner = req.query[String.self, at: "owner"]
+            else {
+                return req.eventLoop.future(error: Abort(.notFound))
+            }
+
+            return PackageCollection.generate(
+                db: req.db,
+                name: owner,
+                overview: nil,
+                keywords: nil,
+                owner: owner,
+                generatedBy: .init(name: "Swift Package Index"))
+        }
+
+    }
+
+}
+
+
+extension PackageCollection: Content {}

--- a/Sources/App/Controllers/API/API+PackageCollectionController.swift
+++ b/Sources/App/Controllers/API/API+PackageCollectionController.swift
@@ -6,19 +6,18 @@ extension API {
 
     struct PackageCollectionController {
 
-        func get(req: Request) throws -> EventLoopFuture<PackageCollection> {
-            guard let owner = req.query[String.self, at: "owner"]
-            else {
-                return req.eventLoop.future(error: Abort(.notFound))
-            }
+        func generate(req: Request) throws -> EventLoopFuture<PackageCollection> {
+            let dto = try req.content.decode(PostPackageCollectionOwnerDTO.self)
 
             return PackageCollection.generate(
                 db: req.db,
-                name: owner,
-                overview: nil,
-                keywords: nil,
-                owner: owner,
-                generatedBy: .init(name: "Swift Package Index"))
+                owner: dto.owner,
+                authorName: dto.authorName ?? "Swift Package Index",
+                collectionName: dto.collectionName ?? dto.owner,
+                keywords: dto.keywords,
+                overview: dto.overview,
+                revision: dto.revision
+            )
         }
 
     }
@@ -27,3 +26,18 @@ extension API {
 
 
 extension PackageCollection: Content {}
+
+
+extension API {
+
+    struct PostPackageCollectionOwnerDTO: Codable {
+        var owner: String
+
+        var authorName: String?
+        var keywords: [String]?
+        var collectionName: String?
+        var overview: String?
+        var revision: Int?
+    }
+
+}

--- a/Sources/App/Controllers/API/API+PackageCollectionController.swift
+++ b/Sources/App/Controllers/API/API+PackageCollectionController.swift
@@ -7,13 +7,23 @@ extension API {
     struct PackageCollectionController {
 
         func generate(req: Request) throws -> EventLoopFuture<PackageCollection> {
-            let dto = try req.content.decode(PostPackageCollectionOwnerDTO.self)
-
+            if let dto = try? req.content.decode(PostPackageCollectionOwnerDTO.self) {
+                return PackageCollection.generate(
+                    db: req.db,
+                    owner: dto.owner,
+                    authorName: dto.authorName ?? "Swift Package Index",
+                    collectionName: dto.collectionName ?? dto.owner,
+                    keywords: dto.keywords,
+                    overview: dto.overview,
+                    revision: dto.revision
+                )
+            }
+            let dto = try req.content.decode(PostPackageCollectionPackageUrlsDTO.self)
             return PackageCollection.generate(
                 db: req.db,
-                owner: dto.owner,
+                packageURLs: dto.packageUrls,
                 authorName: dto.authorName ?? "Swift Package Index",
-                collectionName: dto.collectionName ?? dto.owner,
+                collectionName: dto.collectionName ?? "Package List",
                 keywords: dto.keywords,
                 overview: dto.overview,
                 revision: dto.revision
@@ -32,6 +42,16 @@ extension API {
 
     struct PostPackageCollectionOwnerDTO: Codable {
         var owner: String
+
+        var authorName: String?
+        var keywords: [String]?
+        var collectionName: String?
+        var overview: String?
+        var revision: Int?
+    }
+
+    struct PostPackageCollectionPackageUrlsDTO: Codable {
+        var packageUrls: [String]
 
         var authorName: String?
         var keywords: [String]?

--- a/Sources/App/Core/PackageCollection+generate.swift
+++ b/Sources/App/Core/PackageCollection+generate.swift
@@ -9,34 +9,36 @@ typealias PackageCollection = PackageCollectionModel.Collection
 extension PackageCollection {
 
     static func generate(db: Database,
-                         name: String,
-                         overview: String? = nil,
-                         keywords: [String]? = nil,
                          packageURLs: [String],
-                         generatedBy author: Author? = nil) -> EventLoopFuture<PackageCollection> {
+                         authorName: String? = nil,
+                         collectionName: String,
+                         keywords: [String]? = nil,
+                         overview: String? = nil,
+                         revision: Int? = nil) -> EventLoopFuture<PackageCollection> {
         packageQuery(db: db)
             .filter(\.$url ~~ packageURLs)
             .all()
             .mapEachCompact { Package.init(package:$0, keywords: keywords) }
             .map {
                 PackageCollection.init(
-                    name: name,
+                    name: collectionName,
                     overview: overview,
                     keywords: keywords,
                     packages: $0,
                     formatVersion: .v1_0,
-                    revision: nil,
+                    revision: revision,
                     generatedAt: Current.date(),
-                    generatedBy: author)
+                    generatedBy: authorName.map(Author.init(name:)))
             }
     }
 
     static func generate(db: Database,
-                         name: String,
-                         overview: String? = nil,
-                         keywords: [String]? = nil,
                          owner: String,
-                         generatedBy author: Author? = nil) -> EventLoopFuture<PackageCollection> {
+                         authorName: String? = nil,
+                         collectionName: String,
+                         keywords: [String]? = nil,
+                         overview: String? = nil,
+                         revision: Int? = nil) -> EventLoopFuture<PackageCollection> {
         packageQuery(db: db)
             .join(Repository.self, on: \App.Package.$id == \Repository.$package.$id)
             .filter(Repository.self, \.$owner == owner)
@@ -44,14 +46,14 @@ extension PackageCollection {
             .mapEachCompact { Package.init(package:$0, keywords: keywords) }
             .map {
                 PackageCollection.init(
-                    name: name,
+                    name: collectionName,
                     overview: overview,
                     keywords: keywords,
                     packages: $0,
                     formatVersion: .v1_0,
-                    revision: nil,
+                    revision: revision,
                     generatedAt: Current.date(),
-                    generatedBy: author)
+                    generatedBy: authorName.map(Author.init(name:)))
             }
     }
 

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -16,6 +16,7 @@ import Vapor
 
 enum Api: Resourceable {
     case packages(_ owner: Parameter<String>, _ repository: Parameter<String>, PackagesPathComponents)
+    case packageCollections
     case search
     case version
     case versions(_ id: Parameter<UUID>, VersionsPathComponents)
@@ -26,6 +27,8 @@ enum Api: Resourceable {
                 return "packages/\(owner)/\(repo)/\(next.path)"
             case .packages:
                 fatalError("path must not be called with a name parameter")
+            case .packageCollections:
+                return "package-collections"
             case .version:
                 return "version"
             case let .versions(.value(id), next):
@@ -43,6 +46,8 @@ enum Api: Resourceable {
                 return ["packages", ":owner", ":repository"] + remainder.pathComponents
             case .packages:
                 fatalError("pathComponents must not be called with a value parameter")
+            case .packageCollections:
+                return ["package-collections"]
             case .search, .version:
                 return [.init(stringLiteral: path)]
             case let .versions(.key, remainder):

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -45,8 +45,11 @@ func routes(_ app: Application) throws {
         app.get(SiteURL.api(.search).pathComponents, use: API.SearchController.get)
         app.get(SiteURL.api(.packages(.key, .key, .badge)).pathComponents,
                 use: API.PackageController().badge)
-        app.post(SiteURL.api(.packageCollections).pathComponents,
-                use: API.PackageCollectionController().generate)
+
+        if (try? Environment.detect()) ?? .development == .development {
+            app.post(SiteURL.api(.packageCollections).pathComponents,
+                     use: API.PackageCollectionController().generate)
+        }
 
         // protected routes
         app.group(User.TokenAuthenticator(), User.guardMiddleware()) { protected in

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -45,6 +45,8 @@ func routes(_ app: Application) throws {
         app.get(SiteURL.api(.search).pathComponents, use: API.SearchController.get)
         app.get(SiteURL.api(.packages(.key, .key, .badge)).pathComponents,
                 use: API.PackageController().badge)
+        app.get(SiteURL.api(.packageCollections).pathComponents,
+                use: API.PackageCollectionController().get)
 
         // protected routes
         app.group(User.TokenAuthenticator(), User.guardMiddleware()) { protected in

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -45,8 +45,8 @@ func routes(_ app: Application) throws {
         app.get(SiteURL.api(.search).pathComponents, use: API.SearchController.get)
         app.get(SiteURL.api(.packages(.key, .key, .badge)).pathComponents,
                 use: API.PackageController().badge)
-        app.get(SiteURL.api(.packageCollections).pathComponents,
-                use: API.PackageCollectionController().get)
+        app.post(SiteURL.api(.packageCollections).pathComponents,
+                use: API.PackageCollectionController().generate)
 
         // protected routes
         app.group(User.TokenAuthenticator(), User.guardMiddleware()) { protected in

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -407,4 +407,44 @@ class ApiTests: AppTestCase {
 
     }
 
+    func test_package_collection_owner() throws {
+        // setup
+        let refDate = Date(timeIntervalSince1970: 0)
+        Current.date = { refDate }
+        let p1 = Package(id: UUID(uuidString: "442cf59f-0135-4d08-be00-bc9a7cebabd3")!,
+                         url: "1")
+        try p1.save(on: app.db).wait()
+        let p2 = Package(id: UUID(uuidString: "4e256250-d1ea-4cdd-9fe9-0fc5dce17a80")!,
+                         url: "2")
+        try p2.save(on: app.db).wait()
+        try Repository(package: p1,
+                       summary: "some package",
+                       defaultBranch: "main").save(on: app.db).wait()
+        try Repository(package: p2,
+                       summary: "foo bar package",
+                       defaultBranch: "main",
+                       name: "name 2",
+                       owner: "foo").save(on: app.db).wait()
+        try Version(package: p1, packageName: "Foo", reference: .branch("main")).save(on: app.db).wait()
+        try Version(package: p2, packageName: "Bar", reference: .branch("main")).save(on: app.db).wait()
+        try Search.refresh(on: app.db).wait()
+
+        // MUT
+        try app.test(.GET, "/api/package-collections?owner=foo", afterResponse: { res in
+            // validation
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(
+                try res.content.decode(PackageCollection.self),
+                PackageCollection.init(name: "foo",
+                                       overview: nil,
+                                       keywords: nil,
+                                       packages: [],
+                                       formatVersion: .v1_0,
+                                       revision: nil,
+                                       generatedAt: refDate,
+                                       generatedBy: .init(name: "Swift Package Index"))
+            )
+        })
+    }
+
 }

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -528,4 +528,21 @@ class ApiTests: AppTestCase {
         }
     }
 
+    func test_package_collection_packageURLs_limit() throws {
+        let dto = API.PostPackageCollectionPackageUrlsDTO(
+            // request 21 urls - this should raise a 400
+            packageUrls: (0...20).map(String.init)
+        )
+        let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
+
+        try app.test(.POST,
+                     "api/package-collections",
+                     headers: .init([("Content-Type", "application/json")]),
+                     body: body,
+                     afterResponse: { res in
+                        // validation
+                        XCTAssertEqual(res.status, .badRequest)
+                     })
+    }
+
 }

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -430,15 +430,81 @@ class ApiTests: AppTestCase {
         try Search.refresh(on: app.db).wait()
 
         do {  // MUT
-            let dto = API.PostPackageCollectionOwnerDTO(
-                owner: "owner",
-                authorName: "author",
-                keywords: ["a", "b"],
-                collectionName: "my collection",
-                overview: "my overview",
-                revision: 3
-            )
-            let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
+            let body: ByteBuffer = .init(string: """
+                {
+                  "revision": 3,
+                  "authorName": "author",
+                  "owner": "owner",
+                  "keywords": [
+                    "a",
+                    "b"
+                  ],
+                  "collectionName": "my collection",
+                  "overview": "my overview"
+                }
+                """)
+
+            try app.test(.POST,
+                         "api/package-collections",
+                         headers: .init([("Content-Type", "application/json")]),
+                         body: body,
+                         afterResponse: { res in
+                // validation
+                XCTAssertEqual(res.status, .ok)
+                XCTAssertEqual(
+                    try res.content.decode(PackageCollection.self),
+                    PackageCollection.init(name: "my collection",
+                                           overview: "my overview",
+                                           keywords: ["a", "b"],
+                                           packages: [],
+                                           formatVersion: .v1_0,
+                                           revision: 3,
+                                           generatedAt: refDate,
+                                           generatedBy: .init(name: "author"))
+                )
+            })
+        }
+    }
+
+
+    func test_package_collection_packageURLs() throws {
+        // setup
+        let refDate = Date(timeIntervalSince1970: 0)
+        Current.date = { refDate }
+        let p1 = Package(id: UUID(uuidString: "442cf59f-0135-4d08-be00-bc9a7cebabd3")!,
+                         url: "1")
+        try p1.save(on: app.db).wait()
+        let p2 = Package(id: UUID(uuidString: "4e256250-d1ea-4cdd-9fe9-0fc5dce17a80")!,
+                         url: "2")
+        try p2.save(on: app.db).wait()
+        try Repository(package: p1,
+                       summary: "some package",
+                       defaultBranch: "main").save(on: app.db).wait()
+        try Repository(package: p2,
+                       summary: "foo bar package",
+                       defaultBranch: "main",
+                       name: "name 2",
+                       owner: "foo").save(on: app.db).wait()
+        try Version(package: p1, packageName: "Foo", reference: .branch("main")).save(on: app.db).wait()
+        try Version(package: p2, packageName: "Bar", reference: .branch("main")).save(on: app.db).wait()
+        try Search.refresh(on: app.db).wait()
+
+        do {  // MUT
+            let body: ByteBuffer = .init(string: """
+                {
+                  "revision": 3,
+                  "authorName": "author",
+                  "keywords": [
+                    "a",
+                    "b"
+                  ],
+                  "packageUrls": [
+                    "1"
+                  ],
+                  "collectionName": "my collection",
+                  "overview": "my overview"
+                }
+                """)
 
             try app.test(.POST,
                          "api/package-collections",

--- a/Tests/AppTests/PackageCollectionTests.swift
+++ b/Tests/AppTests/PackageCollectionTests.swift
@@ -149,11 +149,11 @@ class PackageCollectionTests: AppTestCase {
 
         // MUT
         let res = try PackageCollection.generate(db: self.app.db,
-                                                 name: "Foo",
-                                                 overview: "overview",
-                                                 keywords: ["key", "word"],
                                                  packageURLs: ["1"],
-                                                 generatedBy: .init(name: "Foo"))
+                                                 authorName: "Foo",
+                                                 collectionName: "Foo",
+                                                 keywords: ["key", "word"],
+                                                 overview: "overview")
             .wait()
 
         // validate
@@ -241,11 +241,11 @@ class PackageCollectionTests: AppTestCase {
 
         // MUT
         let res = try PackageCollection.generate(db: self.app.db,
-                                                 name: "Foo",
-                                                 overview: "overview",
-                                                 keywords: ["key", "word"],
                                                  owner: "foo",
-                                                 generatedBy: .init(name: "Foo"))
+                                                 authorName: "Foo",
+                                                 collectionName: "Foo",
+                                                 keywords: ["key", "word"],
+                                                 overview: "overview")
             .wait()
 
         // validate

--- a/Tests/AppTests/SiteURLTests.swift
+++ b/Tests/AppTests/SiteURLTests.swift
@@ -98,6 +98,8 @@ class SiteURLTests: XCTestCase {
         XCTAssertEqual(SiteURL.api(.packages(.key, .key, .badge))
                         .pathComponents.map(\.description),
                        ["api", "packages", ":owner", ":repository", "badge"])
+        XCTAssertEqual(SiteURL.api(.packageCollections).pathComponents.map(\.description),
+                       ["api", "package-collections"])
     }
     
     func test_apiBaseURL() throws {

--- a/restfiles/generate-package-collection.restfile
+++ b/restfiles/generate-package-collection.restfile
@@ -1,0 +1,26 @@
+variables:
+    base_url: http://localhost:8080/api
+    # base_url: https://staging.swiftpackageindex.com/api
+
+requests:
+
+    generate:
+        url: ${base_url}/package-collections
+        method: POST
+        body:
+            json:
+                owner: finestructure
+                # or
+                # packageUrls:
+                #    - https://github.com/finestructure/Arena.git
+                #    - https://github.com/finestructure/Rester.git
+                authorName: foo
+                collectionName: my collection
+                keywords:
+                    - a
+                    - b
+                overview: my overview
+                revision: 3    
+        validation:
+            status: 200
+        log: json


### PR DESCRIPTION
Adds a simple API endpoint to generate package collections for either a given "owner" (a Github user or organisation) or a list of package URLs.

See the restfile for example usage and the additional parameters the API supports.

The number of package urls that can be requested is limited to 20.