### PR TITLE
Use organization title or user name as display owner name

### DIFF
--- a/Resources/Styles/base.scss
+++ b/Resources/Styles/base.scss
@@ -178,3 +178,12 @@ a.download {
   visibility: hidden;
   transition: visibility 0s 0.2s, opacity 0.2s linear;
 }
+
+.trimmed {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.collapsable {
+  min-width: 0;
+}

--- a/Sources/App/Controllers/AuthorController.swift
+++ b/Sources/App/Controllers/AuthorController.swift
@@ -33,6 +33,7 @@ struct AuthorController {
             .map {
                 AuthorShow.Model(
                     owner: $0.first?.repository?.owner ?? owner,
+                    ownerName: $0.first?.repository?.ownerDisplayName ?? owner,
                     packages: $0.sorted(by: { $0.score ?? 0 > $1.score ?? 0 })
                                 .compactMap { AuthorShow.PackageInfo(package: $0) }
                 )

--- a/Sources/App/Core/Twitter.swift
+++ b/Sources/App/Core/Twitter.swift
@@ -73,20 +73,20 @@ extension Twitter {
     }
 
     static func newPackageMessage(packageName: String,
-                                  repositoryOwner: String,
+                                  repositoryOwnerName: String,
                                   url: String,
                                   summary: String?) -> String {
-        createMessage(preamble: "📦 \(repositoryOwner) just added a new package, \(packageName)",
+        createMessage(preamble: "📦 \(repositoryOwnerName) just added a new package, \(packageName)",
                       summary: summary,
                       url: url)
     }
 
     static func versionUpdateMessage(packageName: String,
-                                     repositoryOwner: String,
+                                     repositoryOwnerName: String,
                                      url: String,
                                      version: SemanticVersion,
                                      summary: String?) -> String {
-        createMessage(preamble: "⬆️ \(repositoryOwner) just released \(packageName) v\(version)",
+        createMessage(preamble: "⬆️ \(repositoryOwnerName) just released \(packageName) v\(version)",
                       summary: summary,
                       url: url)
     }
@@ -100,16 +100,17 @@ extension Twitter {
                 guard let packageName = version.packageName,
                       let repoName = repo?.name,
                       let owner = repo?.owner,
+                      let ownerName = repo?.ownerDisplayName,
                       let semVer = version.reference?.semVer
                 else { return nil }
                 let url = SiteURL.package(.value(owner), .value(repoName), .none).absoluteURL()
                 return pkg.isNew
                     ? newPackageMessage(packageName: packageName,
-                                        repositoryOwner: owner,
+                                        repositoryOwnerName: ownerName,
                                         url: url,
                                         summary: repo?.summary)
                     : versionUpdateMessage(packageName: packageName,
-                                           repositoryOwner: owner,
+                                           repositoryOwnerName: ownerName,
                                            url: url,
                                            version: semVer,
                                            summary: repo?.summary)

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -168,3 +168,9 @@ extension Repository: Equatable {
         lhs.id == rhs.id
     }
 }
+
+extension Repository {
+    var ownerDisplayName: String? {
+        ownerName ?? owner
+    }
+}

--- a/Sources/App/Views/Author/AuthorShow+Model.swift
+++ b/Sources/App/Views/Author/AuthorShow+Model.swift
@@ -1,15 +1,19 @@
 extension AuthorShow {
     struct Model {
         var owner: String
+        var ownerName: String
         var packages: [PackageInfo]
         
         var count: Int {
             packages.count
         }
         
-        internal init(owner: String,
-                      packages: [PackageInfo]) {
+        internal init(
+            owner: String,
+            ownerName: String,
+            packages: [PackageInfo]) {
             self.owner = owner
+            self.ownerName = ownerName
             self.packages = packages
         }
     }

--- a/Sources/App/Views/Author/AuthorShow+View.swift
+++ b/Sources/App/Views/Author/AuthorShow+View.swift
@@ -13,17 +13,17 @@ enum AuthorShow {
         }
 
         override func pageTitle() -> String? {
-            "Packages by \(model.owner)"
+            "Packages by \(model.ownerName)"
         }
 
         override func pageDescription() -> String? {
             let packagesClause = model.packages.count > 1 ? "1 package" : "\(model.packages.count) packages"
-            return "The Swift Package Index is indexing \(packagesClause) authored by \(model.owner)."
+            return "The Swift Package Index is indexing \(packagesClause) authored by \(model.ownerName)."
         }
 
         override func content() -> Node<HTML.BodyContext> {
             .group(
-                .h2(.text("Packages authored by \(model.owner)")),
+                .h2(.text("Packages authored by \(model.ownerName)")),
                 .ul(
                     .id("package_list"),
                     .group(

--- a/Sources/App/Views/Author/AuthorShow+View.swift
+++ b/Sources/App/Views/Author/AuthorShow+View.swift
@@ -23,7 +23,10 @@ enum AuthorShow {
 
         override func content() -> Node<HTML.BodyContext> {
             .group(
-                .h2(.text("Packages authored by \(model.ownerName)")),
+                .h2(
+                    .class("trimmed"),
+                    .text("Packages authored by \(model.ownerName)")
+                ),
                 .ul(
                     .id("package_list"),
                     .group(

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -8,6 +8,7 @@ extension PackageShow {
     struct Model: Equatable {
         var packageId: Package.Id
         var repositoryOwner: String
+        var repositoryOwnerName: String
         var repositoryName: String
         var activity: Activity?
         var authors: [Link]?
@@ -28,6 +29,7 @@ extension PackageShow {
         
         internal init(packageId: Package.Id,
                       repositoryOwner: String,
+                      repositoryOwnerName: String,
                       repositoryName: String,
                       activity: Activity? = nil,
                       authors: [Link]? = nil,
@@ -47,6 +49,7 @@ extension PackageShow {
                       isArchived: Bool) {
             self.packageId = packageId
             self.repositoryOwner = repositoryOwner
+            self.repositoryOwnerName = repositoryOwnerName
             self.repositoryName = repositoryName
             self.activity = activity
             self.authors = authors
@@ -71,6 +74,7 @@ extension PackageShow {
             guard
                 let repository = package.repository,
                 let repositoryOwner = repository.owner,
+                let repositoryOwnerName = repository.ownerDisplayName,
                 let repositoryName = repository.name,
                 let packageId = package.id
             else { return nil }
@@ -78,6 +82,7 @@ extension PackageShow {
             self.init(
                 packageId: packageId,
                 repositoryOwner: repositoryOwner,
+                repositoryOwnerName: repositoryOwnerName,
                 repositoryName: repositoryName,
                 activity: package.activity(),
                 authors: package.authors(),

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -18,7 +18,7 @@ enum PackageShow {
         }
         
         override func pageDescription() -> String? {
-            var description = "\(model.title) by \(model.repositoryOwner) on the Swift Package Index"
+            var description = "\(model.title) by \(model.repositoryOwnerName) on the Swift Package Index"
             if let summary = model.summary {
                 description += " – \(summary)"
             }
@@ -143,7 +143,7 @@ enum PackageShow {
                     .li(
                         .a(
                             .href(SiteURL.author(.value(model.repositoryOwner)).relativeURL()),
-                            "More packages from this author"
+                            "More packages from \(model.repositoryOwnerName)"
                         )
                     ),
                     .li(

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -141,7 +141,9 @@ enum PackageShow {
                         )
                     ),
                     .li(
+                        .class("collapsable"),
                         .a(
+                            .class("trimmed"),
                             .href(SiteURL.author(.value(model.repositoryOwner)).relativeURL()),
                             "More packages from \(model.repositoryOwnerName)"
                         )

--- a/Tests/AppTests/Mocks/AuthorShow+mock.swift
+++ b/Tests/AppTests/Mocks/AuthorShow+mock.swift
@@ -10,6 +10,6 @@ extension AuthorShow.Model {
             description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas nec orci scelerisque, interdum purus a, tempus turpis.",
             url: ""
         ) }
-        return .init(owner: "test-author", packages: packages)
+        return .init(owner: "test-author", ownerName: "Test Author", packages: packages)
     }
 }

--- a/Tests/AppTests/Mocks/PackageShowModel+mock.swift
+++ b/Tests/AppTests/Mocks/PackageShowModel+mock.swift
@@ -8,6 +8,7 @@ extension PackageShow.Model {
         .init(
             packageId: UUID("cafecafe-cafe-cafe-cafe-cafecafecafe")!,
             repositoryOwner: "Alamo",
+            repositoryOwnerName: "Alamo",
             repositoryName: "Alamofire",
             activity: .init(
                 openIssuesCount: 27,

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -10,7 +10,7 @@ class TwitterTests: AppTestCase {
         XCTAssertEqual(
             Twitter.versionUpdateMessage(
                 packageName: "packageName",
-                repositoryOwner: "owner",
+                repositoryOwnerName: "owner",
                 url: "http://localhost:8080/owner/SuperAwesomePackage",
                 version: .init(2, 6, 4),
                 summary: "This is a test package"),
@@ -25,7 +25,7 @@ class TwitterTests: AppTestCase {
         XCTAssertEqual(
             Twitter.versionUpdateMessage(
                 packageName: "packageName",
-                repositoryOwner: "owner",
+                repositoryOwnerName: "owner",
                 url: "http://localhost:8080/owner/SuperAwesomePackage",
                 version: .init(2, 6, 4),
                 summary: nil),
@@ -40,7 +40,7 @@ class TwitterTests: AppTestCase {
         XCTAssertEqual(
             Twitter.versionUpdateMessage(
                 packageName: "packageName",
-                repositoryOwner: "owner",
+                repositoryOwnerName: "owner",
                 url: "http://localhost:8080/owner/SuperAwesomePackage",
                 version: .init(2, 6, 4),
                 summary: ""),
@@ -55,7 +55,7 @@ class TwitterTests: AppTestCase {
         XCTAssertEqual(
             Twitter.versionUpdateMessage(
                 packageName: "packageName",
-                repositoryOwner: "owner",
+                repositoryOwnerName: "owner",
                 url: "http://localhost:8080/owner/SuperAwesomePackage",
                 version: .init(2, 6, 4),
                 summary: " \n"),
@@ -70,7 +70,7 @@ class TwitterTests: AppTestCase {
     func test_versionUpdateMessage_trimming() throws {
         let msg = Twitter.versionUpdateMessage(
             packageName: "packageName",
-            repositoryOwner: "owner",
+            repositoryOwnerName: "owner",
             url: "http://localhost:8080/owner/SuperAwesomePackage",
             version: .init(2, 6, 4),
             summary: String(repeating: "x", count: 280)
@@ -88,7 +88,7 @@ class TwitterTests: AppTestCase {
         XCTAssertEqual(
             Twitter.newPackageMessage(
                 packageName: "packageName",
-                repositoryOwner: "owner",
+                repositoryOwnerName: "owner",
                 url: "http://localhost:8080/owner/SuperAwesomePackage",
                 summary: "This is a test package"),
             """


### PR DESCRIPTION
Resolves #980

Two pairs of screenshots to demonstrate the text truncation behavior. The long words are going to be truncated; the rest will be wrapped to the following line.

- Reeeally not sure about the `Package's page` changes 🤔
- UI tests should fail at this point
- CSS classes probably need a more delicate attitude

### Author's Page

![Screenshot 2021-05-26 at 11 19 08](https://user-images.githubusercontent.com/765790/119658650-12ed8700-be36-11eb-9135-658eb49c8781.png)
![Screenshot 2021-05-26 at 11 22 21](https://user-images.githubusercontent.com/765790/119658654-13861d80-be36-11eb-8a22-eea259ead8c6.png)

### Package's Page

![Screenshot 2021-05-26 at 11 22 35](https://user-images.githubusercontent.com/765790/119658610-0406d480-be36-11eb-8bc8-1d95fdbd5302.png)
![Screenshot 2021-05-26 at 11 25 24](https://user-images.githubusercontent.com/765790/119658613-05380180-be36-11eb-8c9e-2ae94a83d92b.png)
