### PR TITLE
Updated to the latest Package Collection models

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -266,8 +266,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "swift-DEVELOPMENT-SNAPSHOT-2021-01-23-a",
-          "revision": "0e0964a765af8b0cccdb22f4d058d0fdd0d49c61",
+          "branch": "swift-DEVELOPMENT-SNAPSHOT-2021-03-09-a",
+          "revision": "e372f7ad067a68182ccdaabaf0e9b8b1f7e47023",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
         .package(name: "libcmark_gfm", url: "https://github.com/KristopherGBaker/libcmark_gfm", from: "0.29.3"),
         .package(name: "SwiftPM",
                  url: "https://github.com/apple/swift-package-manager.git",
-                 .revision("swift-DEVELOPMENT-SNAPSHOT-2021-01-23-a"))
+                 .revision("swift-DEVELOPMENT-SNAPSHOT-2021-03-09-a"))
     ],
     targets: [
         .target(name: "App", dependencies: [

--- a/Sources/App/Core/PackageCollection+generate.swift
+++ b/Sources/App/Core/PackageCollection+generate.swift
@@ -115,18 +115,24 @@ extension PackageCollection.Package.Version {
         else {
             return nil
         }
+
+        let manifest = Manifest(
+            toolsVersion: toolsVersion,
+            packageName: packageName,
+            targets: version.targets.map(PackageCollection.Target.init(target:)),
+            products: version.products.compactMap(PackageCollection.Product.init(product:)),
+            minimumPlatformVersions: version.supportedPlatforms
+                .map(PackageCollection.PlatformVersion.init(platform:))
+        )
+
         self.init(
             version: "\(semVer)",
-            packageName: packageName,
-            targets: version.targets
-                .map(PackageCollection.Target.init(target:)),
-            products: version.products
-                .compactMap(PackageCollection.Product.init(product:)),
-            toolsVersion: toolsVersion,
-            minimumPlatformVersions: version.supportedPlatforms
-                .map(PackageCollection.PlatformVersion.init(platform:)),
+            summary: version.releaseNotes,
+            manifests: [toolsVersion: manifest],
+            defaultToolsVersion: toolsVersion,
             verifiedCompatibility: .init(builds: version.builds),
-            license: license
+            license: license,
+            createdAt: version.publishedAt
         )
     }
 }

--- a/Tests/AppTests/PackageCollectionTests.swift
+++ b/Tests/AppTests/PackageCollectionTests.swift
@@ -83,8 +83,7 @@ class PackageCollectionTests: AppTestCase {
         XCTAssertEqual(res.createdAt, Date(timeIntervalSince1970: 0))
 
         // The spec requires there to be a dictionary keyed by the default tools version.
-        guard let manifest = res.manifests[res.defaultToolsVersion]
-        else { XCTFail(); return; }
+        let manifest = try XCTUnwrap(res.manifests[res.defaultToolsVersion])
 
         // Validate the manifest.
         XCTAssertEqual(manifest.packageName, "Foo")

--- a/Tests/AppTests/__Snapshots__/PackageCollectionTests/test_generate_for_owner.1.json
+++ b/Tests/AppTests/__Snapshots__/PackageCollectionTests/test_generate_for_owner.1.json
@@ -24,33 +24,38 @@
       "url" : "https:\/\/github.com\/foo\/1",
       "versions" : [
         {
+          "defaultToolsVersion" : "5.2",
           "license" : {
             "name" : "MIT",
             "url" : "https:\/\/foo\/mit"
           },
-          "minimumPlatformVersions" : [
+          "manifests" : {
+            "5.2" : {
+              "minimumPlatformVersions" : [
 
-          ],
-          "packageName" : "P1-tag",
-          "products" : [
-            {
-              "name" : "P1Lib",
-              "targets" : [
-                "t1"
               ],
-              "type" : {
-                "library" : [
-                  "automatic"
-                ]
-              }
+              "packageName" : "P1-tag",
+              "products" : [
+                {
+                  "name" : "P1Lib",
+                  "targets" : [
+                    "t1"
+                  ],
+                  "type" : {
+                    "library" : [
+                      "automatic"
+                    ]
+                  }
+                }
+              ],
+              "targets" : [
+                {
+                  "name" : "t1"
+                }
+              ],
+              "toolsVersion" : "5.2"
             }
-          ],
-          "targets" : [
-            {
-              "name" : "t1"
-            }
-          ],
-          "toolsVersion" : "5.2",
+          },
           "verifiedCompatibility" : [
             {
               "platform" : {
@@ -62,33 +67,38 @@
           "version" : "2.0.0"
         },
         {
+          "defaultToolsVersion" : "5.1",
           "license" : {
             "name" : "MIT",
             "url" : "https:\/\/foo\/mit"
           },
-          "minimumPlatformVersions" : [
+          "manifests" : {
+            "5.1" : {
+              "minimumPlatformVersions" : [
 
-          ],
-          "packageName" : "P1-tag",
-          "products" : [
-            {
-              "name" : "P1Lib",
-              "targets" : [
-                "t1"
               ],
-              "type" : {
-                "library" : [
-                  "automatic"
-                ]
-              }
+              "packageName" : "P1-tag",
+              "products" : [
+                {
+                  "name" : "P1Lib",
+                  "targets" : [
+                    "t1"
+                  ],
+                  "type" : {
+                    "library" : [
+                      "automatic"
+                    ]
+                  }
+                }
+              ],
+              "targets" : [
+                {
+                  "name" : "t1"
+                }
+              ],
+              "toolsVersion" : "5.1"
             }
-          ],
-          "targets" : [
-            {
-              "name" : "t1"
-            }
-          ],
-          "toolsVersion" : "5.1",
+          },
           "verifiedCompatibility" : [
 
           ],
@@ -109,33 +119,38 @@
       "url" : "https:\/\/github.com\/foo\/2",
       "versions" : [
         {
+          "defaultToolsVersion" : "5.3",
           "license" : {
             "name" : "MIT",
             "url" : "https:\/\/foo\/mit"
           },
-          "minimumPlatformVersions" : [
+          "manifests" : {
+            "5.3" : {
+              "minimumPlatformVersions" : [
 
-          ],
-          "packageName" : "P2-tag",
-          "products" : [
-            {
-              "name" : "P1Lib",
-              "targets" : [
-                "t2"
               ],
-              "type" : {
-                "library" : [
-                  "automatic"
-                ]
-              }
+              "packageName" : "P2-tag",
+              "products" : [
+                {
+                  "name" : "P1Lib",
+                  "targets" : [
+                    "t2"
+                  ],
+                  "type" : {
+                    "library" : [
+                      "automatic"
+                    ]
+                  }
+                }
+              ],
+              "targets" : [
+                {
+                  "name" : "t2"
+                }
+              ],
+              "toolsVersion" : "5.3"
             }
-          ],
-          "targets" : [
-            {
-              "name" : "t2"
-            }
-          ],
-          "toolsVersion" : "5.3",
+          },
           "verifiedCompatibility" : [
 
           ],


### PR DESCRIPTION
Implemented manifests and the new fields. We always just push one manifest, as we don't support multiple, but we're compatible with the schema again 👍