### PR TITLE
Removed the "back" link on the SPI Playgrounds app download page

### DIFF
--- a/Resources/Markdown/try-package.md
+++ b/Resources/Markdown/try-package.md
@@ -12,4 +12,4 @@ What’s the best way to know whether a package is right for your project? Try i
   <small>Requires macOS 11 or newer</small>
 </a>
 
-Once downloaded and installed, <a href="#" onclick="window.history.back()">navigate back to the package page</a> and click **“Try in a Playground”** to open a Swift playground in Xcode with the package imported and ready to try.
+Once downloaded and installed, click **“Try in a Playground”** from any package page on the Swift Package Index to open a Swift playground in Xcode with the package imported, ready for experimentation and testing.

--- a/Resources/Markdown/try-package.md
+++ b/Resources/Markdown/try-package.md
@@ -7,7 +7,7 @@ description: Try any Swift package in a Swift Playground by downloading the Swif
 
 What’s the best way to know whether a package is right for your project? Try it in a Swift Playground! **Download the Swift Package Index Playgrounds app for macOS** and generate playground files with the dependency already inserted, ready to open with Xcode.
 
-<a class="download" href="https://github.com/SwiftPackageIndex/SPI-Playgrounds-Releases/raw/main/SPI-Playgrounds.app.zip">
+<a class="download" href="https://spi-playgrounds-updates.swiftpackageindex.com/SPI-Playgrounds.app.zip">
   Download
   <small>Requires macOS 11 or newer</small>
 </a>


### PR DESCRIPTION
We're sending people directly to this page from various places, so a JavaScript back button is going to send people all over the place. Better to just describe what they should do.

Also updated the URL to the new subdomain.