### PR TITLE
Collections validation fixes

### DIFF
--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -516,8 +516,26 @@ class ApiTests: AppTestCase {
                        defaultBranch: "main",
                        name: "name 2",
                        owner: "foo").save(on: app.db).wait()
-        try Version(package: p1, packageName: "Foo", reference: .branch("main")).save(on: app.db).wait()
-        try Version(package: p2, packageName: "Bar", reference: .branch("main")).save(on: app.db).wait()
+        do {
+            let v = try Version(package: p1,
+                                latest: .release,
+                                packageName: "Foo",
+                                reference: .tag(1, 2, 3),
+                                toolsVersion: "5.3")
+            try v.save(on: app.db).wait()
+            try Product(version: v, type: .library(.automatic), name: "p1")
+                .save(on: app.db).wait()
+        }
+        do {
+            let v = try Version(package: p2,
+                                latest: .release,
+                                packageName: "Bar",
+                                reference: .tag(2, 0, 0),
+                                toolsVersion: "5.4")
+            try v.save(on: app.db).wait()
+            try Product(version: v, type: .library(.automatic), name: "p2")
+                .save(on: app.db).wait()
+        }
         try Search.refresh(on: app.db).wait()
 
         do {  // MUT

--- a/Tests/AppTests/PackageCollectionTests.swift
+++ b/Tests/AppTests/PackageCollectionTests.swift
@@ -120,6 +120,9 @@ class PackageCollectionTests: AppTestCase {
                                     reference: .tag(1, 2, 3),
                                     toolsVersion: "5.3")
                 try v.save(on: app.db).wait()
+                try Product(version: v,
+                            type: .library(.automatic),
+                            name: "product").save(on: app.db).wait()
             }
         }
         let p = try Package.query(on: app.db)
@@ -151,6 +154,16 @@ class PackageCollectionTests: AppTestCase {
         // setup
         Current.date = { Date(timeIntervalSince1970: 1610112345) }
         let pkg = try savePackage(on: app.db, "1")
+        do {
+            let v = try Version(package: pkg,
+                                latest: .release,
+                                packageName: "package",
+                                reference: .tag(1, 2, 3),
+                                toolsVersion: "5.4")
+            try v.save(on: app.db).wait()
+            try Product(version: v, type: .library(.automatic), name: "product")
+                .save(on: app.db).wait()
+        }
         try Repository(package: pkg,
                        summary: "summary",
                        license: .mit,
@@ -362,7 +375,7 @@ class PackageCollectionTests: AppTestCase {
             let p = Package(url: "1".asGithubUrl.url)
             try p.save(on: app.db).wait()
             try p.$versions.load(on: app.db).wait()
-            
+
             XCTAssertNil(PackageCollection.Package(package: p,
                                                    keywords: nil))
         }

--- a/Tests/AppTests/PackageCollectionTests.swift
+++ b/Tests/AppTests/PackageCollectionTests.swift
@@ -337,4 +337,33 @@ class PackageCollectionTests: AppTestCase {
         XCTAssertEqual(res.packages.flatMap { $0.versions.map({$0.version}) },
                        ["2.0.0-b1", "1.2.3"])
     }
+
+    func test_require_products() throws {
+        // Ensure we don't include versions without products (by ensuring
+        // init? returns nil, which will be compact mapped away)
+        let p = Package(url: "1".asGithubUrl.url)
+        try p.save(on: app.db).wait()
+        let v = try Version(package: p,
+                            packageName: "pkg",
+                            reference: .tag(1,2,3),
+                            toolsVersion: "5.3")
+        try v.save(on: app.db).wait()
+        try v.$builds.load(on: app.db).wait()
+        try v.$products.load(on: app.db).wait()
+        try v.$targets.load(on: app.db).wait()
+        XCTAssertNil(PackageCollection.Package.Version(version: v,
+                                                       license: nil))
+    }
+
+    func test_require_versions() throws {
+        // Ensure we don't include packages without versions (by ensuring
+        // init? returns nil, which will be compact mapped away)
+        let p = Package(url: "1".asGithubUrl.url)
+        try p.save(on: app.db).wait()
+        try p.$versions.load(on: app.db).wait()
+
+        XCTAssertNil(PackageCollection.Package(package: p,
+                                               keywords: nil))
+    }
+
 }

--- a/Tests/AppTests/__Snapshots__/ApiTests/test_package_collection_packageURLs.1.txt
+++ b/Tests/AppTests/__Snapshots__/ApiTests/test_package_collection_packageURLs.1.txt
@@ -22,6 +22,29 @@
       ▿ summary: Optional<String>
         - some: "some package"
       - url: 1
-      - versions: 0 elements
+      ▿ versions: 1 element
+        ▿ Version
+          - createdAt: Optional<Date>.none
+          - defaultToolsVersion: "5.3"
+          - license: Optional<License>.none
+          ▿ manifests: 1 key/value pair
+            ▿ (2 elements)
+              - key: "5.3"
+              ▿ value: Manifest
+                ▿ minimumPlatformVersions: Optional<Array<PlatformVersion>>
+                  - some: 0 elements
+                - packageName: "Foo"
+                ▿ products: 1 element
+                  ▿ Product
+                    - name: "p1"
+                    - targets: 0 elements
+                    ▿ type: ProductType
+                      - library: LibraryType.automatic
+                - targets: 0 elements
+                - toolsVersion: "5.3"
+          - summary: Optional<String>.none
+          ▿ verifiedCompatibility: Optional<Array<Compatibility>>
+            - some: 0 elements
+          - version: "1.2.3"
   ▿ revision: Optional<Int>
     - some: 3

--- a/Tests/AppTests/__Snapshots__/PackageCollectionTests/test_generate_from_urls.1.json
+++ b/Tests/AppTests/__Snapshots__/PackageCollectionTests/test_generate_from_urls.1.json
@@ -23,7 +23,42 @@
       "summary" : "summary",
       "url" : "1",
       "versions" : [
+        {
+          "defaultToolsVersion" : "5.4",
+          "license" : {
+            "name" : "MIT",
+            "url" : "https:\/\/foo\/mit"
+          },
+          "manifests" : {
+            "5.4" : {
+              "minimumPlatformVersions" : [
 
+              ],
+              "packageName" : "package",
+              "products" : [
+                {
+                  "name" : "product",
+                  "targets" : [
+
+                  ],
+                  "type" : {
+                    "library" : [
+                      "automatic"
+                    ]
+                  }
+                }
+              ],
+              "targets" : [
+
+              ],
+              "toolsVersion" : "5.4"
+            }
+          },
+          "verifiedCompatibility" : [
+
+          ],
+          "version" : "1.2.3"
+        }
       ]
     }
   ]


### PR DESCRIPTION
The vapor collection now validates without errors:

```
~/P/G/swift-package-collection-generator on  main
❯ git rev-parse @
b55b877aae278a0bf6d57e0d71a05cf19ade191d
~/P/G/swift-package-collection-generator on  main
❯ http http://localhost:8080/vapor/collection.json > vapor.json
~/P/G/swift-package-collection-generator on  main took 13s
❯ swift run package-collection-validate vapor.json
~/P/G/swift-package-collection-generator on  main
❯ echo $status
0
```

cc @yim-lee