### PR TITLE
Simplified snapshot testing setup

### DIFF
--- a/Tests/AppTests/MaintainerInfoIndexModelTests.swift
+++ b/Tests/AppTests/MaintainerInfoIndexModelTests.swift
@@ -4,13 +4,7 @@ import XCTVapor
 import SnapshotTesting
 
 
-class MaintainerInfoIndexModelTests: AppTestCase {
-    
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-
-        SnapshotTesting.isRecording = false
-    }
+class MaintainerInfoIndexModelTests: SnapshotTestCase {
 
     func test_badgeURL() throws {
         Current.siteURL = { "https://spi.com" }

--- a/Tests/AppTests/MarkdownHTMLConverterTests.swift
+++ b/Tests/AppTests/MarkdownHTMLConverterTests.swift
@@ -6,7 +6,7 @@ import XCTest
 import Plot
 
 
-class MarkdownHTMLConverterTests: XCTestCase {
+class MarkdownHTMLConverterTests: WebpageSnapshotTestCase {
     
     class MarkdownConverterPage: PublicPage {
         let markdown: String
@@ -28,20 +28,7 @@ class MarkdownHTMLConverterTests: XCTestCase {
             }
         }
     }
-    
-    override func setUpWithError() throws {
-        try super .setUpWithError()
 
-        try XCTSkipIf((Environment.get("SKIP_SNAPSHOTS") ?? "false") == "true")
-        Current.date = { Date(timeIntervalSince1970: 0) }
-        TempWebRoot.cleanup()
-        SnapshotTesting.isRecording = false
-    }
-    
-    override class func setUp() {
-        TempWebRoot.setup()
-    }
-    
     func test_MarkdownConverter() throws {
         let data = try XCTUnwrap(try loadData(for: "markdown-test.md"))
         let markdown = try XCTUnwrap(String(data: data, encoding: .utf8))

--- a/Tests/AppTests/PackageShowModelTests.swift
+++ b/Tests/AppTests/PackageShowModelTests.swift
@@ -4,13 +4,7 @@ import XCTVapor
 import SnapshotTesting
 
 
-class PackageShowModelTests: AppTestCase {
-    
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-
-        SnapshotTesting.isRecording = false
-    }
+class PackageShowModelTests: SnapshotTestCase {
 
     func test_init_no_title() throws {
         // Tests behaviour when we're lacking data

--- a/Tests/AppTests/RSSTests.swift
+++ b/Tests/AppTests/RSSTests.swift
@@ -4,13 +4,8 @@ import SnapshotTesting
 import XCTVapor
 
 
-class RSSTests: AppTestCase {
-    
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        SnapshotTesting.isRecording = false
-    }
-    
+class RSSTests: SnapshotTestCase {
+
     func test_render_item() throws {
         let item = RecentPackage(id: UUID(),
                                  repositoryOwner: "owner",

--- a/Tests/AppTests/SitemapTests.swift
+++ b/Tests/AppTests/SitemapTests.swift
@@ -5,13 +5,8 @@ import SnapshotTesting
 import XCTVapor
 
 
-class SitemapTests: AppTestCase {
-    
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        SnapshotTesting.isRecording = false
-    }
-    
+class SitemapTests: SnapshotTestCase {
+
     func test_fetchPackages() throws {
         // Test fetching all record in the search view
         // setup

--- a/Tests/AppTests/SnapshotTestCase.swift
+++ b/Tests/AppTests/SnapshotTestCase.swift
@@ -1,0 +1,11 @@
+import SnapshotTesting
+
+
+class SnapshotTestCase: AppTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        SnapshotTesting.isRecording = false
+        SnapshotTesting.diffTool = "ksdiff"
+    }
+}

--- a/Tests/AppTests/SnapshotTestCase.swift
+++ b/Tests/AppTests/SnapshotTestCase.swift
@@ -2,8 +2,9 @@ import SnapshotTesting
 
 
 class SnapshotTestCase: AppTestCase {
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+
+    override class func setUp() {
+        super.setUp()
 
         SnapshotTesting.isRecording = false
         SnapshotTesting.diffTool = "ksdiff"

--- a/Tests/AppTests/WebpageSnapshotTestCase.swift
+++ b/Tests/AppTests/WebpageSnapshotTestCase.swift
@@ -1,0 +1,18 @@
+@testable import App
+
+import XCTVapor
+
+
+class WebpageSnapshotTestCase: SnapshotTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        try XCTSkipIf((Environment.get("SKIP_SNAPSHOTS") ?? "false") == "true")
+        Current.date = { Date(timeIntervalSince1970: 0) }
+        TempWebRoot.cleanup()
+    }
+
+    override class func setUp() {
+        TempWebRoot.setup()
+    }
+}

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -19,21 +19,8 @@ let configs: [(name: String, size: CGSize)] = [
 ]
 
 
-class WebpageSnapshotTests: XCTestCase {
-    
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+class WebpageSnapshotTests: WebpageSnapshotTestCase {
 
-        try XCTSkipIf((Environment.get("SKIP_SNAPSHOTS") ?? "false") == "true")
-        Current.date = { Date(timeIntervalSince1970: 0) }
-        TempWebRoot.cleanup()
-        SnapshotTesting.isRecording = false
-    }
-    
-    override class func setUp() {
-        TempWebRoot.setup()
-    }
-    
     func test_HomeIndexView() throws {
         let page = { HomeIndex.View(path: "/", model: .mock).document() }
         


### PR DESCRIPTION
Merge after #948 

As discussed, simplification of the setup for snapshot test cases. You may not want the second level of abstraction here, it's easy to remove if we decide it's overkill, but the TempWebRoot stuff only needs configuring for web page snapshot tests.