### PR TITLE
Apply shellcheck to the scripts folder

### DIFF
--- a/scripts/base64_images.sh
+++ b/scripts/base64_images.sh
@@ -2,5 +2,5 @@
 
 for filename in Resources/SVGs/*.svg; do
   [ -e "$filename" ] || continue
-  base64 -i $filename -o ${filename}.base64  
+  base64 -i "$filename" -o "${filename}".base64  
 done

--- a/scripts/convert_to_db_dump.sh
+++ b/scripts/convert_to_db_dump.sh
@@ -16,7 +16,7 @@ docker network create backup || true
 
 echo "Unpacking ..."
 
-tar xfz $TARFILE
+tar xfz "$TARFILE"
 
 echo "Launching backup db ..."
 
@@ -31,10 +31,10 @@ RETRIES=30
 until docker run --rm --name pg_dump \
     -v "$PWD":/host \
     --network backup \
-    --env PGPASSWORD=$DATABASE_PASSWORD \
+    --env PGPASSWORD="$DATABASE_PASSWORD" \
     $PG_IMAGE \
-    pg_dump --no-owner -Fc -f /host/$DUMPFILE \
-        -h backup-db -U spi_${ENV} spi_${ENV} \
+    pg_dump --no-owner -Fc -f /host/"$DUMPFILE" \
+        -h backup-db -U spi_"${ENV}" spi_"${ENV}" \
     || [ $RETRIES -eq 0 ]; do
     echo "Waiting for postgres server, $((RETRIES-=1)) remaining attempts..."
     sleep 5
@@ -42,9 +42,9 @@ until docker run --rm --name pg_dump \
 done
 
 echo "Moving file"
-mv $DUMPFILE $DB_BACKUP_DIR
+mv "$DUMPFILE" "$DB_BACKUP_DIR"
 
 echo "Cleaning up"
-rm $TARFILE
+rm "$TARFILE"
 rm -rf db_data
 docker rm -f backup-db

--- a/scripts/db_backup.sh
+++ b/scripts/db_backup.sh
@@ -7,11 +7,11 @@ TARFILE=$1
 echo "Backing up database to $PWD/$TARFILE ..."
 
 docker run --rm \
-    -v $PWD:/host \
+    -v "$PWD":/host \
     -v spi_db_data:/db_data \
     -w /host \
     ubuntu \
-    tar cfz $TARFILE /db_data
+    tar cfz "$TARFILE" /db_data
 
 echo "done."
 

--- a/scripts/dump-dev-db.sh
+++ b/scripts/dump-dev-db.sh
@@ -2,4 +2,4 @@
 # This command assumes the dev db to be available on port 7432 on localhost, via an ssh tunnel:
 # ssh -i <your private key> -L 7432:db:5432 -p 2222 root@173.255.229.82
 PORT=${SPI_STAGING_DB_PORT:-'7432'}
-pg_dump --no-owner -Fc -h localhost -p $PORT -U spi_dev@spi-dev-db-1 spi_dev > spi_dev_$(date +%Y-%m-%d).dump
+pg_dump --no-owner -Fc -h localhost -p "$PORT" -U spi_dev@spi-dev-db-1 spi_dev > spi_dev_$(date +%Y-%m-%d).dump

--- a/scripts/dump-prod-db.sh
+++ b/scripts/dump-prod-db.sh
@@ -6,5 +6,5 @@ then
   # This command assumes the prod db to be available on port 7432 on localhost, via an ssh tunnel:
   # ssh -i <your private key> -L 7432:db:5432 -p 2222 root@173.255.229.82
   PORT=${SPI_PRODUCTION_DB_PORT:-'7432'}
-  pg_dump --no-owner -Fc -h localhost -p $PORT -U spi_prod@spi-prod-db-1 spi_prod > spi_prod_$(date +%Y-%m-%d).dump
+  pg_dump --no-owner -Fc -h localhost -p "$PORT" -U spi_prod@spi-prod-db-1 spi_prod > spi_prod_$(date +%Y-%m-%d).dump
 fi

--- a/scripts/load-db.sh
+++ b/scripts/load-db.sh
@@ -6,4 +6,4 @@ docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POS
 echo "Giving Postgres a moment to launch ..."
 sleep 5
 echo "Importing"
-PGPASSWORD=xxx pg_restore --no-owner -h ${HOST:-localhost} -p 6432 -U spi_dev -d spi_dev < $IMPORT_FILE
+PGPASSWORD=xxx pg_restore --no-owner -h "${HOST:-localhost}" -p 6432 -U spi_dev -d spi_dev < "$IMPORT_FILE"


### PR DESCRIPTION
Details in #1122, PR applied Shellcheck suggestions to the scripts folder.

**⚠️ Please, make sure that the scripts work as expected ⚠️**

Shellcheck (version: `0.7.2`) command I've used:

```bash
$ shellcheck -s bash -f diff -P scripts/*.sh | git apply
```

Although Shellcheck won't stay silent after the merge, I think it's okay to skip the following issues:

```bash
$ shellcheck -s bash -P scripts/*.sh

In scripts/download-prod-db.sh line 3:
scp spi@208.52.185.253:~/Desktop/DB-Backups/spi_prod_$(date +%Y-%m-%d).dump .
                                                     ^---------------^ SC2046: Quote this to prevent word splitting.


In scripts/dump-dev-db.sh line 5:
pg_dump --no-owner -Fc -h localhost -p "$PORT" -U spi_dev@spi-dev-db-1 spi_dev > spi_dev_$(date +%Y-%m-%d).dump
                                                                                         ^---------------^ SC2046: Quote this to prevent word splitting.


In scripts/dump-prod-db.sh line 9:
  pg_dump --no-owner -Fc -h localhost -p "$PORT" -U spi_prod@spi-prod-db-1 spi_prod > spi_prod_$(date +%Y-%m-%d).dump
                                                                                               ^---------------^ SC2046: Quote this to prevent word splitting.


In scripts/ingest-loop.sh line 5:
rester="docker run --rm -t -v $PWD:/host -w /host --network=host finestructure/rester"
^----^ SC2034: rester appears unused. Verify use (or export if used externally).
```