### PR TITLE
Extend product library type

### DIFF
--- a/Sources/App/Commands/ReAnalyzeVersions.swift
+++ b/Sources/App/Commands/ReAnalyzeVersions.swift
@@ -37,7 +37,7 @@ struct ReAnalyzeVersionsCommand: Command {
                                   id: id)
                 .wait()
         } else {
-            guard let cutoffDate = signature.before ?? Current.reAnalyzeVersionsBeforeDate() else {
+            guard let cutoffDate = signature.before else {
                 logger.info("No cut-off date set, skipping re-analysis")
                 return
             }

--- a/Sources/App/Commands/ReAnalyzeVersions.swift
+++ b/Sources/App/Commands/ReAnalyzeVersions.swift
@@ -3,9 +3,12 @@ import Fluent
 
 
 struct ReAnalyzeVersionsCommand: Command {
+    let defaultBatchSize = 10
     let defaultLimit = 1
 
     struct Signature: CommandSignature {
+        @Option(name: "batchSize", short: "b")
+        var batchSize: Int?
         @Option(name: "limit", short: "l")
         var limit: Int?
         @Option(name: "id")
@@ -40,10 +43,10 @@ struct ReAnalyzeVersionsCommand: Command {
             }
 
             logger.info("Re-analyzing versions (limit: \(limit)) ...")
-            let batchSize = 100
             var processed = 0
             while processed < limit {
-                let currentBatchSize = min(batchSize, limit - processed)
+                let currentBatchSize = min(signature.batchSize ?? defaultBatchSize,
+                                           limit - processed)
                 logger.info("Re-analyzing versions (batch: \(processed)..<\(processed + currentBatchSize) ...")
                 try reAnalyzeVersions(client: client,
                                       database: db,

--- a/Sources/App/Commands/ReAnalyzeVersions.swift
+++ b/Sources/App/Commands/ReAnalyzeVersions.swift
@@ -40,13 +40,20 @@ struct ReAnalyzeVersionsCommand: Command {
             }
 
             logger.info("Re-analyzing versions (limit: \(limit)) ...")
-            try reAnalyzeVersions(client: client,
-                                  database: db,
-                                  logger: logger,
-                                  threadPool: threadPool,
-                                  before: cutoffDate,
-                                  limit: limit)
+            let batchSize = 100
+            var processed = 0
+            while processed < limit {
+                let currentBatchSize = min(batchSize, limit - processed)
+                logger.info("Re-analyzing versions (batch: \(processed)..<\(processed + currentBatchSize) ...")
+                try reAnalyzeVersions(client: client,
+                                      database: db,
+                                      logger: logger,
+                                      threadPool: threadPool,
+                                      before: cutoffDate,
+                                      limit: currentBatchSize)
                 .wait()
+                processed += currentBatchSize
+            }
         }
         try AppMetrics.push(client: client,
                             logger: logger,

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -25,7 +25,6 @@ struct AppEnvironment {
     var logger: () -> Logger?
     var metricsPushGatewayUrl: () -> String?
     var random: (_ range: ClosedRange<Double>) -> Double
-    var reAnalyzeVersionsBeforeDate: () -> Date?
     var reportError: (_ client: Client, _ level: AppError.Level, _ error: Error) -> EventLoopFuture<Void>
     var rollbarToken: () -> String?
     var rollbarLogLevel: () -> AppError.Level
@@ -92,9 +91,6 @@ extension AppEnvironment {
         logger: { logger },
         metricsPushGatewayUrl: { Environment.get("METRICS_PUSHGATEWAY_URL") },
         random: Double.random,
-        reAnalyzeVersionsBeforeDate: { Environment.get("RE_ANALYZE_VERSIONS_BEFORE_DATE")
-            .flatMap(Date.init(yyyyMMdd:))
-        },
         reportError: AppError.report,
         rollbarToken: { Environment.get("ROLLBAR_TOKEN") },
         rollbarLogLevel: {

--- a/Sources/App/Core/Extensions/Date+LosslessStringConvertible.swift
+++ b/Sources/App/Core/Extensions/Date+LosslessStringConvertible.swift
@@ -3,6 +3,7 @@ import Foundation
 
 // LosslessStringConvertible conformance is required by @Option command line argument conversion
 extension Date: LosslessStringConvertible {
+    private static let iso8601: ISO8601DateFormatter = ISO8601DateFormatter()
     private static let ymd: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
@@ -11,12 +12,15 @@ extension Date: LosslessStringConvertible {
         return formatter
     }()
 
-    public init?(yyyyMMdd: String) {
-        guard let date = Self.ymd.date(from: yyyyMMdd) else { return nil }
-        self = date
-    }
-
     public init?(_ string: String) {
-        self.init(yyyyMMdd: string)
+        if let date = Self.ymd.date(from: string) {
+            self = date
+            return
+        }
+        if let date = Self.iso8601.date(from: string) {
+            self = date
+            return
+        }
+        return nil
     }
 }

--- a/Sources/App/Core/PackageCollection+generate.swift
+++ b/Sources/App/Core/PackageCollection+generate.swift
@@ -189,8 +189,12 @@ private extension PackageCollection.ProductType {
         switch productType {
             case .executable:
                 self = .executable
-            case .library:  // TODO: wire up detailed data
+            case .library(.automatic):
                 self = .library(.automatic)
+            case .library(.dynamic):
+                self = .library(.dynamic)
+            case .library(.static):
+                self = .library(.static)
             case .test:
                 self = .test
         }

--- a/Sources/App/Core/PackageCollection+generate.swift
+++ b/Sources/App/Core/PackageCollection+generate.swift
@@ -185,7 +185,7 @@ private extension PackageCollection.Product {
 
 
 private extension PackageCollection.ProductType {
-    init?(productType: App.Product.`Type`) {
+    init?(productType: App.ProductType) {
         switch productType {
             case .executable:
                 self = .executable

--- a/Sources/App/Core/PackageCollection+generate.swift
+++ b/Sources/App/Core/PackageCollection+generate.swift
@@ -191,6 +191,8 @@ private extension PackageCollection.ProductType {
                 self = .executable
             case .library:  // TODO: wire up detailed data
                 self = .library(.automatic)
+            case .test:
+                self = .test
         }
     }
 }

--- a/Sources/App/Core/PackageCollection+generate.swift
+++ b/Sources/App/Core/PackageCollection+generate.swift
@@ -174,8 +174,8 @@ private extension PackageCollection.Target {
 
 private extension PackageCollection.Product {
     init?(product: App.Product) {
-        guard let type = PackageCollection
-                .ProductType(productType: product.type)
+        guard let type = product.type
+                .flatMap(PackageCollection.ProductType.init(productType:))
         else { return nil }
         self.init(name: product.name,
                   type: type,

--- a/Sources/App/Migrations/028/UpdateProductType.swift
+++ b/Sources/App/Migrations/028/UpdateProductType.swift
@@ -1,0 +1,17 @@
+import Fluent
+
+struct UpdateProductType: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("products")
+            .deleteField("type")
+            .field("type", .json, .required)
+            .update()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("products")
+            .deleteField("type")
+            .field("type", .string, .required)
+            .update()
+    }
+}

--- a/Sources/App/Migrations/028/UpdateProductType.swift
+++ b/Sources/App/Migrations/028/UpdateProductType.swift
@@ -4,7 +4,7 @@ struct UpdateProductType: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         database.schema("products")
             .deleteField("type")
-            .field("type", .json, .required)
+            .field("type", .json)
             .update()
     }
 

--- a/Sources/App/Models/Product.swift
+++ b/Sources/App/Models/Product.swift
@@ -55,13 +55,18 @@ enum ProductType: Equatable {
     case library(LibraryType)
     case test
 
-    init(manifestProductType: Manifest.Product.`Type`) {
+    init(manifestProductType: Manifest.ProductType) {
         switch manifestProductType {
             case .executable:
                 self = .executable
-            case .library:
-                // FIXME: extend manifest parsing
+            case .library(.automatic):
                 self = .library(.automatic)
+            case .library(.dynamic):
+                self = .library(.dynamic)
+            case .library(.static):
+                self = .library(.static)
+            case .test:
+                self = .test
         }
     }
 

--- a/Sources/App/Models/Product.swift
+++ b/Sources/App/Models/Product.swift
@@ -26,7 +26,7 @@ final class Product: Model, Content {
     // data fields
     
     @Field(key: "type")
-    var type: `Type`
+    var type: ProductType
     
     @Field(key: "name")
     var name: String
@@ -38,7 +38,7 @@ final class Product: Model, Content {
     
     init(id: Id? = nil,
          version: Version,
-         type: `Type`,
+         type: ProductType,
          name: String,
          targets: [String] = []) throws {
         self.id = id
@@ -50,24 +50,42 @@ final class Product: Model, Content {
 }
 
 
-extension Product {
-    enum `Type`: String, Codable {
-        case executable
-        case library
-        case test
+enum ProductType: Equatable {
+    case executable
+    case library(LibraryType)
+    case test
 
-        init(manifestProductType: Manifest.Product.`Type`) {
-            switch manifestProductType {
-                case .executable:
-                    self = .executable
-                case .library:
-                    self = .library
-            }
+    init(manifestProductType: Manifest.Product.`Type`) {
+        switch manifestProductType {
+            case .executable:
+                self = .executable
+            case .library:
+                // FIXME: extend manifest parsing
+                self = .library(.automatic)
         }
     }
-    
-    var isLibrary: Bool { return type == .library }
-    var isExecutable: Bool { return type == .executable }
+
+    enum LibraryType: String, Codable {
+        case automatic
+        case `dynamic`
+        case `static`
+    }
+}
+
+
+extension Product {
+    var isLibrary: Bool {
+        switch type {
+            case .library: return true
+            case .executable, .test: return false
+        }
+    }
+    var isExecutable: Bool {
+        switch type {
+            case .executable: return true
+            case .library, .test: return false
+        }
+    }
 }
 
 
@@ -75,4 +93,58 @@ extension Product: Equatable {
     static func == (lhs: Product, rhs: Product) -> Bool {
         lhs.id == rhs.id
     }
+}
+
+
+
+// https://github.com/apple/swift-evolution/blob/main/proposals/0295-codable-synthesis-for-enums-with-associated-values.md
+@available(swift, deprecated: 5.5, message: "Remove when Codable synthesis for enums with associated values (SE-0295) ships")
+extension ProductType: Codable {
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        guard container.allKeys.count == 1 else {
+            throw DecodingError.typeMismatch(Self.self, .init(
+                codingPath: container.codingPath,
+                debugDescription: "Invalid number of keys found, expected one."
+            ))
+        }
+
+        switch container.allKeys.first! {
+            case .executable:
+                self = .executable
+            case .library:
+                let nestedContainer = try container.nestedContainer(keyedBy: LibraryCodingKeys.self, forKey: .library)
+                let type = try nestedContainer.decode(LibraryType.self, forKey: ._0)
+                self = .library(type)
+            case .test:
+                self = .test
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+            case .executable:
+                try container.encode(Empty(), forKey: .executable)
+            case let .library(type):
+                var nestedContainer = container.nestedContainer(keyedBy: LibraryCodingKeys.self, forKey: .library)
+                try nestedContainer.encode(type, forKey: ._0)
+            case .test:
+                try container.encode(Empty(), forKey: .test)
+        }
+    }
+
+    struct Empty: Encodable {}
+
+    enum CodingKeys: CodingKey {
+        case executable
+        case library
+        case test
+    }
+
+    enum LibraryCodingKeys: CodingKey {
+        case _0
+    }
+
 }

--- a/Sources/App/Models/Product.swift
+++ b/Sources/App/Models/Product.swift
@@ -26,7 +26,7 @@ final class Product: Model, Content {
     // data fields
     
     @Field(key: "type")
-    var type: ProductType
+    var type: ProductType?
     
     @Field(key: "name")
     var name: String
@@ -78,12 +78,14 @@ extension Product {
         switch type {
             case .library: return true
             case .executable, .test: return false
+            case .none: return false
         }
     }
     var isExecutable: Bool {
         switch type {
             case .executable: return true
             case .library, .test: return false
+            case .none: return false
         }
     }
 }

--- a/Sources/App/Models/Product.swift
+++ b/Sources/App/Models/Product.swift
@@ -54,6 +54,7 @@ extension Product {
     enum `Type`: String, Codable {
         case executable
         case library
+        case test
 
         init(manifestProductType: Manifest.Product.`Type`) {
             switch manifestProductType {

--- a/Sources/App/Models/Product.swift
+++ b/Sources/App/Models/Product.swift
@@ -96,7 +96,6 @@ extension Product: Equatable {
 }
 
 
-
 // https://github.com/apple/swift-evolution/blob/main/proposals/0295-codable-synthesis-for-enums-with-associated-values.md
 @available(swift, deprecated: 5.5, message: "Remove when Codable synthesis for enums with associated values (SE-0295) ships")
 extension ProductType: Codable {
@@ -148,3 +147,8 @@ extension ProductType: Codable {
     }
 
 }
+
+
+// PostgresKit.PostgresJSONBCodable is a workaround for https://github.com/vapor/postgres-kit/issues/207
+import PostgresKit
+extension ProductType: PostgresJSONBCodable { }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -127,6 +127,9 @@ public func configure(_ app: Application) throws {
     do {  // Migration 027 - add owner name, owner avatar url, and is in organization metadata to repositories
         app.migrations.add(UpdateRepositoryAddOwnerFields())
     }
+    do {  // Migration 028 - change products.type from string to json
+        app.migrations.add(UpdateProductType())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -152,7 +152,7 @@ class AnalyzerTests: AppTestCase {
         assertEquals(products, \.name, ["p1", "p1", "p1", "p2", "p2", "p2"])
         assertEquals(products, \.targets,
                      [["t1"], ["t1"], ["t1"], ["t2"], ["t2"], ["t2"]])
-        assertEquals(products, \.type, [.executable, .executable, .executable, .library, .library, .library])
+        assertEquals(products, \.type, [.executable, .executable, .executable, .library(.automatic), .library(.automatic), .library(.automatic)])
 
         // validate targets
         // (2 packages with 3 versions with 1 target each = 6 targets)
@@ -698,7 +698,7 @@ class AnalyzerTests: AppTestCase {
         let products = try Product.query(on: app.db).sort(\.$createdAt).all().wait()
         XCTAssertEqual(products.map(\.name), ["p1", "p2"])
         XCTAssertEqual(products.map(\.targets), [["t1", "t2"], ["t3", "t4"]])
-        XCTAssertEqual(products.map(\.type), [.library, .executable])
+        XCTAssertEqual(products.map(\.type), [.library(.automatic), .executable])
     }
     
     func test_createTargets() throws {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -78,7 +78,7 @@ class AnalyzerTests: AppTestCase {
                           "name": "p2",
                           "targets": ["t2"],
                           "type": {
-                            "library": []
+                            "library": ["automatic"]
                           }
                         }
                       ],
@@ -682,7 +682,7 @@ class AnalyzerTests: AppTestCase {
         let m = Manifest(name: "1",
                          products: [.init(name: "p1",
                                           targets: ["t1", "t2"],
-                                          type: .library),
+                                          type: .library(.automatic)),
                                     .init(name: "p2",
                                           targets: ["t3", "t4"],
                                           type: .executable)],

--- a/Tests/AppTests/Controllers/AuthorControllerTests.swift
+++ b/Tests/AppTests/Controllers/AuthorControllerTests.swift
@@ -24,7 +24,7 @@ class AuthorControllerTests: AppTestCase {
                                   package: package,
                                   packageName: "Test package",
                                   reference: .branch("main"))
-        let product = try Product(id: UUID(), version: version, type: .library, name: "Library")
+        let product = try Product(id: UUID(), version: version, type: .library(.automatic), name: "Library")
         
         try package.save(on: app.db).wait()
         try repository.save(on: app.db).wait()

--- a/Tests/AppTests/Controllers/PackageControllerTests.swift
+++ b/Tests/AppTests/Controllers/PackageControllerTests.swift
@@ -24,7 +24,7 @@ class PackageControllerTests: AppTestCase {
                                   package: package,
                                   packageName: "Test package",
                                   reference: .branch("main"))
-        let product = try Product(id: UUID(), version: version, type: .library, name: "Library")
+        let product = try Product(id: UUID(), version: version, type: .library(.automatic), name: "Library")
         
         try package.save(on: app.db).wait()
         try repository.save(on: app.db).wait()

--- a/Tests/AppTests/ManifestTests.swift
+++ b/Tests/AppTests/ManifestTests.swift
@@ -17,9 +17,10 @@ class ManifestTests: XCTestCase {
             """
             let data = Data(json.utf8)
             struct Test: Decodable, Equatable {
-                var type: Manifest.Product.`Type`
+                var type: Manifest.ProductType
             }
-            XCTAssertEqual(try JSONDecoder().decode(Test.self, from: data), .init(type: .executable))
+            XCTAssertEqual(try JSONDecoder().decode(Test.self, from: data),
+                           .init(type: .executable))
         }
         do { // lib
             let json = """
@@ -31,9 +32,10 @@ class ManifestTests: XCTestCase {
             """
             let data = Data(json.utf8)
             struct Test: Decodable, Equatable {
-                var type: Manifest.Product.`Type`
+                var type: Manifest.ProductType
             }
-            XCTAssertEqual(try JSONDecoder().decode(Test.self, from: data), .init(type: .library))
+            XCTAssertEqual(try JSONDecoder().decode(Test.self, from: data),
+                           .init(type: .library(.automatic)))
         }
     }
     
@@ -44,7 +46,7 @@ class ManifestTests: XCTestCase {
         XCTAssertEqual(m.platforms, [.init(platformName: .macos, version: "10.15")])
         XCTAssertEqual(m.products, [.init(name: "Some Product",
                                           targets: ["t1", "t2"],
-                                          type: .library)])
+                                          type: .library(.automatic))])
         XCTAssertEqual(m.swiftLanguageVersions, ["4", "4.2", "5"])
         XCTAssertEqual(m.targets, [.init(name: "App"),
                                    .init(name: "Run"),
@@ -94,28 +96,28 @@ class ManifestTests: XCTestCase {
                   type: .executable),
             .init(name: "NIO",
                   targets: ["NIO"],
-                  type: .library),
+                  type: .library(.automatic)),
             .init(name: "_NIO1APIShims",
                   targets: ["_NIO1APIShims"],
-                  type: .library),
+                  type: .library(.automatic)),
             .init(name: "NIOTLS",
                   targets: ["NIOTLS"],
-                  type: .library),
+                  type: .library(.automatic)),
             .init(name: "NIOHTTP1",
                   targets: ["NIOHTTP1"],
-                  type: .library),
+                  type: .library(.automatic)),
             .init(name: "NIOConcurrencyHelpers",
                   targets: ["NIOConcurrencyHelpers"],
-                  type: .library),
+                  type: .library(.automatic)),
             .init(name: "NIOFoundationCompat",
                   targets: ["NIOFoundationCompat"],
-                  type: .library),
+                  type: .library(.automatic)),
             .init(name: "NIOWebSocket",
                   targets: ["NIOWebSocket"],
-                  type: .library),
+                  type: .library(.automatic)),
             .init(name: "NIOTestUtils",
                   targets: ["NIOTestUtils"],
-                  type: .library),
+                  type: .library(.automatic)),
         ])
     }
     

--- a/Tests/AppTests/ManifestTests.swift
+++ b/Tests/AppTests/ManifestTests.swift
@@ -7,35 +7,77 @@ import XCTest
 class ManifestTests: XCTestCase {
     
     func test_decode_Product_Type() throws {
+        // Test product type decoding.
+        // JSON snippets via `swift package dump-package` from the following
+        // Package.swift `products` definition:
+        //        products: [
+        //            .executable(name: "foo", targets: ["spm-test"]),
+        //            .library(name: "spm-test-automatic",
+        //                     targets: ["spm-test"]),
+        //            .library(name: "spm-test-dynamic",
+        //                     type: .dynamic, targets: ["spm-test"]),
+        //            .library(name: "spm-test-static",
+        //                     type: .static, targets: ["spm-test"])
+        //        ],
+
+        struct Test: Decodable, Equatable {
+            var type: Manifest.ProductType
+        }
+        
         do { // exe
-            let json = """
+            let data = Data("""
             {
                 "type": {
                     "executable": null
                 }
             }
-            """
-            let data = Data(json.utf8)
-            struct Test: Decodable, Equatable {
-                var type: Manifest.ProductType
-            }
+            """.utf8)
             XCTAssertEqual(try JSONDecoder().decode(Test.self, from: data),
                            .init(type: .executable))
         }
-        do { // lib
-            let json = """
+        do { // lib - automatic
+            let data = Data("""
             {
                 "type": {
                     "library": ["automatic"]
                 }
             }
-            """
-            let data = Data(json.utf8)
-            struct Test: Decodable, Equatable {
-                var type: Manifest.ProductType
-            }
+            """.utf8)
             XCTAssertEqual(try JSONDecoder().decode(Test.self, from: data),
                            .init(type: .library(.automatic)))
+        }
+        do { // lib - dynamic
+            let data = Data("""
+            {
+                "type": {
+                    "library": ["dynamic"]
+                }
+            }
+            """.utf8)
+            XCTAssertEqual(try JSONDecoder().decode(Test.self, from: data),
+                           .init(type: .library(.dynamic)))
+        }
+        do { // lib - static
+            let data = Data("""
+            {
+                "type": {
+                    "library": ["static"]
+                }
+            }
+            """.utf8)
+            XCTAssertEqual(try JSONDecoder().decode(Test.self, from: data),
+                           .init(type: .library(.static)))
+        }
+        do { // test
+            let data = Data("""
+            {
+                "type": {
+                    "test": null
+                }
+            }
+            """.utf8)
+            XCTAssertEqual(try JSONDecoder().decode(Test.self, from: data),
+                           .init(type: .test))
         }
     }
     

--- a/Tests/AppTests/MiscTests.swift
+++ b/Tests/AppTests/MiscTests.swift
@@ -21,14 +21,21 @@ class MiscTests: XCTestCase {
     }
 
     func test_Date_init_yyyyMMdd() throws {
-        XCTAssertEqual(Date(yyyyMMdd: "1970-01-01"),
+        XCTAssertEqual(Date("1970-01-01"),
                        Date(timeIntervalSince1970: 0))
-        XCTAssertEqual(Date(yyyyMMdd: "foo"), nil)
+        XCTAssertEqual(Date("foo"), nil)
+    }
+
+    func test_Date_iso8691() throws {
+        XCTAssertEqual(Date("1970-01-01T0:01:23Z"),
+                       Date(timeIntervalSince1970: 83))
     }
 
     func test_Date_LosslessStringConvertible() throws {
         XCTAssertEqual(Date("1970-01-01"),
                        Date(timeIntervalSince1970: 0))
+        XCTAssertEqual(Date("1970-01-01T0:01:23Z"),
+                       Date(timeIntervalSince1970: 83))
         XCTAssertEqual(Date("foo"), nil)
     }
 

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -34,7 +34,6 @@ extension AppEnvironment {
             logger: { nil },
             metricsPushGatewayUrl: { "http://pushgateway:9091" },
             random: Double.random,
-            reAnalyzeVersionsBeforeDate: { nil },
             reportError: { _, _, _ in eventLoop.future(()) },
             rollbarToken: { nil },
             rollbarLogLevel: { .critical },

--- a/Tests/AppTests/Mocks/Manifest+mock.swift
+++ b/Tests/AppTests/Mocks/Manifest+mock.swift
@@ -9,6 +9,6 @@ extension Manifest {
 
 extension Manifest.Product {
     static var mock: Self {
-        .init(name: "MockProduct", type: .library)
+        .init(name: "MockProduct", type: .library(.automatic))
     }
 }

--- a/Tests/AppTests/PackageCollectionControllerTests.swift
+++ b/Tests/AppTests/PackageCollectionControllerTests.swift
@@ -16,7 +16,7 @@ class PackageCollectionControllerTests: AppTestCase {
                                 reference: .branch("main"),
                                 toolsVersion: "5.0")
             try v.save(on: app.db).wait()
-            try Product(version: v, type: .library, name: "P1Lib")
+            try Product(version: v, type: .library(.automatic), name: "P1Lib")
                 .save(on: app.db).wait()
         }
         do {
@@ -26,7 +26,7 @@ class PackageCollectionControllerTests: AppTestCase {
                                 reference: .tag(1, 2, 3),
                                 toolsVersion: "5.1")
             try v.save(on: app.db).wait()
-            try Product(version: v, type: .library, name: "P1Lib", targets: ["t1"])
+            try Product(version: v, type: .library(.automatic), name: "P1Lib", targets: ["t1"])
                 .save(on: app.db).wait()
             try Build(version: v,
                       platform: .ios,

--- a/Tests/AppTests/PackageCollectionTests.swift
+++ b/Tests/AppTests/PackageCollectionTests.swift
@@ -29,11 +29,11 @@ class PackageCollectionTests: AppTestCase {
             try v.save(on: app.db).wait()
             do {
                 try Product(version: v,
-                            type: .library,
+                            type: .library(.automatic),
                             name: "P1",
                             targets: ["T1"]).save(on: app.db).wait()
                 try Product(version: v,
-                            type: .library,
+                            type: .library(.automatic),
                             name: "P2",
                             targets: ["T2"]).save(on: app.db).wait()
             }
@@ -180,7 +180,7 @@ class PackageCollectionTests: AppTestCase {
                                 reference: .branch("main"),
                                 toolsVersion: "5.0")
             try v.save(on: app.db).wait()
-            try Product(version: v, type: .library, name: "P1Lib")
+            try Product(version: v, type: .library(.automatic), name: "P1Lib")
                 .save(on: app.db).wait()
         }
         do {
@@ -190,7 +190,7 @@ class PackageCollectionTests: AppTestCase {
                                 reference: .tag(1, 2, 3),
                                 toolsVersion: "5.1")
             try v.save(on: app.db).wait()
-            try Product(version: v, type: .library, name: "P1Lib", targets: ["t1"])
+            try Product(version: v, type: .library(.automatic), name: "P1Lib", targets: ["t1"])
                 .save(on: app.db).wait()
             try Target(version: v, name: "t1").save(on: app.db).wait()
         }
@@ -201,7 +201,7 @@ class PackageCollectionTests: AppTestCase {
                                 reference: .tag(2, 0, 0),
                                 toolsVersion: "5.2")
             try v.save(on: app.db).wait()
-            try Product(version: v, type: .library, name: "P1Lib", targets: ["t1"])
+            try Product(version: v, type: .library(.automatic), name: "P1Lib", targets: ["t1"])
                 .save(on: app.db).wait()
             try Build(version: v,
                       platform: .ios,
@@ -218,7 +218,7 @@ class PackageCollectionTests: AppTestCase {
                                 reference: .branch("main"),
                                 toolsVersion: "5.3")
             try v.save(on: app.db).wait()
-            try Product(version: v, type: .library, name: "P1Lib")
+            try Product(version: v, type: .library(.automatic), name: "P1Lib")
                 .save(on: app.db).wait()
         }
         do {
@@ -228,7 +228,7 @@ class PackageCollectionTests: AppTestCase {
                                 reference: .tag(1, 2, 3),
                                 toolsVersion: "5.3")
             try v.save(on: app.db).wait()
-            try Product(version: v, type: .library, name: "P1Lib", targets: ["t2"])
+            try Product(version: v, type: .library(.automatic), name: "P1Lib", targets: ["t2"])
                 .save(on: app.db).wait()
             try Target(version: v, name: "t2").save(on: app.db).wait()
         }

--- a/Tests/AppTests/PackageShowModelTests.swift
+++ b/Tests/AppTests/PackageShowModelTests.swift
@@ -23,7 +23,7 @@ class PackageShowModelTests: SnapshotTestCase {
                                       reference: .branch("main"))
         try version.save(on: app.db).wait()
         try Product(version: version,
-                    type: .library, name: "lib 1").save(on: app.db).wait()
+                    type: .library(.automatic), name: "lib 1").save(on: app.db).wait()
         // reload via query to ensure relationships are loaded
         pkg = try Package.query(on: app.db, owner: "foo", repository: "bar").wait()
         

--- a/Tests/AppTests/ProductTests.swift
+++ b/Tests/AppTests/ProductTests.swift
@@ -42,7 +42,6 @@ class ProductTests: AppTestCase {
                     from: Data(#"{"test":{}}"#.utf8)),
                 test)
         }
-
     }
     
     func test_Product_save() throws {

--- a/Tests/AppTests/ProductTests.swift
+++ b/Tests/AppTests/ProductTests.swift
@@ -4,13 +4,53 @@ import XCTVapor
 
 
 class ProductTests: AppTestCase {
+
+    func test_ProductType_Codable() throws {
+        // Ensure ProductType is Codable in a way that's forward compatible with Swift 5.5's Codable synthesis for enums with associated types (SE-0295)
+        let exe: ProductType = .executable
+        let lib: ProductType = .library(.automatic)
+        let test: ProductType = .test
+        do {  // encoding
+            XCTAssertEqual(
+                String(decoding: try JSONEncoder().encode(exe), as: UTF8.self),
+                #"{"executable":{}}"#
+            )
+            XCTAssertEqual(
+                String(decoding: try JSONEncoder().encode(lib), as: UTF8.self),
+                #"{"library":{"_0":"automatic"}}"#
+            )
+            XCTAssertEqual(
+                String(decoding: try JSONEncoder().encode(test), as: UTF8.self),
+                #"{"test":{}}"#
+            )
+        }
+        do {  // decoding
+            XCTAssertEqual(
+                try JSONDecoder().decode(
+                    ProductType.self,
+                    from: Data(#"{"executable":{}}"#.utf8)),
+                exe)
+            XCTAssertEqual(
+                try JSONDecoder().decode(
+                    ProductType.self,
+                    from: Data(#"{"library":{"_0":"automatic"}}"#.utf8)),
+                lib
+            )
+            XCTAssertEqual(
+                try JSONDecoder().decode(
+                    ProductType.self,
+                    from: Data(#"{"test":{}}"#.utf8)),
+                test)
+        }
+
+    }
     
     func test_Product_save() throws {
         let pkg = Package(id: UUID(), url: "1")
         let ver = try Version(id: UUID(), package: pkg)
         let prod = try Product(id: UUID(),
                                version: ver,
-                               type: .library,
+                               type: .library(.automatic),
                                name: "p1",
                                targets: ["t1", "t2"])
         try pkg.save(on: app.db).wait()
@@ -19,7 +59,7 @@ class ProductTests: AppTestCase {
         do {
             let p = try XCTUnwrap(Product.find(prod.id, on: app.db).wait())
             XCTAssertEqual(p.$version.id, ver.id)
-            XCTAssertEqual(p.type, .library)
+            XCTAssertEqual(p.type, .library(.automatic))
             XCTAssertEqual(p.name, "p1")
             XCTAssertEqual(p.targets, ["t1", "t2"])
         }
@@ -29,7 +69,7 @@ class ProductTests: AppTestCase {
         // delete version must delete products
         let pkg = Package(id: UUID(), url: "1")
         let ver = try Version(id: UUID(), package: pkg)
-        let prod = try Product(id: UUID(), version: ver, type: .library, name: "p1")
+        let prod = try Product(id: UUID(), version: ver, type: .library(.automatic), name: "p1")
         try pkg.save(on: app.db).wait()
         try ver.save(on: app.db).wait()
         try prod.save(on: app.db).wait()
@@ -46,4 +86,5 @@ class ProductTests: AppTestCase {
         XCTAssertEqual(try Version.query(on: app.db).count().wait(), 0)
         XCTAssertEqual(try Product.query(on: app.db).count().wait(), 0)
     }
+
 }

--- a/app.yml
+++ b/app.yml
@@ -66,8 +66,8 @@ services:
       resources:
         limits:
           memory: 4GB
-        restart_policy:
-          max_attempts: 5
+      restart_policy:
+        max_attempts: 5
     networks:
       - backend
 
@@ -85,8 +85,8 @@ services:
       resources:
         limits:
           memory: 4GB
-        restart_policy:
-          max_attempts: 5
+      restart_policy:
+        max_attempts: 5
     networks:
       - backend
 
@@ -104,8 +104,8 @@ services:
       resources:
         limits:
           memory: 4GB
-        restart_policy:
-          max_attempts: 5
+      restart_policy:
+        max_attempts: 5
     networks:
       - backend
 
@@ -123,8 +123,8 @@ services:
       resources:
         limits:
           memory: 4GB
-        restart_policy:
-          max_attempts: 5
+      restart_policy:
+        max_attempts: 5
     networks:
       - backend
 

--- a/app.yml
+++ b/app.yml
@@ -62,6 +62,12 @@ services:
     command: ["-c", "--",
       "trap : TERM INT; while true; do ./Run reconcile --env ${ENV}; sleep ${RECONCILE_SLEEP:-120}; done"
     ]
+    deploy:
+      resources:
+        limits:
+          memory: 4GB
+        restart_policy:
+          max_attempts: 5
     networks:
       - backend
 
@@ -75,6 +81,12 @@ services:
     command: ["-c", "--",
       "trap : TERM INT; while true; do ./Run ingest --env ${ENV} --limit ${INGEST_LIMIT:-100}; sleep ${INGEST_SLEEP:-300}; done"
     ]
+    deploy:
+      resources:
+        limits:
+          memory: 4GB
+        restart_policy:
+          max_attempts: 5
     networks:
       - backend
 
@@ -88,6 +100,12 @@ services:
     command: ["-c", "--",
       "trap : TERM INT; while true; do ./Run analyze --env ${ENV} --limit ${ANALYZE_LIMIT:-25}; sleep ${ANALYZE_SLEEP:-20}; done"
     ]
+    deploy:
+      resources:
+        limits:
+          memory: 4GB
+        restart_policy:
+          max_attempts: 5
     networks:
       - backend
 
@@ -101,6 +119,12 @@ services:
     command: ["-c", "--",
       "trap : TERM INT; while true; do ./Run trigger-builds --env ${ENV} --limit ${BUILD_TRIGGER_LIMIT:-1}; sleep ${BUILD_TRIGGER_SLEEP:-60}; done"
     ]
+    deploy:
+      resources:
+        limits:
+          memory: 4GB
+        restart_policy:
+          max_attempts: 5
     networks:
       - backend
 


### PR DESCRIPTION
~Currently blocked by https://github.com/vapor/postgres-kit/issues/207~

~There might be ways to work around the issue by using a different custom encoding format but let's see if there's perhaps an upstream fix available. That would allows us to get rid of the custom encoding in Swift 5.5.~

Simple workaround in place that's easy to remove should the upstream issue be fixed.

I'll leave this in draft while I deploy from the branch to let staging run an ingestion cycle with the schema update and product type update.

~Actually using the new format for package collections will be a separate PR.~

I've added this to this PR, because the change was actually trivial.

Fixes #878 