### PR TITLE
Fetch additional package metadata

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -183,11 +183,14 @@ func insertOrUpdateRepository(on database: Database,
             repo.openIssues = repository.openIssues.totalCount
             repo.openPullRequests = repository.openPullRequests.totalCount
             repo.owner = repository.owner.login
+            repo.ownerName = repository.owner.name
+            repo.ownerAvatarUrl = repository.owner.avatarUrl
             repo.readmeUrl = readmeInfo?.downloadUrl
             repo.readmeHtmlUrl = readmeInfo?.htmlUrl
             repo.releases = metadata.repository?.releases.nodes
                 .map(Release.init(from:)) ?? []
             repo.stars = repository.stargazerCount
+            repo.isInOrganization = repository.isInOrganization
             repo.summary = repository.description
             return repo.save(on: database)
         }

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -259,6 +259,7 @@ extension Github {
                     }
                     owner {
                       login
+                      avatarUrl
                     }
                     releases(first: 20, orderBy: {field: CREATED_AT, direction: DESC}) {
                       nodes {
@@ -270,6 +271,7 @@ extension Github {
                       }
                     }
                     stargazerCount
+                    isInOrganization
                   }
                 }
                 """)
@@ -292,6 +294,7 @@ extension Github {
             var owner: Owner
             var releases: ReleaseNodes
             var stargazerCount: Int
+            var isInOrganization: Bool
             // derived properties
             var defaultBranch: String? { defaultBranchRef?.name }
             var lastIssueClosedAt: Date? {
@@ -335,6 +338,7 @@ extension Github {
 
         struct Owner: Decodable, Equatable {
             var login: String
+            var avatarUrl: String
         }
 
         struct OpenPullRequests: Decodable, Equatable {

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -260,6 +260,12 @@ extension Github {
                     owner {
                       login
                       avatarUrl
+                      ... on User {
+                        name
+                      }
+                      ... on Organization {
+                        name
+                      }
                     }
                     releases(first: 20, orderBy: {field: CREATED_AT, direction: DESC}) {
                       nodes {
@@ -338,6 +344,7 @@ extension Github {
 
         struct Owner: Decodable, Equatable {
             var login: String
+            var name: String
             var avatarUrl: String
         }
 

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -344,7 +344,7 @@ extension Github {
 
         struct Owner: Decodable, Equatable {
             var login: String
-            var name: String
+            var name: String?
             var avatarUrl: String
         }
 

--- a/Sources/App/Migrations/027/UpdateRepositoryAddOwnerFields.swift
+++ b/Sources/App/Migrations/027/UpdateRepositoryAddOwnerFields.swift
@@ -1,7 +1,7 @@
 import Fluent
 
 
-struct UpdateRepositoryAddOwnerNameAndOwnerAvatarUrlAndIsInOrganizationFlag: Migration {
+struct UpdateRepositoryAddOwnerFields: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         database.schema("repositories")
             .field("owner_name", .string)

--- a/Sources/App/Migrations/027/UpdateRepositoryAddOwnerFields.swift
+++ b/Sources/App/Migrations/027/UpdateRepositoryAddOwnerFields.swift
@@ -1,0 +1,20 @@
+import Fluent
+
+
+struct UpdateRepositoryAddOwnerNameAndOwnerAvatarUrlAndIsInOrganizationFlag: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("repositories")
+            .field("owner_name", .string)
+            .field("owner_avatar_url", .string)
+            .field("is_in_organization", .bool)
+            .update()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("repositories")
+            .deleteField("owner_name")
+            .deleteField("owner_avatar_url")
+            .deleteField("is_in_organization")
+            .update()
+    }
+}

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -72,6 +72,12 @@ final class Repository: Model, Content {
     
     @Field(key: "owner")
     var owner: String?
+
+    @Field(key: "owner_name")
+    var ownerName: String?
+
+    @Field(key: "owner_avatar_url")
+    var ownerAvatarUrl: String?
     
     @Field(key: "readme_url")
     var readmeUrl: String?
@@ -84,6 +90,9 @@ final class Repository: Model, Content {
 
     @Field(key: "stars")
     var stars: Int?
+
+    @Field(key: "is_in_organization")
+    var isInOrganization: Bool?
     
     @Field(key: "summary")
     var summary: String?
@@ -108,11 +117,14 @@ final class Repository: Model, Content {
          openIssues: Int? = nil,
          openPullRequests: Int? = nil,
          owner: String? = nil,
+         ownerName: String? = nil,
+         ownerAvatarUrl: String? = nil,
          readmeUrl: String? = nil,
          readmeHtmlUrl: String? = nil,
          releases: [Release] = [],
          isArchived: Bool? = nil,
          stars: Int? = nil,
+         isInOrganization: Bool? = nil,
          forks: Int? = nil,
          forkedFrom: Repository? = nil) throws {
         self.id = id
@@ -131,11 +143,14 @@ final class Repository: Model, Content {
         self.openIssues = openIssues
         self.openPullRequests = openPullRequests
         self.owner = owner
+        self.ownerName = ownerName
+        self.ownerAvatarUrl = ownerAvatarUrl
         self.readmeUrl = readmeUrl
         self.readmeHtmlUrl = readmeHtmlUrl
         self.releases = releases
         self.isArchived = isArchived
         self.stars = stars
+        self.isInOrganization = isInOrganization
         self.forks = forks
         if let forkId = forkedFrom?.id {
             self.$forkedFrom.id = forkId

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -124,6 +124,9 @@ public func configure(_ app: Application) throws {
     do {  // Migration 026 - Add rendered README url
         app.migrations.add(UpdateRepositoryAddReadmeHtmlUrl())
     }
+    do {  // Migration 027 - add owner name, owner avatar url, and is in organization metadata to repositories
+        app.migrations.add(UpdateRepositoryAddOwnerNameAndOwnerAvatarUrlAndIsInOrganizationFlag())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -125,7 +125,7 @@ public func configure(_ app: Application) throws {
         app.migrations.add(UpdateRepositoryAddReadmeHtmlUrl())
     }
     do {  // Migration 027 - add owner name, owner avatar url, and is in organization metadata to repositories
-        app.migrations.add(UpdateRepositoryAddOwnerNameAndOwnerAvatarUrlAndIsInOrganizationFlag())
+        app.migrations.add(UpdateRepositoryAddOwnerFields())
     }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")

--- a/Tests/AppTests/Fixtures/github-graphql-resource.json
+++ b/Tests/AppTests/Fixtures/github-graphql-resource.json
@@ -933,7 +933,9 @@
         "totalCount": 6
       },
       "owner": {
-        "login": "Alamofire"
+        "login": "Alamofire",
+        "avatarUrl": "https://avatars.githubusercontent.com/u/7774181?v=4",
+        "name": "Alamofire"
       },
       "releases": {
         "nodes": [
@@ -1009,7 +1011,8 @@
           }
         ]
       },
-      "stargazerCount": 34720
+      "stargazerCount": 34720,
+      "isInOrganization": true
     }
   }
 }

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -32,7 +32,7 @@ class GithubTests: AppTestCase {
         }
         do {
             let data = """
-            {"data":{"repository":{"closedIssues":{"nodes":[]},"closedPullRequests":{"nodes":[]},"createdAt":"2019-04-23T09:26:22Z","defaultBranchRef":{"name":"master"},"description":null,"forkCount":0,"isArchived":false,"isFork":false,"licenseInfo":null,"mergedPullRequests":{"nodes":[]},"name":"CRToastSwift","openIssues":{"totalCount":0},"openPullRequests":{"totalCount":0},"owner":{"login":"krugazor"},"releases":{"nodes":[]},"stargazerCount":3},"rateLimit":{"remaining":4753}}}
+            {"data":{"repository":{"closedIssues":{"nodes":[]},"closedPullRequests":{"nodes":[]},"createdAt":"2019-04-23T09:26:22Z","defaultBranchRef":{"name":"master"},"description":null,"forkCount":0,"isArchived":false,"isFork":false,"licenseInfo":null,"mergedPullRequests":{"nodes":[]},"name":"CRToastSwift","openIssues":{"totalCount":0},"openPullRequests":{"totalCount":0},"owner":{"login":"krugazor","avatarUrl": "https://avatars.githubusercontent.com/u/2742179?u=28d2ccb6a27c975e663738fe86af579ff74203ac&v=4","name": "Nicolas Zinovieff"},"releases":{"nodes":[]},"stargazerCount":3,"isInOrganization":false},"rateLimit":{"remaining":4753}}}
             """
             _ = try Github.decoder.decode(Response.self, from: Data(data.utf8))
         }
@@ -87,6 +87,9 @@ class GithubTests: AppTestCase {
         XCTAssertEqual(res.repository?.mergedPullRequests.nodes.first!.closedAt,
                        iso8601.date(from: "2020-11-04T21:27:43Z"))
         XCTAssertEqual(res.repository?.name, "Alamofire")
+        XCTAssertEqual(res.repository?.owner.name, "Alamofire")
+        XCTAssertEqual(res.repository?.owner.login, "Alamofire")
+        XCTAssertEqual(res.repository?.owner.avatarUrl, "https://avatars.githubusercontent.com/u/7774181?v=4")
         XCTAssertEqual(res.repository?.openIssues.totalCount, 30)
         XCTAssertEqual(res.repository?.openPullRequests.totalCount, 6)
         XCTAssertEqual(res.repository?.releases.nodes.count, 10)
@@ -98,6 +101,7 @@ class GithubTests: AppTestCase {
                               url: "https://github.com/Alamofire/Alamofire/releases/tag/5.4.0")
         ))
         XCTAssertEqual(res.repository?.stargazerCount, 34720)
+        XCTAssertEqual(res.repository?.isInOrganization, true)
         // derived properties
         XCTAssertEqual(res.repository?.lastIssueClosedAt,
                        iso8601.date(from: "2020-11-24T16:00:07Z"))

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -118,7 +118,7 @@ class IngestorTests: AppTestCase {
                             name: "bar",
                             stars: 2,
                             summary: "package desc",
-                            isInOrganization: false),
+                            isInOrganization: true),
                       licenseInfo: .init(htmlUrl: "license url"),
                       readmeInfo: .init(downloadUrl: "readme url", htmlUrl: "readme html url")))
         ]
@@ -142,6 +142,8 @@ class IngestorTests: AppTestCase {
         XCTAssertEqual(repo.openIssues, 1)
         XCTAssertEqual(repo.openPullRequests, 2)
         XCTAssertEqual(repo.owner, "foo")
+        XCTAssertEqual(repo.ownerName, "foo")
+        XCTAssertEqual(repo.ownerAvatarUrl, "https://avatars.githubusercontent.com/u/61124617?s=200&v=4")
         XCTAssertEqual(repo.readmeUrl, "readme url")
         XCTAssertEqual(repo.readmeHtmlUrl, "readme html url")
         XCTAssertEqual(repo.releases, [
@@ -153,6 +155,7 @@ class IngestorTests: AppTestCase {
         ])
         XCTAssertEqual(repo.name, "bar")
         XCTAssertEqual(repo.stars, 2)
+        XCTAssertEqual(repo.isInOrganization, true)
         XCTAssertEqual(repo.summary, "package desc")
     }
     

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -117,7 +117,8 @@ class IngestorTests: AppTestCase {
                             ],
                             name: "bar",
                             stars: 2,
-                            summary: "package desc"),
+                            summary: "package desc",
+                            isInOrganization: false),
                       licenseInfo: .init(htmlUrl: "license url"),
                       readmeInfo: .init(downloadUrl: "readme url", htmlUrl: "readme html url")))
         ]
@@ -294,7 +295,8 @@ class IngestorTests: AppTestCase {
                                                     pullRequestsClosedAtDates: [],
                                                     name: "name",
                                                     stars: 0,
-                                                    summary: "desc"))
+                                                    summary: "desc",
+                                                    isInOrganization: false))
         }
         var reportedLevel: AppError.Level? = nil
         var reportedError: String? = nil

--- a/Tests/AppTests/Mocks/GithubMetadata+mock.swift
+++ b/Tests/AppTests/Mocks/GithubMetadata+mock.swift
@@ -15,7 +15,8 @@ extension Github.Metadata {
                                   releases: [],
                                   name: "packageName",
                                   stars: 2,
-                                  summary: "desc")
+                                  summary: "desc",
+                                  isInOrganization: false)
 
     static func mock(for package: Package) -> Self {
         let (owner, name) = try! Github.parseOwnerName(url: package.url)
@@ -30,7 +31,8 @@ extension Github.Metadata {
               releases: [],
               name: name,
               stars: package.url.count + 1,
-              summary: "This is package " + package.url)
+              summary: "This is package " + package.url,
+              isInOrganization: false)
     }
 
     init(defaultBranch: String,
@@ -44,7 +46,9 @@ extension Github.Metadata {
          releases: [ReleaseNodes.ReleaseNode] = [],
          name: String,
          stars: Int,
-         summary: String) {
+         summary: String,
+         isInOrganization: Bool
+    ) {
         self = .init(
             repository: .init(closedIssues: .init(closedAtDates: issuesClosedAtDates),
                               closedPullRequests: .init(closedAtDates: pullRequestsClosedAtDates),
@@ -58,9 +62,10 @@ extension Github.Metadata {
                               name: name,
                               openIssues: .init(totalCount: openIssues),
                               openPullRequests: .init(totalCount: openPullRequests),
-                              owner: .init(login: owner),
+                              owner: .init(login: owner, name: owner, avatarUrl: "https://avatars.githubusercontent.com/u/61124617?s=200&v=4"),
                               releases: .init(nodes: releases),
-                              stargazerCount: stars)
+                              stargazerCount: stars,
+                              isInOrganization: isInOrganization)
         )
     }
 }


### PR DESCRIPTION
Additional fields are:

- `ownerAvatarUrl` for #975
- `ownerAvatarName` as referenced [in the discussion](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1116#issuecomment-845024446)
- `isInOrganization` for #980

From my understanding of Github's GraphQL API, the `Repository.owner` field is shared by both `User` and `Organization` entities. E.g., if a repository belongs to an organization, `login` and `avatarUrl` should point to the organization's metadata. Otherwise, `login` and `avatarUrl` point to the author's account. ([Explorer configuration for API probing](https://gist.github.com/elfenlaid/61d5a72a20278eca948e6e9ff2a5b62c))

So, it's not clear only from the `owner` field whether the author is an organization or a person. Thus, the additional `Repository.isInOrganization` field helps to distinguish the owner's type.

Probably I've missed something (maybe you have a running revamp plan of Repo's ownership), so looking forward to the feedback :)
