### PR TITLE
Replace vapor-beta binaries with swift run

### DIFF
--- a/scripts/analysis-loop.sh
+++ b/scripts/analysis-loop.sh
@@ -5,7 +5,7 @@ set -eu
 # export LOG_LEVEL=warning
 
 while true; do
-    time vapor-beta run analyze -l 10
+    time swift run Run analyze -l 10
     echo Pausing...
     sleep 2
 done

--- a/scripts/ingest-loop.sh
+++ b/scripts/ingest-loop.sh
@@ -7,7 +7,7 @@ rester="docker run --rm -t -v $PWD:/host -w /host --network=host finestructure/r
 # export LOG_LEVEL=warning
 
 while true; do
-    time vapor-beta run ingest -l 100
+    time swift run Run ingest -l 100
     # $rester restfiles/ingest.restfile
     echo Pausing...
     sleep 2


### PR DESCRIPTION
Not sure about this one, but the `vapor-beta` command seems like a left-over or at least doesn't work anymore