### PR TITLE
Add visual warning when the repository is archived

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -213,7 +213,7 @@ extension PackageShow.Model {
         var releasesSentenceFragments: [Node<HTML.BodyContext>] = []
         if isArchived {
             releasesSentenceFragments.append(contentsOf: [
-                .strong("No longer in active development."),
+                .strong("⚠️ No longer in active development."),
                 " The package author has archived this project and the repository is read-only. It had ",
                 commitsLinkNode, " and ", releasesLinkNode,
                 " before being archived."


### PR DESCRIPTION
In the package listing, in my opinion, it should visually warn the user when the repository has been archived by the owner. 

**Example:**

Before:
![Screenshot 2021-06-14 at 15 50 21](https://user-images.githubusercontent.com/3541185/121912161-3e261080-cd28-11eb-85df-cf5b16a3f344.png)

After (add a warning symbol):
![Screenshot 2021-06-14 at 15 48 00](https://user-images.githubusercontent.com/3541185/121911806-fb643880-cd27-11eb-8456-e3d0d504b1e6.png)