### PR TITLE
Align postgres version with hosted db

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       image: finestructure/spi-base:0.2.0
     services:
       postgres:
-        image: postgres:12.1-alpine
+        image: postgres:11.6-alpine
         env:
           POSTGRES_DB: spi_test
           POSTGRES_USER: spi_test
@@ -38,7 +38,7 @@ jobs:
   #   runs-on: macOS-latest
   #   services:
   #     postgres:
-  #       image: postgres:12
+  #       image: postgres:11.6
   #       env:
   #         POSTGRES_DB: spi_dev
   #         POSTGRES_USER: spi_dev

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ analyze:
 db-up: db-up-dev db-up-test
 
 db-up-dev:
-	docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 -d postgres:12.1-alpine
+	docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 -d postgres:11.6-alpine
 
 db-up-test:
 	docker run --name spi_test \
@@ -67,7 +67,7 @@ db-up-test:
 		--tmpfs /pgdata:rw,noexec,nosuid,size=1024m \
 		-p 5432:5432 \
 		-d \
-		postgres:12.1-alpine
+		postgres:11.6-alpine
 
 db-down: db-down-dev db-down-test
 

--- a/scripts/convert_to_db_dump.sh
+++ b/scripts/convert_to_db_dump.sh
@@ -4,7 +4,7 @@ set -eu
 
 TARFILE=$1
 DUMPFILE=$2
-PG_IMAGE=postgres:12.1-alpine
+PG_IMAGE=postgres:11.6-alpine
 
 [[ -n $DATABASE_PASSWORD ]]  || (echo "DATABASE_PASSWORD not set" && exit 1)
 [[ -n $DB_BACKUP_DIR ]]      || (echo "DB_BACKUP_DIR not set" && exit 1)

--- a/scripts/load-db.sh
+++ b/scripts/load-db.sh
@@ -2,7 +2,7 @@
 set -eu
 IMPORT_FILE=$1
 docker rm -f spi_dev
-docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 -d postgres:12.1-alpine
+docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 -d postgres:11.6-alpine
 echo "Giving Postgres a moment to launch ..."
 sleep 5
 echo "Importing"


### PR DESCRIPTION
Post-migration clean-up continues: aligning db versions with Azure hosted db. Make sure to delete local db containers and re-initialise with `make db-up` to start using 11.6.