### PR TITLE
Add `timeout` build status for build reporting

### DIFF
--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -100,6 +100,7 @@ extension Build {
         case ok
         case failed
         case pending
+        case timeout
     }
 }
 

--- a/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
@@ -91,6 +91,8 @@ private extension Build.Status {
                 return "This build failed, but detailed logs are not available. Logs are only retained for a few months after a build, and they may have expired, or the request to fetch them may have failed."
             case .pending:
                 return "This build is pending execution, and logs are not yet available."
+            case .timeout:
+                return "This build exceeded its build quota and timed out."
         }
     }
 }

--- a/Sources/App/Views/PackageController/Builds/BuildShow+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+View.swift
@@ -73,13 +73,13 @@ enum BuildShow {
 
 private extension Build.Status {
 
-    // There should never be pending builds visible on this page so the pending cases are only for completeness.
+    // There should never be pending or timed-out builds visible on this page (they don't have any details to display) so the these cases are only for completeness.
 
     var text: String {
         switch self {
             case .ok: return "Successful"
             case .failed: return "Failed"
-            case .pending: return ""
+            case .pending, .timeout: return ""
         }
     }
 
@@ -87,7 +87,7 @@ private extension Build.Status {
         switch self {
             case .ok: return " build of "
             case .failed: return " to build "
-            case .pending: return ""
+            case .pending, .timeout: return ""
         }
     }
 
@@ -95,7 +95,7 @@ private extension Build.Status {
         switch self {
             case .ok: return "green"
             case .failed: return "red"
-            case .pending: return ""
+            case .pending, .timeout: return ""
         }
     }
 }


### PR DESCRIPTION
I think I've found a way to run the build command with the `timeout` command and report jobs that are exceeding it.

I'll test this on staging by deploying from this branch - keeping it in draft until I know this will work.