### PR TITLE
Add backtrace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ test-docker:
 test-e2e: db-reset reconcile ingest analyze
 	@# run import sequence test
 
+crash-docker:
+	@# run crash inside a docker container
+	docker run --rm -v "$(PWD)":/host -w /host --network="host" finestructure/spi-base:0.5.2 \
+	  swift run -c release -Xswiftc -g Run crash
+
 migrate:
 	echo y | swift run Run migrate
 

--- a/Makefile
+++ b/Makefile
@@ -35,11 +35,6 @@ test-docker:
 test-e2e: db-reset reconcile ingest analyze
 	@# run import sequence test
 
-crash-docker:
-	@# run crash inside a docker container
-	docker run --rm -v "$(PWD)":/host -w /host --network="host" finestructure/spi-base:0.5.2 \
-	  swift run -c release -Xswiftc -g Run crash
-
 migrate:
 	echo y | swift run Run migrate
 

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
         .package(name: "SwiftPM",
                  url: "https://github.com/apple/swift-package-manager.git",
-                 .revision("swift-DEVELOPMENT-SNAPSHOT-2021-05-04-a"))
+                 .revision("swift-DEVELOPMENT-SNAPSHOT-2021-05-04-a")),
+        .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.2.0")
     ],
     targets: [
         .target(name: "App", dependencies: [
@@ -36,7 +37,8 @@ let package = Package(
             "SwiftPrometheus",
             "OhhAuth",
             "SwiftSoup",
-            .product(name: "PackageCollectionsModel", package: "SwiftPM")
+            .product(name: "PackageCollectionsModel", package: "SwiftPM"),
+            .product(name: "Backtrace", package: "swift-backtrace")
         ]),
         .target(name: "Run", dependencies: ["App"]),
         .testTarget(name: "AppTests", dependencies: [

--- a/Sources/App/Commands/Crash.swift
+++ b/Sources/App/Commands/Crash.swift
@@ -4,21 +4,49 @@ import ShellOut
 import Vapor
 
 struct CrashCommand: Command {
+    enum Reason: String, CaseIterable {
+        case precondition
+        case fatal
+        case unwrap
+    }
+    
     struct Signature: CommandSignature {
-        @Flag(name: "backtrace", short: "b", help: "installs Backtrace crash handler before crashing")
+        @Flag(name: "backtrace", short: "b", help: "installs Backtrace handler before crashing")
         var backtrace: Bool
         
-        @Option(name: "reason", short: "r", help: "specifies fatal error reason")
-        var reason: String?
+        @Option(name: "reason", short: "r", help: "specifies crash reason: \(Reason.allCases)")
+        var reason: Reason?
     }
 
     var help: String { "Intentionally crashes the app" }
 
-    func run(using _: CommandContext, signature: Signature) throws {
+    func run(using context: CommandContext, signature: Signature) throws {
         if signature.backtrace {
+            context.console.info("Installing backtrace...")
             Backtrace.install()
         }
         
-        fatalError(signature.reason ?? "Intentionally crashing the app")
+        let reason = signature.reason ?? .fatal
+        
+        switch reason {
+        case .fatal:
+            fatalError("Intentionally crashing the app with fatalError")
+        case .precondition:
+            precondition(false, "Intentionally crashing the app with precondition")
+        case .unwrap:
+            context.console.info("Intentionally crashing the app with force unwrap")
+            let something: Int? = nil
+            print(something!)
+        }
+    }
+}
+
+extension CrashCommand.Reason: LosslessStringConvertible {
+    var description: String {
+        rawValue
+    }
+    
+    init?(_ description: String) {
+        self.init(rawValue: description)
     }
 }

--- a/Sources/App/Commands/Crash.swift
+++ b/Sources/App/Commands/Crash.swift
@@ -1,0 +1,24 @@
+import Backtrace
+import Fluent
+import ShellOut
+import Vapor
+
+struct CrashCommand: Command {
+    struct Signature: CommandSignature {
+        @Flag(name: "backtrace", short: "b", help: "installs Backtrace crash handler before crashing")
+        var backtrace: Bool
+        
+        @Option(name: "reason", short: "r", help: "specifies fatal error reason")
+        var reason: String?
+    }
+
+    var help: String { "Intentionally crashes the app" }
+
+    func run(using _: CommandContext, signature: Signature) throws {
+        if signature.backtrace {
+            Backtrace.install()
+        }
+        
+        fatalError(signature.reason ?? "Intentionally crashing the app")
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -138,6 +138,7 @@ public func configure(_ app: Application) throws {
     app.commands.use(ReconcileCommand(), as: "reconcile")
     app.commands.use(TriggerBuildsCommand(), as: "trigger-builds")
     app.commands.use(ReAnalyzeVersionsCommand(), as: "re-analyze-versions")
+    app.commands.use(CrashCommand(), as: "crash")
     
     // register routes
     try routes(app)

--- a/scripts/test-crash-handling.sh
+++ b/scripts/test-crash-handling.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eux
+
+docker run --rm -v "$(PWD)":/host -w /host --network="host" finestructure/spi-base:0.5.2 \
+  swift run -c release -Xswiftc -g Run crash "$@"


### PR DESCRIPTION
Resolving #1071; Adding `swift-backtrace` package

Though, I've failed to identify an actual difference that `Backtrace.install` should make: 

<details>
 <summary>Fatal error with `Backtrace`</summary>

 ```swift
Installing backtrace...
App/Crash.swift:33: Fatal error: Intentionally crashing the app with fatalError
0x7f3d3e89b3bf
0x7f3d3ea1c307
0x5623cca3bcbb, function signature specialization <Arg[0] = Exploded, Arg[2] = Dead> of App.CrashCommand.run(using: ConsoleKit.CommandContext, signature: App.CrashCommand.Signature) throws -> () at /host/Sources/App/Commands/Crash.swift:33
0x5623cca3b876, App.CrashCommand.run(using: ConsoleKit.CommandContext, signature: App.CrashCommand.Signature) throws -> () at /host/<compiler-generated>:0
0x5623cca3b876, protocol witness for ConsoleKit.Command.run(using: ConsoleKit.CommandContext, signature: A.Signature) throws -> () in conformance App.CrashCommand : ConsoleKit.Command in App at /host/<compiler-generated>:23
0x5623cce24ba2, (extension in ConsoleKit):ConsoleKit.Command.run(using: inout ConsoleKit.CommandContext) throws -> () at /host/.build/checkouts/console-kit/Sources/ConsoleKit/Command/Command.swift:93
0x5623cca3b8ac, protocol witness for ConsoleKit.AnyCommand.run(using: inout ConsoleKit.CommandContext) throws -> () in conformance App.CrashCommand : ConsoleKit.AnyCommand in App at /host/<compiler-generated>:0
0x5623cce2c5f8, generic specialization <ConsoleKit.(_Group in _846E45F60D0A5EF0D14D777A7C196788)> of (extension in ConsoleKit):ConsoleKit.CommandGroup.run(using: inout ConsoleKit.CommandContext) throws -> () at /host/.build/checkouts/console-kit/Sources/ConsoleKit/Command/CommandGroup.swift:0
0x5623cce2e985, protocol witness for ConsoleKit.AnyCommand.run(using: inout ConsoleKit.CommandContext) throws -> () in conformance ConsoleKit.(_Group in _846E45F60D0A5EF0D14D777A7C196788) : ConsoleKit.AnyCommand in ConsoleKit at /host/<compiler-generated>:0
0x5623cce42c0a, (extension in ConsoleKit):ConsoleKit.Console.run(_: ConsoleKit.AnyCommand, with: ConsoleKit.CommandContext) throws -> () at /host/.build/checkouts/console-kit/Sources/ConsoleKit/Command/Console+Run.swift:44
0x5623cd3436d4, Vapor.Application.start() throws -> () at /host/.build/checkouts/vapor/Sources/Vapor/Application.swift:111
0x5623cd343063, Vapor.Application.run() throws -> () at /host/.build/checkouts/vapor/Sources/Vapor/Application.swift:98
0x5623cd28dd90, main at /host/Sources/Run/main.swift:9
0x7f3d3d9a10b2
0x5623cc9feced
0xffffffffffffffff
 ```

</details>

<details>
 <summary>Fatal error without `Backtrace`</summary>

 ```swift
App/Crash.swift:33: Fatal error: Intentionally crashing the app with fatalError
0x7fddbd97c3bf
0x7fddbdafd307
0x564fb90a4cbb, function signature specialization <Arg[0] = Exploded, Arg[2] = Dead> of App.CrashCommand.run(using: ConsoleKit.CommandContext, signature: App.CrashCommand.Signature) throws -> () at /host/Sources/App/Commands/Crash.swift:33
0x564fb90a4876, App.CrashCommand.run(using: ConsoleKit.CommandContext, signature: App.CrashCommand.Signature) throws -> () at /host/<compiler-generated>:0
0x564fb90a4876, protocol witness for ConsoleKit.Command.run(using: ConsoleKit.CommandContext, signature: A.Signature) throws -> () in conformance App.CrashCommand : ConsoleKit.Command in App at /host/<compiler-generated>:23
0x564fb948daa2, (extension in ConsoleKit):ConsoleKit.Command.run(using: inout ConsoleKit.CommandContext) throws -> () at /host/.build/checkouts/console-kit/Sources/ConsoleKit/Command/Command.swift:93
0x564fb90a48ac, protocol witness for ConsoleKit.AnyCommand.run(using: inout ConsoleKit.CommandContext) throws -> () in conformance App.CrashCommand : ConsoleKit.AnyCommand in App at /host/<compiler-generated>:0
0x564fb94954f8, generic specialization <ConsoleKit.(_Group in _846E45F60D0A5EF0D14D777A7C196788)> of (extension in ConsoleKit):ConsoleKit.CommandGroup.run(using: inout ConsoleKit.CommandContext) throws -> () at /host/.build/checkouts/console-kit/Sources/ConsoleKit/Command/CommandGroup.swift:0
0x564fb9497885, protocol witness for ConsoleKit.AnyCommand.run(using: inout ConsoleKit.CommandContext) throws -> () in conformance ConsoleKit.(_Group in _846E45F60D0A5EF0D14D777A7C196788) : ConsoleKit.AnyCommand in ConsoleKit at /host/<compiler-generated>:0
0x564fb94abb0a, (extension in ConsoleKit):ConsoleKit.Console.run(_: ConsoleKit.AnyCommand, with: ConsoleKit.CommandContext) throws -> () at /host/.build/checkouts/console-kit/Sources/ConsoleKit/Command/Console+Run.swift:44
0x564fb99ac5d4, Vapor.Application.start() throws -> () at /host/.build/checkouts/vapor/Sources/Vapor/Application.swift:111
0x564fb99abf63, Vapor.Application.run() throws -> () at /host/.build/checkouts/vapor/Sources/Vapor/Application.swift:98
0x564fb98f6c90, main at /host/Sources/Run/main.swift:9
0x7fddbca820b2
0x564fb9067ced
 ```

</details>

One can compare it to the `Console.app` backtrace on macOS:

<details>
 <summary>Console.app backtrace</summary>

 ```swift
Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   libswiftCore.dylib            	0x00007fff2c74c0f4 _assertionFailure(_:_:file:line:flags:) + 532
1   Run                           	0x00000001073a19b7 CrashCommand.run(using:signature:) + 311 (Crash.swift:22)
2   Run                           	0x00000001073a19f9 protocol witness for Command.run(using:signature:) in conformance CrashCommand + 25
3   Run                           	0x0000000107962dbc Command.run(using:) + 668 (Command.swift:93)
4   Run                           	0x00000001073a1a54 protocol witness for AnyCommand.run(using:) in conformance CrashCommand + 20
5   Run                           	0x000000010796bd4e CommandGroup.run(using:) + 350 (CommandGroup.swift:30)
6   Run                           	0x0000000107974e54 protocol witness for AnyCommand.run(using:) in conformance _Group + 20
7   Run                           	0x000000010798334a Console.run(_:with:) + 954 (Console+Run.swift:44)
8   Run                           	0x0000000108369748 Application.start() + 808 (Application.swift:111)
9   Run                           	0x0000000108369152 Application.run() + 34 (Application.swift:98)
10  Run                           	0x00000001081e456a main + 618 (main.swift:9)
11  libdyld.dylib                 	0x00007fff20359621 start + 1
 ```

</details>

Certainly, I've missed something here. So, I've assembled an app command to test different crash scenarios:

```bash
# executes the crash command in the docker container
$ ./scripts/test-crash-handling.sh

# with backtrace 
$ ./scripts/test-crash-handling.sh -b

# specify crash reason
$ ./scripts/test-crash-handling.sh -r fatal # 'precondition' | 'unwrap'
```

Maybe I can somehow emulate the actual crash environment/scenario 🤔

P.S. It will take forever to run on M1  🙄 