### PR TITLE
Snapshot precision

### DIFF
--- a/Tests/AppTests/MarkdownHTMLConverterTests.swift
+++ b/Tests/AppTests/MarkdownHTMLConverterTests.swift
@@ -46,7 +46,7 @@ class MarkdownHTMLConverterTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: { page.document() },
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)

--- a/Tests/AppTests/MarkdownHTMLConverterTests.swift
+++ b/Tests/AppTests/MarkdownHTMLConverterTests.swift
@@ -46,7 +46,9 @@ class MarkdownHTMLConverterTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: { page.document() },
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }

--- a/Tests/AppTests/WebpageSnapshotTestCase.swift
+++ b/Tests/AppTests/WebpageSnapshotTestCase.swift
@@ -4,6 +4,8 @@ import XCTVapor
 
 
 class WebpageSnapshotTestCase: SnapshotTestCase {
+    let defaultPrecision: Float = 0.999
+
     override func setUpWithError() throws {
         try super.setUpWithError()
 

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -30,7 +30,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -46,7 +48,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -65,7 +69,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -84,7 +90,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -103,7 +111,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -122,7 +132,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -141,7 +153,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -162,7 +176,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -209,7 +225,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -225,7 +243,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -241,7 +261,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -262,7 +284,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
                 var mutableSize = $0.size
                 mutableSize.height = 3000
                 assertSnapshot(matching: page,
-                               as: .image(size: mutableSize, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: mutableSize,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -278,7 +302,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -294,7 +320,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -310,7 +338,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -326,7 +356,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }
@@ -342,7 +374,9 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(size: $0.size, baseURL: TempWebRoot.baseURL),
+                               as: .image(precision: 0.999,
+                                          size: $0.size,
+                                          baseURL: TempWebRoot.baseURL),
                                named: $0.name)
             }
         }

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -30,7 +30,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -48,7 +48,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -69,7 +69,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -90,7 +90,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -111,7 +111,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -132,7 +132,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -153,7 +153,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -176,7 +176,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -225,7 +225,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -243,7 +243,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -261,7 +261,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -284,7 +284,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
                 var mutableSize = $0.size
                 mutableSize.height = 3000
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: mutableSize,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -302,7 +302,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -320,7 +320,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)
@@ -374,7 +374,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         if !isRunningInCI {
             configs.forEach {
                 assertSnapshot(matching: page,
-                               as: .image(precision: 0.999,
+                               as: .image(precision: defaultPrecision,
                                           size: $0.size,
                                           baseURL: TempWebRoot.baseURL),
                                named: $0.name)


### PR DESCRIPTION
Fixes snapshot failures on M1 (but drastically increases test run time, some improvements proposed upstream: https://github.com/pointfreeco/swift-snapshot-testing/pull/435)