### PR TITLE
Make the resourceReloadString be based on local file modification date rather than the current time.

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ build:
     - ceres
   script: |
     VERSION=${CI_COMMIT_TAG:-$CI_COMMIT_SHA}
-    echo 'let appVersion = "'${VERSION}'"' > ./Sources/App/Core/AppVersion.swift
+    echo 'let appVersion: String? = "'${VERSION}'"' > ./Sources/App/Core/AppVersion.swift
 
     docker run --rm -v $PWD:/host -w /host --entrypoint sh node:15.8-alpine /usr/local/bin/yarn && /usr/local/bin/yarn build
     docker build -t $REGISTRY_IMAGE:$VERSION .

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -5,6 +5,7 @@ import Vapor
 struct AppEnvironment {
     var allowBuildTriggers: () -> Bool
     var allowTwitterPosts: () -> Bool
+    var appVersion: () -> String?
     var builderToken: () -> String?
     var buildTriggerDownscaling: () -> Double
     var date: () -> Date
@@ -49,6 +50,7 @@ extension AppEnvironment {
                 .flatMap(\.asBool)
                 ?? Constants.defaultAllowTwitterPosts
         },
+        appVersion: { App.appVersion },
         builderToken: { Environment.get("BUILDER_TOKEN") },
         buildTriggerDownscaling: {
             Environment.get("BUILD_TRIGGER_DOWNSCALING")
@@ -108,13 +110,6 @@ extension AppEnvironment {
         twitterPostTweet: Twitter.post(client:tweet:)
     )
 }
-
-extension AppEnvironment {
-    static func isRunningUnderTest() -> Bool {
-        ProcessInfo.processInfo.environment.keys.contains("XCTestSessionIdentifier")
-    }
-}
-
 
 struct FileManager {
     var checkoutsDirectory: () -> String

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -109,6 +109,12 @@ extension AppEnvironment {
     )
 }
 
+extension AppEnvironment {
+    static func isRunningUnderTest() -> Bool {
+        ProcessInfo.processInfo.environment.keys.contains("XCTestSessionIdentifier")
+    }
+}
+
 
 struct FileManager {
     var checkoutsDirectory: () -> String

--- a/Sources/App/Core/AppVersion.swift
+++ b/Sources/App/Core/AppVersion.swift
@@ -1,4 +1,8 @@
 // In a local development environment, appVersion will remain nil (as set here).
 // In the staging development environment, appVersion is set to the commit hash of the deployed version.
 // In production, appVersion is set either to released tag name, or to the commit hash if that does not exist.
+
+// Note: If the definition of appVersion ever changes, the `gitlab-ci.yml` file also
+// needs updating as this file is re-generated during the deployment process.
+
 let appVersion: String? = nil

--- a/Sources/App/Core/AppVersion.swift
+++ b/Sources/App/Core/AppVersion.swift
@@ -1,1 +1,4 @@
-let appVersion = "dev - will be overriden in release builds"
+// In a local development environment, appVersion will remain nil (as set here).
+// In the staging development environment, appVersion is set to the commit hash of the deployed version.
+// In production, appVersion is set either to released tag name, or to the commit hash if that does not exist.
+let appVersion: String? = nil

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -127,6 +127,9 @@ class PublicPage {
         if let appVersion = appVersion {
             return appVersion
         } else {
+            // Running under test? It's annoying to need to update snapshots every time the CSS or JS is saved.
+            if let _ = NSClassFromString("XCTest") { return "test" }
+
             // Return the date of the most recently modified between the JavaScript and CSS resources.
             let jsModificationDate = modificationDate(forLocalResource: "main.js")
             let cssModificationDate = modificationDate(forLocalResource: "main.css")

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -101,15 +101,37 @@ class PublicPage {
                     """))
     }
 
-    /// A query string that will force resources to reload after they change. In development this is the
-    /// current date, to force a reload every time. In production this is the date of the last deploy.
+    /// A query string that will force resources to reload CSS/JS resources change.
     /// - Returns: A string containing the query string.
     final func resourceReloadQueryString() -> String {
-        let secondsSince1970String = String(Int(Current.date().timeIntervalSince1970))
-        do {
-            return (try Environment.detect() == .development) ? secondsSince1970String : appVersion
-        } catch {
-            return secondsSince1970String
+
+        // This method is only called in a local development environment, so all paths
+        // can be relative to this source file.
+        func modificationDate(for resource: String) -> Date {
+            let relativePathToPublic = "../../../Public/"
+            let url = URL(fileURLWithPath: relativePathToPublic + resource,
+                relativeTo: URL(fileURLWithPath: #file))
+
+            // Assume the file has been modified *now* if the file can't be found.
+            guard let attributes = try? Foundation.FileManager.default.attributesOfItem(atPath: url.absoluteString)
+            else { return Date() }
+
+            // Also assume the file is modified now if the attribute doesn't exist.
+            let modificationDate = attributes[FileAttributeKey.modificationDate] as? Date
+            return modificationDate ?? Date()
+        }
+
+
+        // In staging or production appVersion will be set to a commit hash, or a tag name.
+        // It will only ever be nil when running in a local development environment.
+        if let appVersion = appVersion {
+            return appVersion
+        } else {
+            // Return the date of the most recently modified between the JavaScript and CSS resources.
+            let jsModificationDate = modificationDate(for: "main.js")
+            let cssModificationDate = modificationDate(for: "main.css")
+            let latestModificationDate = max(jsModificationDate, cssModificationDate)
+            return String(Int(latestModificationDate.timeIntervalSince1970))
         }
     }
     

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -124,12 +124,9 @@ class PublicPage {
 
         // In staging or production appVersion will be set to a commit hash, or a tag name.
         // It will only ever be nil when running in a local development environment.
-        if let appVersion = appVersion {
+        if let appVersion = Current.appVersion() {
             return appVersion
         } else {
-            // Running under test? It's annoying to need to update snapshots every time the CSS or JS is saved.
-            if AppEnvironment.isRunningUnderTest() { return "test" }
-
             // Return the date of the most recently modified between the JavaScript and CSS resources.
             let jsModificationDate = modificationDate(forLocalResource: "main.js")
             let cssModificationDate = modificationDate(forLocalResource: "main.css")

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -107,7 +107,7 @@ class PublicPage {
 
         // This method is only called in a local development environment, so all paths
         // can be relative to this source file.
-        func modificationDate(for resource: String) -> Date {
+        func modificationDate(forLocalResource resource: String) -> Date {
             let relativePathToPublic = "../../../Public/"
             let url = URL(fileURLWithPath: relativePathToPublic + resource,
                 relativeTo: URL(fileURLWithPath: #file))
@@ -128,8 +128,8 @@ class PublicPage {
             return appVersion
         } else {
             // Return the date of the most recently modified between the JavaScript and CSS resources.
-            let jsModificationDate = modificationDate(for: "main.js")
-            let cssModificationDate = modificationDate(for: "main.css")
+            let jsModificationDate = modificationDate(forLocalResource: "main.js")
+            let cssModificationDate = modificationDate(forLocalResource: "main.css")
             let latestModificationDate = max(jsModificationDate, cssModificationDate)
             return String(Int(latestModificationDate.timeIntervalSince1970))
         }

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -113,7 +113,7 @@ class PublicPage {
                 relativeTo: URL(fileURLWithPath: #file))
 
             // Assume the file has been modified *now* if the file can't be found.
-            guard let attributes = try? Foundation.FileManager.default.attributesOfItem(atPath: url.absoluteString)
+            guard let attributes = try? Foundation.FileManager.default.attributesOfItem(atPath: url.path)
             else { return Date() }
 
             // Also assume the file is modified now if the attribute doesn't exist.

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -128,7 +128,7 @@ class PublicPage {
             return appVersion
         } else {
             // Running under test? It's annoying to need to update snapshots every time the CSS or JS is saved.
-            if let _ = NSClassFromString("XCTest") { return "test" }
+            if AppEnvironment.isRunningUnderTest() { return "test" }
 
             // Return the date of the most recently modified between the JavaScript and CSS resources.
             let jsModificationDate = modificationDate(forLocalResource: "main.js")

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -44,7 +44,10 @@ func routes(_ app: Application) throws {
     do {  // api
 
         // public routes
-        app.get(SiteURL.api(.version).pathComponents) { req in API.Version(version: appVersion) }
+        app.get(SiteURL.api(.version).pathComponents) { req in
+            API.Version(version: appVersion ?? "Unknown")
+        }
+
         app.get(SiteURL.api(.search).pathComponents, use: API.SearchController.get)
         app.get(SiteURL.api(.packages(.key, .key, .badge)).pathComponents,
                 use: API.PackageController().badge)

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -9,8 +9,7 @@ class ApiTests: AppTestCase {
     func test_version() throws {
         try app.test(.GET, "api/version", afterResponse: { res in
             XCTAssertEqual(res.status, .ok)
-            XCTAssertEqual(try res.content.decode(API.Version.self),
-                           API.Version(version: "dev - will be overriden in release builds"))
+            XCTAssertEqual(try res.content.decode(API.Version.self), API.Version(version: "Unknown"))
         })
     }
     

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -9,6 +9,7 @@ extension AppEnvironment {
         .init(
             allowBuildTriggers: { true },
             allowTwitterPosts: { true },
+            appVersion: { "test" },
             builderToken: { nil },
             buildTriggerDownscaling: { 1.0 },
             date: Date.init,

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_AuthorShow.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_AuthorShow.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body>
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body>
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ErrorPageView.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ErrorPageView.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body>
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_HomeIndexView.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_HomeIndexView.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body>
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MaintainerInfoIndex.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MaintainerInfoIndex.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body>
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MarkdownPage.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MarkdownPage.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="markdown">
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MarkdownPageStyling.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MarkdownPageStyling.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="markdown">
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE--><!--10-->
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE--><!--10-->
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE--><!--10-->
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE--><!--10-->
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE--><!--10-->
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE--><!--10-->
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE--><!--10-->
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE--><!--10-->
     <div class="staging">Staging / Development</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow.1.txt
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html><!--Version: dev - will be overriden in release builds-->
+<html><!--Version: nil-->
   <head>
     <meta name="robots" content="noindex"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
@@ -19,13 +19,13 @@
     <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
     <link rel="shortcut icon" href="/images/logo-simple.png" type="image/png"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"/>
-    <link rel="stylesheet" href="/main.css?0"/>
+    <link rel="stylesheet" href="/main.css?test"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
     <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
-    <script src="/main.js?0"></script>
+    <script src="/main.js?test"></script>
   </head>
   <body>
     <div class="staging">Staging / Development</div>


### PR DESCRIPTION
It was always a bit of a hack to use the current date/time to force the local dev environment to reload fresh JS/CSS resources. This is how it should have been done originally.

This changed was prompted by the addition of Turbolinks. If we reload the CSS/JS with *every* page load, like we were, then Turbolinks never gets to do its job and it's effectively impossible to test Turbolinks locally as it's always doing full resource re-loads.