### PR TITLE
Pull out some unrelated tidying up

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -61,11 +61,7 @@ func analyze(client: Client,
              logger: Logger,
              threadPool: NIOThreadPool,
              id: Package.Id) -> EventLoopFuture<Void> {
-    Package.query(on: database)
-        .with(\.$repositories)
-        .filter(\.$id == id)
-        .first()
-        .unwrap(or: Abort(.notFound))
+    Package.fetchCandidate(database, id: id)
         .map { [$0] }
         .flatMap {
             analyze(client: client,

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -49,11 +49,7 @@ func ingest(client: Client,
             database: Database,
             logger: Logger,
             id: Package.Id) -> EventLoopFuture<Void> {
-    Package.query(on: database)
-        .with(\.$repositories)
-        .filter(\.$id == id)
-        .first()
-        .unwrap(or: Abort(.notFound))
+    Package.fetchCandidate(database, id: id)
         .map { [$0] }
         .flatMap { packages in
             ingest(client: client,

--- a/Sources/App/Commands/ReAnalyzeVersions.swift
+++ b/Sources/App/Commands/ReAnalyzeVersions.swift
@@ -73,11 +73,7 @@ func reAnalyzeVersions(client: Client,
                        threadPool: NIOThreadPool,
                        versionsLastUpdatedBefore cutOffDate: Date,
                        id: Package.Id) -> EventLoopFuture<Void> {
-    Package.query(on: database)
-        .with(\.$repositories)
-        .filter(\.$id == id)
-        .first()
-        .unwrap(or: Abort(.notFound))
+    Package.fetchCandidate(database, id: id)
         .map { [$0] }
         .flatMap { reAnalyzeVersions(client: client,
                                      database: database,

--- a/Sources/App/Core/Git.swift
+++ b/Sources/App/Core/Git.swift
@@ -62,12 +62,12 @@ enum Git {
     
     static func revisionInfo(_ reference: Reference, at path: String) throws -> RevisionInfo {
         let safe = sanitizeInput("\(reference)")
-        let dash = "-"
+        let separator = "-"
         let res = try Current.shell.run(
-            command: .init(string: #"git log -n1 --format=format:"%H\#(dash)%ct" "\#(safe)""#),
+            command: .init(string: #"git log -n1 --format=format:"%H\#(separator)%ct" "\#(safe)""#),
             at: path
         )
-        let parts = res.components(separatedBy: dash)
+        let parts = res.components(separatedBy: separator)
         guard parts.count == 2 else { throw GitError.invalidRevisionInfo }
         let hash = parts[0]
         guard let timestamp = TimeInterval(parts[1]) else { throw GitError.invalidTimestamp }

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -220,6 +220,15 @@ extension QueryBuilder where Model == Package {
 
 
 extension Package {
+    static func fetchCandidate(_ database: Database,
+                               id: Id) -> EventLoopFuture<Package> {
+        Package.query(on: database)
+            .with(\.$repositories)
+            .filter(\.$id == id)
+            .first()
+            .unwrap(or: Abort(.notFound))
+    }
+
     static func fetchCandidates(_ database: Database,
                                 for stage: ProcessingStage,
                                 limit: Int) -> EventLoopFuture<[Package]> {

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -148,17 +148,3 @@ extension Repository: Equatable {
         lhs.id == rhs.id
     }
 }
-
-
-extension Repository {
-    static func defaultBranch(on db: Database, for package: Package) -> EventLoopFuture<String?> {
-        do {
-            return try Repository.query(on: db)
-                .filter(\.$package.$id == package.requireID())
-                .first()
-                .map { $0?.defaultBranch }
-        } catch {
-            return db.eventLoop.makeSucceededFuture(nil)
-        }
-    }
-}

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -448,11 +448,13 @@ class AnalyzerTests: AppTestCase {
             if cmd.string == #"git log -n1 --format=format:"%H-%ct" "1.2.3""# { return "sha.1.2.3-1" }
             throw TestError.unknownCommand
         }
-        let pkg = Package(id: UUID(), url: "1".asGithubUrl.url)
-        try pkg.save(on: app.db).wait()
-        try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
-        // fetch relationship, which is what `fetchCandidates` does
-        try pkg.$repositories.load(on: app.db).wait()
+        let pkgId = UUID()
+        do {
+            let pkg = Package(id: pkgId, url: "1".asGithubUrl.url)
+            try pkg.save(on: app.db).wait()
+            try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
+        }
+        let pkg = try Package.fetchCandidate(app.db, id: pkgId).wait()
 
         // MUT
         let delta = try diffVersions(client: app.client,

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -451,13 +451,15 @@ class AnalyzerTests: AppTestCase {
         let pkg = Package(id: UUID(), url: "1".asGithubUrl.url)
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
+        // fetch relationship, which is what `fetchCandidates` does
+        try pkg.$repositories.load(on: app.db).wait()
 
         // MUT
         let delta = try diffVersions(client: app.client,
-                                        logger: app.logger,
-                                        threadPool: app.threadPool,
-                                        transaction: app.db,
-                                        package: pkg).wait()
+                                     logger: app.logger,
+                                     threadPool: app.threadPool,
+                                     transaction: app.db,
+                                     package: pkg).wait()
 
         // validate
         assertEquals(delta.toAdd, \.reference,
@@ -489,6 +491,8 @@ class AnalyzerTests: AppTestCase {
             .failure(AppError.invalidPackageUrl(nil, "some reason")),
             .success(pkg)
         ]
+        // fetch relationship, which is what `fetchCandidates` does
+        try pkg.$repositories.load(on: app.db).wait()
 
         // MUT
         let results = try diffVersions(client: app.client,

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -120,20 +120,6 @@ final class RepositoryTests: AppTestCase {
         XCTAssertEqual(try Repository.query(on: app.db).count().wait(), 0)
     }
     
-    func test_defaultBranch() throws {
-        // setup
-        let pkg = Package(id: UUID(), url: "1")
-        let repo = try Repository(id: UUID(), package: pkg, defaultBranch: "default")
-        try pkg.save(on: app.db).wait()
-        try repo.save(on: app.db).wait()
-        
-        // MUT
-        let b = try Repository.defaultBranch(on: app.db, for: pkg).wait()
-        
-        // validate
-        XCTAssertEqual(b, "default")
-    }
-    
     func test_uniqueOwnerRepository() throws {
         // Ensure owner/repository is unique, testing various combinations with
         // matching/non-matching case


### PR DESCRIPTION
Get these out of the big PR for the build throttling to reduce the overall footprint:

- remove `Repository.defaultBranch`, which was redundant
- factor out single id candidate fetching into `Package.fetchCandidate`
- tidy up `separator` naming in `Git.revisionInfo`