### PR TITLE
Log server version on startup (for monitoring)

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -5,7 +5,9 @@ import Vapor
 
 public func configure(_ app: Application) throws {
     Current.setLogger(app.logger)
-    
+
+    app.logger.info("SPI Server version \(appVersion) starting up ...")
+
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(ErrorMiddleware())
     


### PR DESCRIPTION
With the move to docker swarm, we're deploying from a `shell` executor instead of `docker`. That means that the deployment message isn't being picked up by `promtail`, which in turn means it's not picked up as an annotation in the monitoring dashboard.

<img width="234" alt="CleanShot 2021-03-22 at 13 40 28@2x" src="https://user-images.githubusercontent.com/65520/111991076-2e75a200-8b14-11eb-8c5e-465a68d27ddf.png">

If we log the server version on boot from the app we can pick up the annotation from there instead.