### PR TITLE
Fix build metrics scrape target

### DIFF
--- a/infrastructure/prometheus.yml
+++ b/infrastructure/prometheus.yml
@@ -5,7 +5,7 @@ global:
 scrape_configs:
   - job_name: 'spi-app'
     static_configs:
-      - targets: ['app:80']
+      - targets: ['app_server:80']
 
   - job_name: 'pushgateway'
     honor_labels: true

--- a/restfiles/post-build.restfile
+++ b/restfiles/post-build.restfile
@@ -1,6 +1,6 @@
 variables:
-    # base_url: http://localhost:8080/api
-    base_url: https://staging.swiftpackageindex.com/api
+    base_url: http://localhost:8080/api
+    # base_url: https://staging.swiftpackageindex.com/api
     # set here or via env variables:
     # env version_id=... builder_token=... rester ...
     # version_id: 
@@ -15,10 +15,9 @@ requests:
             Authorization: Bearer ${builder_token}
         body:
             json:
-                logs: some logs
-                platform:
-                    name: unknown
-                    version: test
+                logUrl: http://localhost/logurl
+                jobUrl: http://localhost/joburl
+                platform: ios
                 status: ok
                 swiftVersion:
                     major: 5


### PR DESCRIPTION
When we changed to docker swarm deployment I changed the app container's name from `app` to `app_server`. This broke the scrape target in prometheus' config and is the reason the "Build Reports" panel is blank:

<img width="480" alt="CleanShot 2021-05-18 at 15 26 39@2x" src="https://user-images.githubusercontent.com/65520/118659318-7d2a7a00-b7ed-11eb-8ca8-3218ee480ece.png">
