### PR TITLE
Analyze swift 5.4 packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: finestructure/spi-base:0.2.0
+      image: finestructure/spi-base:0.3.0
     services:
       postgres:
         image: postgres:11.6-alpine

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # ================================
 # Build image
 # ================================
-FROM finestructure/spi-base:0.2.0 as build
+FROM finestructure/spi-base:0.3.0 as build
 WORKDIR /build
 
 # First just resolve dependencies.
@@ -24,7 +24,7 @@ RUN swift build \
 # Run image
 # ================================
 # we need a special base image so that we can run `swift dump-package`
-FROM finestructure/spi-base:0.2.0
+FROM finestructure/spi-base:0.3.0
 
 WORKDIR /run
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -11,8 +11,8 @@ RUN apt-get update && apt-get install -y git curl
 # install swift toolchain so we can run `swift package dump-package`
 # (enable this whenever we need to support an upcoming Swift version before updating the
 # base image's swift version)
-# WORKDIR /
-# RUN curl https://swift.org/builds/swift-5.3-branch/ubuntu1804/swift-5.3-DEVELOPMENT-SNAPSHOT-2020-07-04-a/swift-5.3-DEVELOPMENT-SNAPSHOT-2020-07-04-a-ubuntu18.04.tar.gz -o toolchain.tgz \
-#     && tar xvfz toolchain.tgz \
-#     && rm toolchain.tgz
-# RUN ln -s /swift-5.3-DEVELOPMENT-SNAPSHOT-2020-07-04-a-ubuntu18.04 /swift-5.3
+WORKDIR /
+RUN curl https://swift.org/builds/swift-5.4-branch/ubuntu1804/swift-5.4-DEVELOPMENT-SNAPSHOT-2021-03-25-a/swift-5.4-DEVELOPMENT-SNAPSHOT-2021-03-25-a-ubuntu18.04.tar.gz -o toolchain.tgz \
+    && tar xvfz toolchain.tgz \
+    && rm toolchain.tgz
+RUN ln -s /swift-5.4-DEVELOPMENT-SNAPSHOT-2021-03-25-a-ubuntu18.04 /swift-5.4

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ docker-push:
 
 test-docker:
 	@# run tests inside a docker container
-	docker run --rm -v "$(PWD)":/host -w /host --network="host" finestructure/spi-base:0.2.0 \
+	docker run --rm -v "$(PWD)":/host -w /host --network="host" finestructure/spi-base:0.3.0 \
 	  bash -c "apt-get update && apt-get install -y unzip && make test"
 
 test-e2e: db-reset reconcile ingest analyze

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -563,8 +563,8 @@ func dumpPackage(at path: String) throws -> Manifest {
         // up the tree through parent directories to find one
         throw AppError.invalidRevision(nil, "no Package.swift")
     }
-    let swiftCommand = Current.fileManager.fileExists("/swift-5.3/usr/bin/swift")
-        ? "/swift-5.3/usr/bin/swift"
+    let swiftCommand = Current.fileManager.fileExists("/swift-5.4/usr/bin/swift")
+        ? "/swift-5.4/usr/bin/swift"
         : "swift"
     let json = try Current.shell.run(command: .init(string: "\(swiftCommand) package dump-package"),
                                      at: path)

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -594,7 +594,7 @@ class AnalyzerTests: AppTestCase {
         // validation
         XCTAssertEqual(commands, [
             "git checkout \"0.4.2\" --quiet",
-            "/swift-5.3/usr/bin/swift package dump-package"
+            "/swift-5.4/usr/bin/swift package dump-package"
         ])
         XCTAssertEqual(v.id, version.id)
         XCTAssertEqual(m.name, "SPI-Server")
@@ -629,7 +629,7 @@ class AnalyzerTests: AppTestCase {
         // validation
         XCTAssertEqual(commands, [
             "git checkout \"0.4.2\" --quiet",
-            "/swift-5.3/usr/bin/swift package dump-package"
+            "/swift-5.4/usr/bin/swift package dump-package"
         ])
         XCTAssertEqual(results.map(\.isSuccess), [false, true])
         let (_, versionsManifests) = try XCTUnwrap(results.last).get()
@@ -871,8 +871,8 @@ class AnalyzerTests: AppTestCase {
         assertSnapshot(matching: commands, as: .dump)
     }
 
-    func test_dumpPackage_5_3() throws {
-        // Test parsing a Package.swift that requires a 5.3 toolchain
+    func test_dumpPackage_5_4() throws {
+        // Test parsing a Package.swift that requires a 5.4 toolchain
         // NB: If this test fails on macOS with Xcode 12, make sure
         // xcode-select -p points to the correct version of Xcode!
         // setup

--- a/Tests/AppTests/Fixtures/VisualEffects-Package-swift
+++ b/Tests/AppTests/Fixtures/VisualEffects-Package-swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription


### PR DESCRIPTION
Deploy to staging and test by re-processing 5.4 packages (and some 5.3 packages). For instance (via #1003):

```
2021-02-23 19:33:17.339539+00	bd073441-a63d-46d6-9621-898b4356132d	https://github.com/christopherweems/Resultto/tree/main
2021-02-02 23:21:45.902597+00	d3e68637-d4e2-46ee-afca-54a8c5a36bf1	https://github.com/christopherweems/Sight/tree/main
2021-04-03 22:14:43.919267+00	34aeb60a-cd7e-4810-9953-42a808925827	https://github.com/christopherweems/unstandard/tree/main
```