### PR TITLE
Fix bad escape string

### DIFF
--- a/infrastructure/promtail/promtail.yaml
+++ b/infrastructure/promtail/promtail.yaml
@@ -19,7 +19,7 @@ scrape_configs:
     pipeline_stages:
       - docker: {}
       - regex:
-          expression: "\\[component:\\s*(?P<component>\[\w,-]+)\\]"
+          expression: "\\[component:\\s*(?P<component>[\\w,-]+)\\]"
       - labels:
           component:
       - drop:


### PR DESCRIPTION
Fixes #907 

Deployed to `dev` for testing:

<img width="488" alt="CleanShot 2021-02-01 at 09 14 26@2x" src="https://user-images.githubusercontent.com/65520/106431746-03ed5e00-646e-11eb-8f18-9614e46bd965.png">
