### PR TITLE
Log more build details

### DIFF
--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -162,7 +162,7 @@ func triggerBuildsUnchecked(on database: Database,
                             logger: Logger,
                             triggers: [BuildTriggerInfo]) -> EventLoopFuture<Void> {
     triggers.flatMap { trigger -> [EventLoopFuture<Void>] in
-        logger.info("Triggering \(trigger.pairs.count) builds for version id: \(trigger.versionId)")
+        logger.info("Triggering \(trigger.pairs.count) builds for package id: \(trigger.packageId), ref: \(trigger.reference)")
         return trigger.pairs.map { pair in
             AppMetrics.buildTriggerTotal?.inc(1, .init(pair.platform, pair.swiftVersion))
             return Build.trigger(database: database,
@@ -240,10 +240,18 @@ struct BuildPair: Equatable, Hashable {
 struct BuildTriggerInfo: Equatable {
     var versionId: Version.Id
     var pairs: Set<BuildPair>
+    // non-essential fields, used for logging
+    var packageId: Package.Id?
+    var reference: Reference?
 
-    init(_ versionId: Version.Id, _ pairs: Set<BuildPair>) {
+    init(versionId: Version.Id,
+         pairs: Set<BuildPair>,
+         packageId: Package.Id? = nil,
+         reference: Reference? = nil) {
         self.versionId = versionId
         self.pairs = pairs
+        self.packageId = packageId
+        self.reference = reference
     }
 }
 
@@ -260,7 +268,10 @@ func findMissingBuilds(_ database: Database,
         guard let versionId = v.id else { return nil }
         let existing = v.builds.map { BuildPair($0.platform, $0.swiftVersion) }
         let pairs = Set(BuildPair.all).subtracting(Set(existing))
-        return BuildTriggerInfo(versionId, pairs)
+        return BuildTriggerInfo(versionId: versionId,
+                                pairs: pairs,
+                                packageId: packageId,
+                                reference: v.reference)
     }
 }
 

--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -162,7 +162,7 @@ func triggerBuildsUnchecked(on database: Database,
                             logger: Logger,
                             triggers: [BuildTriggerInfo]) -> EventLoopFuture<Void> {
     triggers.flatMap { trigger -> [EventLoopFuture<Void>] in
-        logger.info("Triggering \(trigger.pairs.count) builds for package id: \(trigger.packageId), ref: \(trigger.reference)")
+        logger.info("Triggering \(trigger.pairs.count) builds for package name: \(trigger.packageName), ref: \(trigger.reference), id: \(trigger.packageId)")
         return trigger.pairs.map { pair in
             AppMetrics.buildTriggerTotal?.inc(1, .init(pair.platform, pair.swiftVersion))
             return Build.trigger(database: database,
@@ -242,15 +242,18 @@ struct BuildTriggerInfo: Equatable {
     var pairs: Set<BuildPair>
     // non-essential fields, used for logging
     var packageId: Package.Id?
+    var packageName: String?
     var reference: Reference?
 
     init(versionId: Version.Id,
          pairs: Set<BuildPair>,
          packageId: Package.Id? = nil,
+         packageName: String? = nil,
          reference: Reference? = nil) {
         self.versionId = versionId
         self.pairs = pairs
         self.packageId = packageId
+        self.packageName = packageName
         self.reference = reference
     }
 }
@@ -271,6 +274,7 @@ func findMissingBuilds(_ database: Database,
         return BuildTriggerInfo(versionId: versionId,
                                 pairs: pairs,
                                 packageId: packageId,
+                                packageName: v.packageName,
                                 reference: v.reference)
     }
 }

--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -162,7 +162,7 @@ func triggerBuildsUnchecked(on database: Database,
                             logger: Logger,
                             triggers: [BuildTriggerInfo]) -> EventLoopFuture<Void> {
     triggers.flatMap { trigger -> [EventLoopFuture<Void>] in
-        logger.info("Triggering \(trigger.pairs.count) builds for package name: \(trigger.packageName), ref: \(trigger.reference), id: \(trigger.packageId)")
+        logger.info("Triggering \(trigger.pairs.count) builds for package name: \(trigger.packageName), ref: \(trigger.reference)")
         return trigger.pairs.map { pair in
             AppMetrics.buildTriggerTotal?.inc(1, .init(pair.platform, pair.swiftVersion))
             return Build.trigger(database: database,
@@ -241,18 +241,15 @@ struct BuildTriggerInfo: Equatable {
     var versionId: Version.Id
     var pairs: Set<BuildPair>
     // non-essential fields, used for logging
-    var packageId: Package.Id?
     var packageName: String?
     var reference: Reference?
 
     init(versionId: Version.Id,
          pairs: Set<BuildPair>,
-         packageId: Package.Id? = nil,
          packageName: String? = nil,
          reference: Reference? = nil) {
         self.versionId = versionId
         self.pairs = pairs
-        self.packageId = packageId
         self.packageName = packageName
         self.reference = reference
     }
@@ -273,7 +270,6 @@ func findMissingBuilds(_ database: Database,
         let pairs = Set(BuildPair.all).subtracting(Set(existing))
         return BuildTriggerInfo(versionId: versionId,
                                 pairs: pairs,
-                                packageId: packageId,
                                 packageName: v.packageName,
                                 reference: v.reference)
     }

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -80,7 +80,9 @@ class BuildTriggerTests: AppTestCase {
         let res = try findMissingBuilds(app.db, packageId: pkgId).wait()
         let droppedPlatform = try XCTUnwrap(Build.Platform.allActive.first)
         let expectedPairs = Set(SwiftVersion.allActive.map { BuildPair(droppedPlatform, $0) })
-        XCTAssertEqual(res, [.init(versionId, expectedPairs)])
+        XCTAssertEqual(res, [.init(versionId: versionId,
+                                   pairs: expectedPairs,
+                                   packageId: pkgId)])
     }
 
     func test_triggerBuildsUnchecked() throws {
@@ -105,7 +107,8 @@ class BuildTriggerTests: AppTestCase {
             let v = try Version(id: versionId, package: p, latest: .defaultBranch, reference: .branch("main"))
             try v.save(on: app.db).wait()
         }
-        let triggers = [BuildTriggerInfo(versionId, [BuildPair(.ios, .v4_2)])]
+        let triggers = [BuildTriggerInfo(versionId: versionId,
+                                         pairs: [BuildPair(.ios, .v4_2)])]
 
         // MUT
         try triggerBuildsUnchecked(on: app.db,

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -81,8 +81,7 @@ class BuildTriggerTests: AppTestCase {
         let droppedPlatform = try XCTUnwrap(Build.Platform.allActive.first)
         let expectedPairs = Set(SwiftVersion.allActive.map { BuildPair(droppedPlatform, $0) })
         XCTAssertEqual(res, [.init(versionId: versionId,
-                                   pairs: expectedPairs,
-                                   packageId: pkgId)])
+                                   pairs: expectedPairs)])
     }
 
     func test_triggerBuildsUnchecked() throws {

--- a/Tests/AppTests/MetricsTests.swift
+++ b/Tests/AppTests/MetricsTests.swift
@@ -18,7 +18,11 @@ class MetricsTests: AppTestCase {
         try triggerBuildsUnchecked(on: app.db,
                                client: app.client,
                                logger: app.logger,
-                               triggers: [.init(versionId, [.init(.macosSpm, .v5_3)])]).wait()
+                               triggers: [
+                                .init(versionId: versionId,
+                                      pairs: [.init(.macosSpm, .v5_3)])
+                               ]
+        ).wait()
 
         // MUT
         try app.test(.GET, "metrics", afterResponse: { res in


### PR DESCRIPTION
Merge after #889 so we can benefit from its string interpolation of options, which will turn

```
2021-01-22T11:22:28+0100 info codes.vapor.application : Triggering 32 builds for package name: nil, ref: Optional(main), id: Optional(005AF96B-8214-4F35-899E-FCDD434C6EA0)
```

into

```
2021-01-22T11:22:28+0100 info codes.vapor.application : Triggering 32 builds for package name: nil, ref: main, id: 005AF96B-8214-4F35-899E-FCDD434C6EA0
```
