### PR TITLE
spi-ci → spi-server-deploy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ build:
     - if: '$ENV == "prod"'
   stage: build
   tags:
-    - spi-ci
+    - spi-ci-server
   script: |
     VERSION=${CI_COMMIT_TAG:-$CI_COMMIT_SHA}
     echo 'let appVersion: String? = "'${VERSION}'"' > ./Sources/App/Core/AppVersion.swift
@@ -182,7 +182,7 @@ smoke-test:
     - if: '$ENV == "dev"'
   stage: smoke-test
   tags:
-    - spi-ci
+    - spi-ci-server
   script: |
     rester() {
       docker run --rm -t -e base_url="$SITE_URL" -v $PWD:/host -w /host finestructure/rester:0.7.2 "$1"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -28,7 +28,7 @@ build:
     - if: '$ENV == "prod"'
   stage: build
   tags:
-    - spi-ci-server
+    - spi-server-deploy
   script: |
     VERSION=${CI_COMMIT_TAG:-$CI_COMMIT_SHA}
     echo 'let appVersion: String? = "'${VERSION}'"' > ./Sources/App/Core/AppVersion.swift
@@ -182,7 +182,7 @@ smoke-test:
     - if: '$ENV == "dev"'
   stage: smoke-test
   tags:
-    - spi-ci-server
+    - spi-server-deploy
   script: |
     rester() {
       docker run --rm -t -e base_url="$SITE_URL" -v $PWD:/host -w /host finestructure/rester:0.7.2 "$1"


### PR DESCRIPTION
This isn't really CI - that's running on GH. This is the deployment pipeline, hence the rename.

<img width="253" alt="CleanShot 2021-05-11 at 17 24 37@2x" src="https://user-images.githubusercontent.com/65520/117841966-c757ac80-b27d-11eb-8994-feda0f3fb873.png">

- [ ] merge
- [ ] remove old tags after merge