### PR TITLE
Remove attempt to test all packages

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,6 +187,3 @@ smoke-test:
     }
     echo Testing with SITE_URL: ${SITE_URL}
     rester restfiles/smoke-test.restfile
-    echo "Running full suite of package tests ..."
-    docker run finestructure/rester-sitemap:1.0.0 ${SITE_URL}/sitemap.xml > all-packages.restfile
-    rester all-packages.restfile


### PR DESCRIPTION
The smoke tests have been unreliable for a long time now because they flag 404s that are "legitimate" 404s in the sense that packages are unavailable at the time they're being run. These are typically repositories that go private, have no or invalid package manifests etc.

The smoke test should really be a smoke test if the service deployed correctly, not a package validation test across all packages. (That was useful at the start when we wanted to find genuine issues leading to false negative 404s.)

The nightly weeds out and corrects any renamed or bad packages and there's room for a process that crawls all urls to highlight any (new) issues but smoke testing isn't the place.