### PR TITLE
Send only "major.minor" Swift version build triggers

### DIFF
--- a/Sources/App/Core/Gitlab.swift
+++ b/Sources/App/Core/Gitlab.swift
@@ -63,7 +63,7 @@ extension Gitlab.Builder {
                         "BUILDER_TOKEN": builderToken,
                         "CLONE_URL": cloneURL,
                         "REFERENCE": "\(reference)",
-                        "SWIFT_VERSION": "\(swiftVersion.major).\(swiftVersion.minor).\(swiftVersion.patch)",
+                        "SWIFT_VERSION": "\(swiftVersion.major).\(swiftVersion.minor)",
                         "VERSION_ID": versionID.uuidString
                     ])
                 try req.query.encode(data)

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -125,7 +125,7 @@ class BuildTests: AppTestCase {
                                 "BUILDER_TOKEN": "builder token",
                                 "CLONE_URL": "1",
                                 "REFERENCE": "main",
-                                "SWIFT_VERSION": "5.2.4",
+                                "SWIFT_VERSION": "5.2",
                                 "VERSION_ID": versionID.uuidString,
                             ]))
         }

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -154,7 +154,7 @@ class BuildTriggerTests: AppTestCase {
         XCTAssertEqual(queries.count, 1)
         XCTAssertEqual(queries.map { $0.variables["VERSION_ID"] }, [versionId.uuidString])
         XCTAssertEqual(queries.map { $0.variables["BUILD_PLATFORM"] }, ["ios"])
-        XCTAssertEqual(queries.map { $0.variables["SWIFT_VERSION"] }, ["4.2.3"])
+        XCTAssertEqual(queries.map { $0.variables["SWIFT_VERSION"] }, ["4.2"])
 
         // ensure the Build stubs is created to prevent re-selection
         let v = try Version.find(versionId, on: app.db).wait()
@@ -214,12 +214,12 @@ class BuildTriggerTests: AppTestCase {
         let swiftVersions = queries.compactMap { $0.variables["SWIFT_VERSION"] }
         XCTAssertEqual(Dictionary(grouping: swiftVersions, by: { $0 })
                         .mapValues(\.count),
-                       ["4.2.3": 6,
-                        "5.0.3": 6,
-                        "5.1.5": 6,
-                        "5.2.4": 6,
-                        "5.3.3": 8,
-                        "5.4.0": 8])
+                       ["4.2": 6,
+                        "5.0": 6,
+                        "5.1": 6,
+                        "5.2": 6,
+                        "5.3": 8,
+                        "5.4": 8])
 
         // ensure the Build stubs are created to prevent re-selection
         let v = try Version.find(versionId, on: app.db).wait()

--- a/Tests/AppTests/GitlabBuilderTests.swift
+++ b/Tests/AppTests/GitlabBuilderTests.swift
@@ -44,7 +44,7 @@ class GitlabBuilderTests: XCTestCase {
                                 "BUILDER_TOKEN": "builder token",
                                 "CLONE_URL": "https://github.com/daveverwer/LeftPad.git",
                                 "REFERENCE": "1.2.3",
-                                "SWIFT_VERSION": "5.2.4",
+                                "SWIFT_VERSION": "5.2",
                                 "VERSION_ID": versionID.uuidString,
                             ]))
         }
@@ -72,7 +72,7 @@ class GitlabBuilderTests: XCTestCase {
             // validate
             let swiftVersion = (try? req.query.decode(Gitlab.Builder.PostDTO.self))
                 .flatMap { $0.variables["SWIFT_VERSION"] }
-            XCTAssertEqual(swiftVersion, "5.0.3")
+            XCTAssertEqual(swiftVersion, "5.0")
         }
 
         // MUT


### PR DESCRIPTION
Fixes #1062 

I'll manually test this on staging before we deploy