### PR TITLE
Populate topics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,18 @@ db-up-test:
 		-d \
 		postgres:11.6-alpine
 
+db-up-test-log-statement:
+	docker run --name spi_test \
+		-e POSTGRES_DB=spi_test \
+		-e POSTGRES_USER=spi_test \
+		-e POSTGRES_PASSWORD=xxx \
+		-e PGDATA=/pgdata \
+		--tmpfs /pgdata:rw,noexec,nosuid,size=1024m \
+		-p 5432:5432 \
+		--rm \
+		postgres:11.6-alpine \
+		postgres -c log_statement=all
+
 db-down: db-down-dev db-down-test
 
 db-down-dev:

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -201,7 +201,7 @@ func insertOrUpdateRepository(on database: Database,
                 .map(Release.init(from:)) ?? []
             repo.stars = repository.stargazerCount
             repo.summary = repository.description
-            repo.topics = Set(repository.topics.map { $0.lowercased() }).sorted()
+            repo.keywords = Set(repository.topics.map { $0.lowercased() }).sorted()
             return repo.save(on: database)
         }
 }

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -184,6 +184,7 @@ func insertOrUpdateRepository(on database: Database,
             repo.defaultBranch = repository.defaultBranch
             repo.forks = repository.forkCount
             repo.isArchived = repository.isArchived
+            repo.isInOrganization = repository.isInOrganization
             repo.lastIssueClosedAt = repository.lastIssueClosedAt
             repo.lastPullRequestClosedAt = repository.lastPullRequestClosedAt
             repo.license = .init(from: repository.licenseInfo)
@@ -199,8 +200,8 @@ func insertOrUpdateRepository(on database: Database,
             repo.releases = metadata.repository?.releases.nodes
                 .map(Release.init(from:)) ?? []
             repo.stars = repository.stargazerCount
-            repo.isInOrganization = repository.isInOrganization
             repo.summary = repository.description
+            repo.topics = repository.topics
             return repo.save(on: database)
         }
 }

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -185,6 +185,7 @@ func insertOrUpdateRepository(on database: Database,
             repo.forks = repository.forkCount
             repo.isArchived = repository.isArchived
             repo.isInOrganization = repository.isInOrganization
+            repo.keywords = Set(repository.topics.map { $0.lowercased() }).sorted()
             repo.lastIssueClosedAt = repository.lastIssueClosedAt
             repo.lastPullRequestClosedAt = repository.lastPullRequestClosedAt
             repo.license = .init(from: repository.licenseInfo)
@@ -201,7 +202,6 @@ func insertOrUpdateRepository(on database: Database,
                 .map(Release.init(from:)) ?? []
             repo.stars = repository.stargazerCount
             repo.summary = repository.description
-            repo.keywords = Set(repository.topics.map { $0.lowercased() }).sorted()
             return repo.save(on: database)
         }
 }

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -267,6 +267,14 @@ extension Github {
                         name
                       }
                     }
+                    repositoryTopics(first: 20) {
+                      totalCount
+                      nodes {
+                        topic {
+                          name
+                        }
+                      }
+                    }
                     releases(first: 20, orderBy: {field: CREATED_AT, direction: DESC}) {
                       nodes {
                         description

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -267,14 +267,6 @@ extension Github {
                         name
                       }
                     }
-                    repositoryTopics(first: 20) {
-                      totalCount
-                      nodes {
-                        topic {
-                          name
-                        }
-                      }
-                    }
                     releases(first: 20, orderBy: {field: CREATED_AT, direction: DESC}) {
                       nodes {
                         description
@@ -283,6 +275,14 @@ extension Github {
                         publishedAt
                         tagName
                         url
+                      }
+                    }
+                    repositoryTopics(first: 20) {
+                      totalCount
+                      nodes {
+                        topic {
+                          name
+                        }
                       }
                     }
                     stargazerCount

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -308,6 +308,7 @@ extension Github {
             var openPullRequests: OpenPullRequests
             var owner: Owner
             var releases: ReleaseNodes
+            var repositoryTopics: RepositoryTopicNodes
             var stargazerCount: Int
             var isInOrganization: Bool
             // derived properties
@@ -371,6 +372,19 @@ extension Github {
                 var publishedAt: Date?
                 var tagName: String
                 var url: String
+            }
+        }
+
+        struct RepositoryTopicNodes: Decodable, Equatable {
+            var totalCount: Int
+            var nodes: [RepositoryTopic]
+
+            struct RepositoryTopic: Decodable, Equatable {
+                var topic: Topic
+
+                struct Topic: Decodable, Equatable {
+                    var name: String
+                }
             }
         }
     }

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -319,6 +319,9 @@ extension Github {
             var lastPullRequestClosedAt: Date? {
                 (closedPullRequests.nodes + mergedPullRequests.nodes).map(\.closedAt).sorted().last
             }
+            var topics: [String] {
+                repositoryTopics.nodes.map(\.topic.name)
+            }
         }
 
         struct IssueNodes: Decodable, Equatable {

--- a/Sources/App/Migrations/030/UpdateRepositoryAddKeywords.swift
+++ b/Sources/App/Migrations/030/UpdateRepositoryAddKeywords.swift
@@ -1,16 +1,16 @@
 import Fluent
 
 
-struct UpdateRepositoryAddTopics: Migration {
+struct UpdateRepositoryAddKeywords: Migration {
     func prepare(on database: Database) -> EventLoopFuture<Void> {
         database.schema("repositories")
-            .field("topics", .array(of: .string), .sql(.default("{}")))
+            .field("keywords", .array(of: .string), .sql(.default("{}")))
             .update()
     }
 
     func revert(on database: Database) -> EventLoopFuture<Void> {
         database.schema("repositories")
-            .deleteField("topics")
+            .deleteField("keywords")
             .update()
     }
 }

--- a/Sources/App/Migrations/030/UpdateRepositoryAddTopics.swift
+++ b/Sources/App/Migrations/030/UpdateRepositoryAddTopics.swift
@@ -1,0 +1,16 @@
+import Fluent
+
+
+struct UpdateRepositoryAddTopics: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("repositories")
+            .field("topics", .array(of: .string), .sql(.default("{}")))
+            .update()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("repositories")
+            .deleteField("topics")
+            .update()
+    }
+}

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -46,6 +46,9 @@ final class Repository: Model, Content {
     @Field(key: "is_archived")
     var isArchived: Bool?
 
+    @Field(key: "is_in_organization")
+    var isInOrganization: Bool?
+
     @Field(key: "last_commit_date")
     var lastCommitDate: Date?
     
@@ -91,12 +94,12 @@ final class Repository: Model, Content {
     @Field(key: "stars")
     var stars: Int?
 
-    @Field(key: "is_in_organization")
-    var isInOrganization: Bool?
-    
     @Field(key: "summary")
     var summary: String?
-    
+
+    @Field(key: "topics")
+    var topics: [String]
+
     // initializers
     
     init() { }
@@ -104,13 +107,16 @@ final class Repository: Model, Content {
     init(id: Id? = nil,
          package: Package,
          authors: [Author] = [],
-         summary: String? = nil,
          commitCount: Int? = nil,
+         defaultBranch: String? = nil,
          firstCommitDate: Date? = nil,
+         forks: Int? = nil,
+         forkedFrom: Repository? = nil,
+         isArchived: Bool? = nil,
+         isInOrganization: Bool? = nil,
          lastCommitDate: Date? = nil,
          lastIssueClosedAt: Date? = nil,
          lastPullRequestClosedAt: Date? = nil,
-         defaultBranch: String? = nil,
          license: License = .none,
          licenseUrl: String? = nil,
          name: String? = nil,
@@ -122,17 +128,22 @@ final class Repository: Model, Content {
          readmeUrl: String? = nil,
          readmeHtmlUrl: String? = nil,
          releases: [Release] = [],
-         isArchived: Bool? = nil,
          stars: Int? = nil,
-         isInOrganization: Bool? = nil,
-         forks: Int? = nil,
-         forkedFrom: Repository? = nil) throws {
+         summary: String? = nil,
+         topics: [String] = []
+    ) throws {
         self.id = id
         self.$package.id = try package.requireID()
         self.authors = authors
         self.summary = summary
         self.commitCount = commitCount
         self.firstCommitDate = firstCommitDate
+        self.forks = forks
+        if let forkId = forkedFrom?.id {
+            self.$forkedFrom.id = forkId
+        }
+        self.isArchived = isArchived
+        self.isInOrganization = isInOrganization
         self.lastCommitDate = lastCommitDate
         self.lastIssueClosedAt = lastIssueClosedAt
         self.lastPullRequestClosedAt = lastPullRequestClosedAt
@@ -148,13 +159,8 @@ final class Repository: Model, Content {
         self.readmeUrl = readmeUrl
         self.readmeHtmlUrl = readmeHtmlUrl
         self.releases = releases
-        self.isArchived = isArchived
         self.stars = stars
-        self.isInOrganization = isInOrganization
-        self.forks = forks
-        if let forkId = forkedFrom?.id {
-            self.$forkedFrom.id = forkId
-        }
+        self.topics = topics
     }
     
     init(packageId: Package.Id) {

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -49,15 +49,18 @@ final class Repository: Model, Content {
     @Field(key: "is_in_organization")
     var isInOrganization: Bool?
 
+    @Field(key: "keywords")
+    var keywords: [String]
+
     @Field(key: "last_commit_date")
     var lastCommitDate: Date?
-    
+
     @Field(key: "last_issue_closed_at")
     var lastIssueClosedAt: Date?
-    
+
     @Field(key: "last_pull_request_closed_at")
     var lastPullRequestClosedAt: Date?
-    
+
     @Field(key: "license")
     var license: License
 
@@ -66,13 +69,13 @@ final class Repository: Model, Content {
 
     @Field(key: "name")
     var name: String?
-    
+
     @Field(key: "open_issues")
     var openIssues: Int?
-    
+
     @Field(key: "open_pull_requests")
     var openPullRequests: Int?
-    
+
     @Field(key: "owner")
     var owner: String?
 
@@ -81,7 +84,7 @@ final class Repository: Model, Content {
 
     @Field(key: "owner_avatar_url")
     var ownerAvatarUrl: String?
-    
+
     @Field(key: "readme_url")
     var readmeUrl: String?
 
@@ -97,9 +100,6 @@ final class Repository: Model, Content {
     @Field(key: "summary")
     var summary: String?
 
-    @Field(key: "topics")
-    var topics: [String]
-
     // initializers
     
     init() { }
@@ -114,6 +114,7 @@ final class Repository: Model, Content {
          forkedFrom: Repository? = nil,
          isArchived: Bool? = nil,
          isInOrganization: Bool? = nil,
+         keywords: [String] = [],
          lastCommitDate: Date? = nil,
          lastIssueClosedAt: Date? = nil,
          lastPullRequestClosedAt: Date? = nil,
@@ -129,8 +130,7 @@ final class Repository: Model, Content {
          readmeHtmlUrl: String? = nil,
          releases: [Release] = [],
          stars: Int? = nil,
-         summary: String? = nil,
-         topics: [String] = []
+         summary: String? = nil
     ) throws {
         self.id = id
         self.$package.id = try package.requireID()
@@ -144,6 +144,7 @@ final class Repository: Model, Content {
         }
         self.isArchived = isArchived
         self.isInOrganization = isInOrganization
+        self.keywords = keywords
         self.lastCommitDate = lastCommitDate
         self.lastIssueClosedAt = lastIssueClosedAt
         self.lastPullRequestClosedAt = lastPullRequestClosedAt
@@ -160,7 +161,6 @@ final class Repository: Model, Content {
         self.readmeHtmlUrl = readmeHtmlUrl
         self.releases = releases
         self.stars = stars
-        self.topics = topics
     }
     
     init(packageId: Package.Id) {

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -135,7 +135,7 @@ public func configure(_ app: Application) throws {
         app.migrations.add(UpdateRecentReleases6())
     }
     do {  // Migration 030 - add repositories.topics
-        app.migrations.add(UpdateRepositoryAddTopics())
+        app.migrations.add(UpdateRepositoryAddKeywords())
     }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -134,6 +134,9 @@ public func configure(_ app: Application) throws {
         app.migrations.add(UpdateVersionAddReleaseNotesHTML())
         app.migrations.add(UpdateRecentReleases6())
     }
+    do {  // Migration 030 - add repositories.topics
+        app.migrations.add(UpdateRepositoryAddTopics())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -134,7 +134,7 @@ public func configure(_ app: Application) throws {
         app.migrations.add(UpdateVersionAddReleaseNotesHTML())
         app.migrations.add(UpdateRecentReleases6())
     }
-    do {  // Migration 030 - add repositories.topics
+    do {  // Migration 030 - add repositories.keywords
         app.migrations.add(UpdateRepositoryAddKeywords())
     }
 

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -30,13 +30,13 @@ class ApiTests: AppTestCase {
                          url: "2")
         try p2.save(on: app.db).wait()
         try Repository(package: p1,
-                       summary: "some package",
-                       defaultBranch: "main").save(on: app.db).wait()
+                       defaultBranch: "main",
+                       summary: "some package").save(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "foo bar package",
                        defaultBranch: "main",
                        name: "name 2",
-                       owner: "owner 2").save(on: app.db).wait()
+                       owner: "owner 2",
+                       summary: "foo bar package").save(on: app.db).wait()
         try Version(package: p1, packageName: "Foo", reference: .branch("main")).save(on: app.db).wait()
         try Version(package: p2, packageName: "Bar", reference: .branch("main")).save(on: app.db).wait()
         try Search.refresh(on: app.db).wait()
@@ -449,13 +449,13 @@ class ApiTests: AppTestCase {
                          url: "2")
         try p2.save(on: app.db).wait()
         try Repository(package: p1,
-                       summary: "some package",
-                       defaultBranch: "main").save(on: app.db).wait()
+                       defaultBranch: "main",
+                       summary: "some package").save(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "foo bar package",
                        defaultBranch: "main",
                        name: "name 2",
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "foo bar package").save(on: app.db).wait()
         try Version(package: p1, packageName: "Foo", reference: .branch("main")).save(on: app.db).wait()
         try Version(package: p2, packageName: "Bar", reference: .branch("main")).save(on: app.db).wait()
         try Search.refresh(on: app.db).wait()
@@ -509,13 +509,13 @@ class ApiTests: AppTestCase {
                          url: "2")
         try p2.save(on: app.db).wait()
         try Repository(package: p1,
-                       summary: "some package",
-                       defaultBranch: "main").save(on: app.db).wait()
+                       defaultBranch: "main",
+                       summary: "some package").save(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "foo bar package",
                        defaultBranch: "main",
                        name: "name 2",
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "foo bar package").save(on: app.db).wait()
         do {
             let v = try Version(package: p1,
                                 latest: .release,

--- a/Tests/AppTests/BuildIndexModelTests.swift
+++ b/Tests/AppTests/BuildIndexModelTests.swift
@@ -11,13 +11,13 @@ class BuildIndexModelTests: AppTestCase {
         // setup package without package name
         let pkg = try savePackage(on: app.db, "1".url)
         try Repository(package: pkg,
-                       summary: "summary",
                        defaultBranch: "main",
+                       forks: 42,
                        license: .mit,
                        name: "bar",
                        owner: "foo",
                        stars: 17,
-                       forks: 42).save(on: app.db).wait()
+                       summary: "summary").save(on: app.db).wait()
 
         // MUT
         let m = BuildIndex.Model(package: pkg)

--- a/Tests/AppTests/BuildShowModelTests.swift
+++ b/Tests/AppTests/BuildShowModelTests.swift
@@ -20,13 +20,13 @@ class BuildShowModelTests: AppTestCase {
         // setup
         let pkg = try savePackage(on: app.db, "1".url)
         try Repository(package: pkg,
-                       summary: "summary",
                        defaultBranch: "main",
+                       forks: 42,
                        license: .mit,
                        name: "bar",
                        owner: "foo",
                        stars: 17,
-                       forks: 42).save(on: app.db).wait()
+                       summary: "summary").save(on: app.db).wait()
         let v = try Version(id: UUID(), package: pkg, packageName: "Bar", reference: .branch("main"))
         try v.save(on: app.db).wait()
         let buildId = UUID()

--- a/Tests/AppTests/Controllers/AuthorControllerTests.swift
+++ b/Tests/AppTests/Controllers/AuthorControllerTests.swift
@@ -13,13 +13,13 @@ class AuthorControllerTests: AppTestCase {
         let package = Package(id: testPackageId, url: "https://github.com/user/package.git")
         let repository = try Repository(id: UUID(),
                                         package: package,
-                                        summary: "This is a test package",
                                         defaultBranch: "main",
+                                        forks: 2,
                                         license: .mit,
                                         name: "package",
                                         owner: "owner",
                                         stars: 3,
-                                        forks: 2)
+                                        summary: "This is a test package")
         let version = try Version(id: UUID(),
                                   package: package,
                                   packageName: "Test package",

--- a/Tests/AppTests/Controllers/PackageControllerTests.swift
+++ b/Tests/AppTests/Controllers/PackageControllerTests.swift
@@ -13,13 +13,13 @@ class PackageControllerTests: AppTestCase {
         let package = Package(id: testPackageId, url: "https://github.com/user/package.git")
         let repository = try Repository(id: UUID(),
                                         package: package,
-                                        summary: "This is a test package",
                                         defaultBranch: "main",
+                                        forks: 2,
                                         license: .mit,
                                         name: "package",
                                         owner: "owner",
                                         stars: 3,
-                                        forks: 2)
+                                        summary: "This is a test package")
         let version = try Version(id: UUID(),
                                   package: package,
                                   packageName: "Test package",

--- a/Tests/AppTests/Fixtures/github-graphql-resource.json
+++ b/Tests/AppTests/Fixtures/github-graphql-resource.json
@@ -937,86 +937,6 @@
         "avatarUrl": "https://avatars.githubusercontent.com/u/7774181?v=4",
         "name": "Alamofire"
       },
-      "repositoryTopics": {
-        "totalCount": 15,
-        "nodes": [
-          {
-            "topic": {
-              "name": "networking"
-            }
-          },
-          {
-            "topic": {
-              "name": "urlsession"
-            }
-          },
-          {
-            "topic": {
-              "name": "urlrequest"
-            }
-          },
-          {
-            "topic": {
-              "name": "httpurlresponse"
-            }
-          },
-          {
-            "topic": {
-              "name": "request"
-            }
-          },
-          {
-            "topic": {
-              "name": "response"
-            }
-          },
-          {
-            "topic": {
-              "name": "swift"
-            }
-          },
-          {
-            "topic": {
-              "name": "xcode"
-            }
-          },
-          {
-            "topic": {
-              "name": "certificate-pinning"
-            }
-          },
-          {
-            "topic": {
-              "name": "public-key-pinning"
-            }
-          },
-          {
-            "topic": {
-              "name": "parameter-encoding"
-            }
-          },
-          {
-            "topic": {
-              "name": "alamofire"
-            }
-          },
-          {
-            "topic": {
-              "name": "cocoapods"
-            }
-          },
-          {
-            "topic": {
-              "name": "carthage"
-            }
-          },
-          {
-            "topic": {
-              "name": "swift-package-manager"
-            }
-          }
-        ]
-      },
       "releases": {
         "nodes": [
           {
@@ -1168,6 +1088,86 @@
             "publishedAt": "2019-09-04T00:47:09Z",
             "tagName": "4.9.0",
             "url": "https://github.com/Alamofire/Alamofire/releases/tag/4.9.0"
+          }
+        ]
+      },
+      "repositoryTopics": {
+        "totalCount": 15,
+        "nodes": [
+          {
+            "topic": {
+              "name": "networking"
+            }
+          },
+          {
+            "topic": {
+              "name": "urlsession"
+            }
+          },
+          {
+            "topic": {
+              "name": "urlrequest"
+            }
+          },
+          {
+            "topic": {
+              "name": "httpurlresponse"
+            }
+          },
+          {
+            "topic": {
+              "name": "request"
+            }
+          },
+          {
+            "topic": {
+              "name": "response"
+            }
+          },
+          {
+            "topic": {
+              "name": "swift"
+            }
+          },
+          {
+            "topic": {
+              "name": "xcode"
+            }
+          },
+          {
+            "topic": {
+              "name": "certificate-pinning"
+            }
+          },
+          {
+            "topic": {
+              "name": "public-key-pinning"
+            }
+          },
+          {
+            "topic": {
+              "name": "parameter-encoding"
+            }
+          },
+          {
+            "topic": {
+              "name": "alamofire"
+            }
+          },
+          {
+            "topic": {
+              "name": "cocoapods"
+            }
+          },
+          {
+            "topic": {
+              "name": "carthage"
+            }
+          },
+          {
+            "topic": {
+              "name": "swift-package-manager"
+            }
           }
         ]
       },

--- a/Tests/AppTests/Fixtures/github-graphql-resource.json
+++ b/Tests/AppTests/Fixtures/github-graphql-resource.json
@@ -941,6 +941,7 @@
         "nodes": [
           {
             "description": "Released on 2020-04-21. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/77?closed=1).\r\n\r\n#### Fixed\r\n- Change in multipart upload creation order.\r\n  - Fixed by [Christian Noon](https://github.com/cnoon) in Pull Request [#3438](https://github.com/Alamofire/Alamofire/pull/3438).\r\n- Typo in Alamofire 5 migration guide.\r\n  - Fixed by [DevYeom](https://github.com/DevYeom) in Pull Request [#3431](https://github.com/Alamofire/Alamofire/pull/3431).",
+            "descriptionHTML": "<p>mock descriptionHTML</>",
             "isDraft": false,
             "publishedAt": "2021-04-22T02:50:05Z",
             "tagName": "5.4.3",

--- a/Tests/AppTests/Fixtures/github-graphql-resource.json
+++ b/Tests/AppTests/Fixtures/github-graphql-resource.json
@@ -4,309 +4,342 @@
       "closedIssues": {
         "nodes": [
           {
-            "closedAt": "2020-11-24T16:00:07Z"
+            "closedAt": "2020-07-17T16:27:10Z"
           },
           {
-            "closedAt": "2020-10-29T14:19:13Z"
+            "closedAt": "2021-06-09T00:59:39Z"
           },
           {
-            "closedAt": "2020-11-21T22:32:04Z"
+            "closedAt": "2020-01-04T23:16:51Z"
           },
           {
-            "closedAt": "2019-03-06T03:54:44Z"
-          },
-          {
-            "closedAt": "2020-01-29T22:19:33Z"
-          },
-          {
-            "closedAt": "2020-11-17T09:53:07Z"
-          },
-          {
-            "closedAt": "2020-11-17T00:47:07Z"
-          },
-          {
-            "closedAt": "2020-11-13T16:15:37Z"
-          },
-          {
-            "closedAt": "2020-11-13T16:15:26Z"
-          },
-          {
-            "closedAt": "2017-01-26T19:07:05Z"
-          },
-          {
-            "closedAt": "2020-11-10T19:02:59Z"
-          },
-          {
-            "closedAt": "2020-11-09T16:48:49Z"
-          },
-          {
-            "closedAt": "2020-08-17T14:19:03Z"
-          },
-          {
-            "closedAt": "2020-11-06T18:13:21Z"
-          },
-          {
-            "closedAt": "2020-11-06T18:06:53Z"
-          },
-          {
-            "closedAt": "2020-10-18T01:06:44Z"
-          },
-          {
-            "closedAt": "2020-10-18T01:43:11Z"
-          },
-          {
-            "closedAt": "2020-11-04T19:43:21Z"
-          },
-          {
-            "closedAt": "2020-11-04T04:20:55Z"
-          },
-          {
-            "closedAt": "2016-02-04T07:36:37Z"
-          },
-          {
-            "closedAt": "2020-11-02T15:26:47Z"
-          },
-          {
-            "closedAt": "2020-11-02T03:17:32Z"
-          },
-          {
-            "closedAt": "2017-02-19T22:15:07Z"
-          },
-          {
-            "closedAt": "2020-10-29T14:28:57Z"
-          },
-          {
-            "closedAt": "2020-10-28T07:35:38Z"
-          },
-          {
-            "closedAt": "2020-10-18T01:56:43Z"
-          },
-          {
-            "closedAt": "2020-10-27T15:15:25Z"
-          },
-          {
-            "closedAt": "2020-10-18T01:59:28Z"
-          },
-          {
-            "closedAt": "2020-10-26T19:22:30Z"
-          },
-          {
-            "closedAt": "2020-10-25T22:38:42Z"
-          },
-          {
-            "closedAt": "2020-10-25T22:35:29Z"
-          },
-          {
-            "closedAt": "2020-10-25T22:34:56Z"
-          },
-          {
-            "closedAt": "2020-10-25T22:32:39Z"
-          },
-          {
-            "closedAt": "2020-10-23T15:20:23Z"
-          },
-          {
-            "closedAt": "2020-10-22T14:33:48Z"
-          },
-          {
-            "closedAt": "2020-10-22T14:39:40Z"
-          },
-          {
-            "closedAt": "2020-10-21T17:49:06Z"
-          },
-          {
-            "closedAt": "2020-10-21T14:23:36Z"
-          },
-          {
-            "closedAt": "2020-10-19T14:53:03Z"
-          },
-          {
-            "closedAt": "2020-10-19T14:52:28Z"
-          },
-          {
-            "closedAt": "2020-10-18T02:01:26Z"
-          },
-          {
-            "closedAt": "2020-10-18T02:00:21Z"
-          },
-          {
-            "closedAt": "2020-10-18T01:44:31Z"
-          },
-          {
-            "closedAt": "2020-10-15T14:30:25Z"
-          },
-          {
-            "closedAt": "2019-04-01T15:06:44Z"
-          },
-          {
-            "closedAt": "2020-10-13T06:46:07Z"
-          },
-          {
-            "closedAt": "2015-09-06T21:38:33Z"
-          },
-          {
-            "closedAt": "2020-03-28T20:07:45Z"
-          },
-          {
-            "closedAt": "2020-10-09T02:38:04Z"
-          },
-          {
-            "closedAt": "2019-09-02T21:29:52Z"
-          },
-          {
-            "closedAt": "2020-10-01T19:22:33Z"
-          },
-          {
-            "closedAt": "2020-10-03T21:41:25Z"
-          },
-          {
-            "closedAt": "2020-10-03T20:05:17Z"
-          },
-          {
-            "closedAt": "2020-09-02T17:43:01Z"
-          },
-          {
-            "closedAt": "2020-05-04T01:18:48Z"
-          },
-          {
-            "closedAt": "2020-09-28T00:22:04Z"
-          },
-          {
-            "closedAt": "2018-09-27T16:14:40Z"
-          },
-          {
-            "closedAt": "2020-09-22T15:32:30Z"
-          },
-          {
-            "closedAt": "2020-09-21T14:20:45Z"
+            "closedAt": "2021-06-02T07:16:36Z"
           },
           {
             "closedAt": "2020-06-14T05:10:23Z"
           },
           {
-            "closedAt": "2020-09-21T15:59:39Z"
+            "closedAt": "2021-05-28T15:57:51Z"
           },
           {
-            "closedAt": "2020-09-21T14:21:57Z"
+            "closedAt": "2021-05-27T22:37:58Z"
+          },
+          {
+            "closedAt": "2021-05-27T22:37:03Z"
+          },
+          {
+            "closedAt": "2021-05-27T22:31:12Z"
           },
           {
             "closedAt": "2020-09-16T14:17:35Z"
           },
           {
-            "closedAt": "2020-09-19T19:43:16Z"
+            "closedAt": "2016-07-26T19:52:27Z"
           },
           {
-            "closedAt": "2020-03-22T21:20:23Z"
+            "closedAt": "2021-05-11T05:04:54Z"
           },
           {
-            "closedAt": "2020-08-07T16:09:41Z"
+            "closedAt": "2021-05-10T14:31:13Z"
           },
           {
-            "closedAt": "2014-10-31T02:43:00Z"
+            "closedAt": "2021-04-22T23:54:40Z"
           },
           {
-            "closedAt": "2020-09-17T16:06:36Z"
+            "closedAt": "2021-04-20T16:30:37Z"
           },
           {
-            "closedAt": "2020-09-17T12:52:48Z"
+            "closedAt": "2021-04-20T09:13:27Z"
           },
           {
-            "closedAt": "2020-03-28T20:06:53Z"
+            "closedAt": "2021-04-13T17:16:34Z"
           },
           {
-            "closedAt": "2020-09-16T14:18:20Z"
+            "closedAt": "2021-04-13T09:02:19Z"
           },
           {
-            "closedAt": "2018-01-22T18:45:11Z"
+            "closedAt": "2021-04-12T16:53:12Z"
           },
           {
-            "closedAt": "2017-09-14T19:12:10Z"
+            "closedAt": "2021-04-08T02:45:17Z"
           },
           {
-            "closedAt": "2020-09-10T20:35:09Z"
+            "closedAt": "2021-03-08T04:14:50Z"
           },
           {
-            "closedAt": "2020-09-10T20:30:15Z"
+            "closedAt": "2021-04-03T21:48:07Z"
           },
           {
-            "closedAt": "2020-09-10T20:24:25Z"
+            "closedAt": "2021-04-02T07:47:40Z"
           },
           {
-            "closedAt": "2019-09-10T13:12:49Z"
+            "closedAt": "2021-03-31T20:52:15Z"
           },
           {
-            "closedAt": "2019-12-26T14:05:38Z"
+            "closedAt": "2014-11-05T19:34:15Z"
           },
           {
-            "closedAt": "2020-09-04T16:16:34Z"
+            "closedAt": "2021-03-25T05:48:40Z"
+          },
+          {
+            "closedAt": "2020-11-02T03:17:32Z"
+          },
+          {
+            "closedAt": "2021-03-18T20:28:01Z"
+          },
+          {
+            "closedAt": "2021-03-18T15:52:08Z"
+          },
+          {
+            "closedAt": "2021-03-15T02:02:51Z"
+          },
+          {
+            "closedAt": "2015-10-20T06:11:13Z"
           },
           {
             "closedAt": "2020-09-03T14:43:05Z"
           },
           {
-            "closedAt": "2020-09-03T01:00:16Z"
+            "closedAt": "2021-03-08T08:05:19Z"
           },
           {
-            "closedAt": "2020-09-02T18:00:34Z"
+            "closedAt": "2021-03-07T03:44:04Z"
           },
           {
-            "closedAt": "2016-09-07T14:34:47Z"
+            "closedAt": "2021-03-02T03:21:33Z"
           },
           {
-            "closedAt": "2016-11-20T09:33:05Z"
+            "closedAt": "2021-03-01T02:52:22Z"
           },
           {
-            "closedAt": "2015-11-22T21:13:32Z"
+            "closedAt": "2021-03-01T03:12:55Z"
           },
           {
-            "closedAt": "2020-08-26T16:27:37Z"
+            "closedAt": "2021-03-01T03:12:28Z"
           },
           {
-            "closedAt": "2020-08-25T14:33:39Z"
+            "closedAt": "2021-03-01T03:07:32Z"
           },
           {
-            "closedAt": "2020-08-23T21:59:21Z"
+            "closedAt": "2021-03-01T03:06:07Z"
           },
           {
-            "closedAt": "2020-08-22T18:16:52Z"
+            "closedAt": "2021-03-01T03:04:57Z"
           },
           {
-            "closedAt": "2020-08-22T18:15:34Z"
+            "closedAt": "2021-03-01T02:38:25Z"
           },
           {
-            "closedAt": "2020-08-22T18:11:43Z"
+            "closedAt": "2021-02-26T20:59:25Z"
           },
           {
-            "closedAt": "2020-08-18T14:24:55Z"
+            "closedAt": "2021-02-26T20:58:58Z"
           },
           {
-            "closedAt": "2020-08-17T07:28:43Z"
+            "closedAt": "2021-02-26T20:37:45Z"
           },
           {
-            "closedAt": "2020-08-13T19:18:12Z"
+            "closedAt": "2021-02-26T20:37:22Z"
           },
           {
-            "closedAt": "2020-08-13T19:18:00Z"
+            "closedAt": "2021-01-11T19:11:48Z"
           },
           {
-            "closedAt": "2019-10-14T02:54:52Z"
+            "closedAt": "2018-04-01T01:29:12Z"
           },
           {
-            "closedAt": "2020-08-12T14:23:33Z"
+            "closedAt": "2020-01-29T22:14:09Z"
           },
           {
-            "closedAt": "2020-08-07T15:33:16Z"
+            "closedAt": "2021-02-09T13:28:54Z"
           },
           {
-            "closedAt": "2020-07-17T16:27:10Z"
+            "closedAt": "2020-03-28T20:06:53Z"
           },
           {
-            "closedAt": "2020-07-28T14:23:50Z"
+            "closedAt": "2021-02-04T02:36:56Z"
+          },
+          {
+            "closedAt": "2021-02-01T23:35:29Z"
+          },
+          {
+            "closedAt": "2017-03-29T13:19:40Z"
+          },
+          {
+            "closedAt": "2021-01-28T06:01:00Z"
+          },
+          {
+            "closedAt": "2017-06-22T18:25:29Z"
+          },
+          {
+            "closedAt": "2021-01-25T20:46:26Z"
+          },
+          {
+            "closedAt": "2021-01-25T00:37:42Z"
+          },
+          {
+            "closedAt": "2021-01-25T00:40:24Z"
+          },
+          {
+            "closedAt": "2021-01-25T00:35:53Z"
+          },
+          {
+            "closedAt": "2021-01-25T00:27:52Z"
+          },
+          {
+            "closedAt": "2020-06-18T18:40:53Z"
+          },
+          {
+            "closedAt": "2020-04-28T23:01:48Z"
+          },
+          {
+            "closedAt": "2019-12-25T08:24:05Z"
+          },
+          {
+            "closedAt": "2015-04-06T02:41:58Z"
+          },
+          {
+            "closedAt": "2021-01-14T23:34:25Z"
+          },
+          {
+            "closedAt": "2021-01-14T15:45:14Z"
+          },
+          {
+            "closedAt": "2020-07-16T09:26:53Z"
+          },
+          {
+            "closedAt": "2021-01-12T17:41:52Z"
+          },
+          {
+            "closedAt": "2021-01-11T21:55:35Z"
+          },
+          {
+            "closedAt": "2021-01-11T19:05:24Z"
+          },
+          {
+            "closedAt": "2020-06-29T10:11:51Z"
+          },
+          {
+            "closedAt": "2021-01-08T10:05:02Z"
+          },
+          {
+            "closedAt": "2016-07-08T00:19:03Z"
+          },
+          {
+            "closedAt": "2016-10-01T22:09:02Z"
+          },
+          {
+            "closedAt": "2021-01-06T20:25:23Z"
+          },
+          {
+            "closedAt": "2021-01-05T14:03:31Z"
+          },
+          {
+            "closedAt": "2021-01-04T15:25:26Z"
+          },
+          {
+            "closedAt": "2021-01-04T15:24:14Z"
+          },
+          {
+            "closedAt": "2020-06-19T16:11:08Z"
+          },
+          {
+            "closedAt": "2020-12-26T04:25:51Z"
+          },
+          {
+            "closedAt": "2019-05-09T22:06:41Z"
+          },
+          {
+            "closedAt": "2020-12-23T04:57:12Z"
+          },
+          {
+            "closedAt": "2020-12-18T16:22:10Z"
+          },
+          {
+            "closedAt": "2020-12-21T02:27:27Z"
+          },
+          {
+            "closedAt": "2020-12-20T02:00:54Z"
+          },
+          {
+            "closedAt": "2020-12-20T02:08:47Z"
+          },
+          {
+            "closedAt": "2020-12-20T02:05:31Z"
+          },
+          {
+            "closedAt": "2020-12-18T16:25:58Z"
+          },
+          {
+            "closedAt": "2020-12-16T10:38:52Z"
+          },
+          {
+            "closedAt": "2020-10-18T01:06:44Z"
+          },
+          {
+            "closedAt": "2020-12-10T17:15:25Z"
+          },
+          {
+            "closedAt": "2020-12-10T16:44:04Z"
+          },
+          {
+            "closedAt": "2020-12-10T16:42:15Z"
+          },
+          {
+            "closedAt": "2020-12-10T16:41:54Z"
+          },
+          {
+            "closedAt": "2020-11-24T16:00:07Z"
+          },
+          {
+            "closedAt": "2015-10-31T22:37:11Z"
+          },
+          {
+            "closedAt": "2015-07-07T02:29:47Z"
+          },
+          {
+            "closedAt": "2018-05-07T21:38:52Z"
+          },
+          {
+            "closedAt": "2020-11-27T20:17:58Z"
           }
         ]
       },
       "closedPullRequests": {
         "nodes": [
+          {
+            "closedAt": "2021-05-28T15:50:17Z"
+          },
+          {
+            "closedAt": "2021-05-01T22:48:39Z"
+          },
+          {
+            "closedAt": "2021-04-28T23:05:12Z"
+          },
+          {
+            "closedAt": "2021-04-22T08:25:11Z"
+          },
+          {
+            "closedAt": "2021-04-17T00:46:57Z"
+          },
+          {
+            "closedAt": "2021-03-25T15:19:53Z"
+          },
+          {
+            "closedAt": "2021-03-08T01:59:47Z"
+          },
+          {
+            "closedAt": "2021-01-16T20:10:11Z"
+          },
+          {
+            "closedAt": "2020-12-31T01:49:40Z"
+          },
+          {
+            "closedAt": "2020-12-20T01:36:32Z"
+          },
+          {
+            "closedAt": "2020-12-20T01:30:25Z"
+          },
           {
             "closedAt": "2020-08-13T19:10:08Z"
           },
@@ -573,39 +606,6 @@
           },
           {
             "closedAt": "2017-08-22T05:53:00Z"
-          },
-          {
-            "closedAt": "2017-08-22T05:46:58Z"
-          },
-          {
-            "closedAt": "2016-06-12T23:09:07Z"
-          },
-          {
-            "closedAt": "2017-07-10T14:34:51Z"
-          },
-          {
-            "closedAt": "2017-06-28T20:41:04Z"
-          },
-          {
-            "closedAt": "2017-06-21T14:54:53Z"
-          },
-          {
-            "closedAt": "2017-06-16T21:26:56Z"
-          },
-          {
-            "closedAt": "2017-06-17T21:58:44Z"
-          },
-          {
-            "closedAt": "2017-06-16T22:31:32Z"
-          },
-          {
-            "closedAt": "2017-06-16T22:18:02Z"
-          },
-          {
-            "closedAt": "2017-06-16T21:53:28Z"
-          },
-          {
-            "closedAt": "2017-06-15T21:04:24Z"
           }
         ]
       },
@@ -613,7 +613,7 @@
         "name": "master"
       },
       "description": "Elegant HTTP Networking in Swift",
-      "forkCount": 6480,
+      "forkCount": 6727,
       "isArchived": false,
       "isFork": false,
       "licenseInfo": {
@@ -623,6 +623,60 @@
       },
       "mergedPullRequests": {
         "nodes": [
+          {
+            "closedAt": "2021-06-07T22:47:01Z"
+          },
+          {
+            "closedAt": "2021-05-28T16:23:20Z"
+          },
+          {
+            "closedAt": "2021-05-13T14:10:28Z"
+          },
+          {
+            "closedAt": "2021-05-02T23:20:49Z"
+          },
+          {
+            "closedAt": "2021-05-01T23:08:29Z"
+          },
+          {
+            "closedAt": "2020-01-16T21:22:50Z"
+          },
+          {
+            "closedAt": "2021-04-22T02:49:02Z"
+          },
+          {
+            "closedAt": "2021-04-08T02:36:40Z"
+          },
+          {
+            "closedAt": "2021-04-17T04:17:57Z"
+          },
+          {
+            "closedAt": "2021-03-08T02:10:01Z"
+          },
+          {
+            "closedAt": "2021-03-08T01:59:28Z"
+          },
+          {
+            "closedAt": "2021-04-03T21:45:03Z"
+          },
+          {
+            "closedAt": "2021-03-01T03:59:19Z"
+          },
+          {
+            "closedAt": "2021-03-08T02:38:04Z"
+          },
+          {
+            "closedAt": "2021-03-15T02:20:03Z"
+          },
+          {
+            "closedAt": "2021-02-01T05:05:07Z"
+          },
+          {
+            "closedAt": "2020-12-21T02:07:21Z"
+          },
+          {
+            "closedAt": "2020-12-20T01:29:27Z"
+          },
           {
             "closedAt": "2020-11-04T21:27:43Z"
           },
@@ -868,60 +922,6 @@
           },
           {
             "closedAt": "2020-01-30T01:25:06Z"
-          },
-          {
-            "closedAt": "2020-02-14T19:05:22Z"
-          },
-          {
-            "closedAt": "2020-02-14T19:28:41Z"
-          },
-          {
-            "closedAt": "2020-02-14T18:59:30Z"
-          },
-          {
-            "closedAt": "2020-02-14T19:07:06Z"
-          },
-          {
-            "closedAt": "2020-02-14T18:57:47Z"
-          },
-          {
-            "closedAt": "2020-01-25T19:38:39Z"
-          },
-          {
-            "closedAt": "2020-01-22T01:42:56Z"
-          },
-          {
-            "closedAt": "2020-01-16T21:22:50Z"
-          },
-          {
-            "closedAt": "2020-01-04T22:59:09Z"
-          },
-          {
-            "closedAt": "2020-01-04T22:58:36Z"
-          },
-          {
-            "closedAt": "2019-11-30T03:33:02Z"
-          },
-          {
-            "closedAt": "2019-11-17T23:01:56Z"
-          },
-          {
-            "closedAt": "2019-10-27T00:54:45Z"
-          },
-          {
-            "closedAt": "2019-10-19T23:00:51Z"
-          },
-          {
-            "closedAt": "2019-09-27T14:54:21Z"
-          },
-          {
-            "closedAt": "2019-10-19T23:20:48Z"
-          },
-          {
-            "closedAt": "2019-10-21T23:55:46Z"
-          },
-          {
-            "closedAt": "2019-10-19T23:21:44Z"
           }
         ]
       },
@@ -937,8 +937,109 @@
         "avatarUrl": "https://avatars.githubusercontent.com/u/7774181?v=4",
         "name": "Alamofire"
       },
+      "repositoryTopics": {
+        "totalCount": 15,
+        "nodes": [
+          {
+            "topic": {
+              "name": "networking"
+            }
+          },
+          {
+            "topic": {
+              "name": "urlsession"
+            }
+          },
+          {
+            "topic": {
+              "name": "urlrequest"
+            }
+          },
+          {
+            "topic": {
+              "name": "httpurlresponse"
+            }
+          },
+          {
+            "topic": {
+              "name": "request"
+            }
+          },
+          {
+            "topic": {
+              "name": "response"
+            }
+          },
+          {
+            "topic": {
+              "name": "swift"
+            }
+          },
+          {
+            "topic": {
+              "name": "xcode"
+            }
+          },
+          {
+            "topic": {
+              "name": "certificate-pinning"
+            }
+          },
+          {
+            "topic": {
+              "name": "public-key-pinning"
+            }
+          },
+          {
+            "topic": {
+              "name": "parameter-encoding"
+            }
+          },
+          {
+            "topic": {
+              "name": "alamofire"
+            }
+          },
+          {
+            "topic": {
+              "name": "cocoapods"
+            }
+          },
+          {
+            "topic": {
+              "name": "carthage"
+            }
+          },
+          {
+            "topic": {
+              "name": "swift-package-manager"
+            }
+          }
+        ]
+      },
       "releases": {
         "nodes": [
+          {
+            "description": "Released on 2020-04-21. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/77?closed=1).\r\n\r\n#### Fixed\r\n- Change in multipart upload creation order.\r\n  - Fixed by [Christian Noon](https://github.com/cnoon) in Pull Request [#3438](https://github.com/Alamofire/Alamofire/pull/3438).\r\n- Typo in Alamofire 5 migration guide.\r\n  - Fixed by [DevYeom](https://github.com/DevYeom) in Pull Request [#3431](https://github.com/Alamofire/Alamofire/pull/3431).",
+            "isDraft": false,
+            "publishedAt": "2021-04-22T02:50:05Z",
+            "tagName": "5.4.3",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/5.4.3"
+          },
+          {
+            "description": "Released on 2020-04-03. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/76?closed=1).\r\n\r\n#### Updated\r\n- Resume data handling for `DownloadRequest`s to access resume data from errors as well as cancellation.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#3419](https://github.com/Alamofire/Alamofire/pull/3419).\r\n- Project files and templates for Xcode 12.4 and GitHub templates.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#3414](https://github.com/Alamofire/Alamofire/pull/3414).\r\n\r\n#### Fixed\r\n- `MultipartUpload` thread-safety.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#3421](https://github.com/Alamofire/Alamofire/pull/3421).\r\n- Multipart body stream length handling to better handle partial streams.\r\n  - Fixed by [Yu Ao](https://github.com/YuAo) and [Jon Shier](https://github.com/jshier) in Pull Requests [#3380](https://github.com/Alamofire/Alamofire/pull/3380) and [#3420](https://github.com/Alamofire/Alamofire/pull/3420).",
+            "isDraft": false,
+            "publishedAt": "2021-04-03T21:46:06Z",
+            "tagName": "5.4.2",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/5.4.2"
+          },
+          {
+            "description": "Released on 2020-12-20. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/75?closed=1).\r\n\r\n#### Updated\r\n- Project and CocoaPods installation of Obj-C header.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#3378](https://github.com/Alamofire/Alamofire/pull/3378).",
+            "isDraft": false,
+            "publishedAt": "2020-12-21T02:11:14Z",
+            "tagName": "5.4.1",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/5.4.1"
+          },
           {
             "description": "Released on 2020-11-04. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/74?closed=1).\r\n\r\n#### Added\r\n- `URLResponseSerializer` and attendant convenience methods so downloads can produce a non-optional `URL`.\r\n  - Added by[Jon Shier](https://github.com/jshier) in Pull Request [#3343](https://github.com/Alamofire/Alamofire/pull/3343).\r\n\r\n#### Updated\r\n- Handing of `file://` `URL`s, removing error added in 5.3.0 and adding support for `DownloadRequest`.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#3342](https://github.com/Alamofire/Alamofire/pull/3342).",
             "descriptionHTML": "<p>Released on 2020-11-04. All issues associated with this milestone can be found using this <a href=\"https://github.com/Alamofire/Alamofire/milestone/74?closed=1\">filter</a>.</p>\n<h4>Added</h4>\n<ul>\n<li><code>URLResponseSerializer</code> and attendant convenience methods so downloads can produce a non-optional <code>URL</code>.\n<ul>\n<li>Added by<a href=\"https://github.com/jshier\">Jon Shier</a> in Pull Request <a href=\"https://github.com/Alamofire/Alamofire/pull/3343\" data-hovercard-type=\"pull_request\" data-hovercard-url=\"/Alamofire/Alamofire/pull/3343/hovercard\">#3343</a>.</li>\n</ul>\n</li>\n</ul>\n<h4>Updated</h4>\n<ul>\n<li>Handing of <code>file://</code> <code>URL</code>s, removing error added in 5.3.0 and adding support for <code>DownloadRequest</code>.\n<ul>\n<li>Updated by <a href=\"https://github.com/jshier\">Jon Shier</a> in Pull Request <a href=\"https://github.com/Alamofire/Alamofire/pull/3342\" data-hovercard-type=\"pull_request\" data-hovercard-url=\"/Alamofire/Alamofire/pull/3342/hovercard\">#3342</a>.</li>\n</ul>\n</li>\n</ul>",
@@ -1018,10 +1119,59 @@
             "publishedAt": "2020-02-23T21:45:55Z",
             "tagName": "5.0.2",
             "url": "https://github.com/Alamofire/Alamofire/releases/tag/5.0.2"
+          },
+          {
+            "description": "Released on 2020-02-23. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/64?closed=1).\r\n\r\n#### Updated\r\n- `AlamofireExtension` to have public properties and initializer, and conform to `@dynamicMemberLookup`.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#3075](https://github.com/Alamofire/Alamofire/pull/3075).",
+            "isDraft": false,
+            "publishedAt": "2020-02-23T05:29:28Z",
+            "tagName": "5.0.1",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/5.0.1"
+          },
+          {
+            "description": "Released on 2020-02-14. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/63?closed=1).\r\n\r\n#### Added\r\n- Support for `NSURLAuthenticationMethodClientCertificate` when handling auth challenges using `URLCredential`s.\r\n  - Added by [刘富东](https://github.com/liuwin7) in Pull Request [#2993](https://github.com/Alamofire/Alamofire/pull/2993).\r\n- Migration Guide for Alamofire 5.\r\n  - Added by [Jon Shier](https://github.com/jshier) in Pull Request [#3061](https://github.com/Alamofire/Alamofire/pull/3061).\r\n\r\n#### Updated\r\n- Advanced Usage documentation for Alamofire 5.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#3062](https://github.com/Alamofire/Alamofire/pull/3062).\r\n- `AF` namespace to be a reference to `Session.default`.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#3059](https://github.com/Alamofire/Alamofire/pull/3059).\r\n\r\n#### Fixed\r\n- Runtime crashes due to overzealous state checking in `SessionDelegate` by reducing the severity of the assertions.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#3010](https://github.com/Alamofire/Alamofire/pull/3010).\r\n- Unwanted `public` attribute on `_URLEncodedFormEncoder`.\r\n  - Fixed by [Mattt](https://github.com/mattt) in Pull Request [#3053](https://github.com/Alamofire/Alamofire/pull/3053).",
+            "isDraft": false,
+            "publishedAt": "2020-02-14T23:26:43Z",
+            "tagName": "5.0.0",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/5.0.0"
+          },
+          {
+            "description": "Released on 2019-10-26. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/62?closed=1). **Note:** Alamofire 5 is now API stable.\r\n\r\n#### Updated\r\n- Automatic `resume()` behavior to be called after the first response handler is added instead of immediately after task creation.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#2965](https://github.com/Alamofire/Alamofire/pull/2965).\r\n\r\n#### Fixed\r\n- Incorrect header convenience method in Usage documentation.\r\n  - Fixed by [Sebastian](https://github.com/Buesing-Sebastian) in Pull Request [#2952](https://github.com/Alamofire/Alamofire/pull/2952).\r\n- Unstable parameter ordering in `URLEncodedFormEncoder`.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#2961](https://github.com/Alamofire/Alamofire/pull/2961).\r\n- Xcode build issues and precompiled binary build issues by removing the dynamic bundle identifier.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#2966](https://github.com/Alamofire/Alamofire/pull/2966).\r\n- Build warnings for deprecated `SecTrust` API when building for Catalyst.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#2977](https://github.com/Alamofire/Alamofire/pull/2977).\r\n- Regression from Alamofire 4 causing Alamofire to reject NTLM and Negotiate authentication methods.\r\n  - Fixed by [Adrian Kashivskyy](https://github.com/akashivskyy) in Pull Request [#2975](https://github.com/Alamofire/Alamofire/pull/2975).",
+            "isDraft": false,
+            "publishedAt": "2019-10-27T00:59:37Z",
+            "tagName": "5.0.0-rc.3",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/5.0.0-rc.3"
+          },
+          {
+            "description": "Released on 2019-10-26. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/61?closed=1).\r\n\r\n#### Added\r\n- Support for GitHub Actions for CI.\r\n  - Added by [Jon Shier](https://github.com/jshier) in Pull Request [#2979](https://github.com/Alamofire/Alamofire/pull/2979).\r\n\r\n#### Updated\r\n- `DataResponse` and `DownloadResponse` `debugDescription` to include more useful information.\r\n  - Updated by [rain2540](https://github.com/rain2540) in Pull Request [#2976](https://github.com/Alamofire/Alamofire/pull/2976).\r\n\r\n#### Fixed\r\n- Dynamic bundle identifier causing issues with Xcode and precompiled binaries by removing the dynamic behavior.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#2967](https://github.com/Alamofire/Alamofire/pull/2967).\r\n- Compiler warnings when building for Catalyst by updating the usage of deprecated API.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#2979](https://github.com/Alamofire/Alamofire/pull/2979).\r\n",
+            "isDraft": false,
+            "publishedAt": "2019-10-26T23:22:13Z",
+            "tagName": "4.9.1",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/4.9.1"
+          },
+          {
+            "description": "Released on 2019-09-08. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/59?closed=1). **Note:** Alamofire 5 is now API stable.\r\n\r\n#### Fixed\r\n- Single remaining use of `Error` instead of generic `Failure` constraint in `DataResponse` API.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#2937](https://github.com/Alamofire/Alamofire/pull/2937).",
+            "isDraft": false,
+            "publishedAt": "2019-09-08T22:50:38Z",
+            "tagName": "5.0.0-rc.2",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/5.0.0-rc.2"
+          },
+          {
+            "description": "Released on 2019-09-04. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/58?closed=1). **Note:** Alamofire 5 is now API stable.\r\n\r\n#### Added\r\n- `cancelAllRequests` method on `Session` to cancel all in flight requests.\r\n  - Added by [Jon Shier](https://github.com/jshier) in Pull Request [#2890](https://github.com/Alamofire/Alamofire/pull/2890).\r\n- Ability to inject `FileManager` instance into `UploadRequest`.\r\n  - Added by [Jon Shier](https://github.com/jshier) in Pull Request [#2898](https://github.com/Alamofire/Alamofire/pull/2898).\r\n- `DataPreprocessor` protocol and implementations, allowing the preprocessing of data before serialization.\r\n  - Added by [Jon Shier](https://github.com/jshier) in Pull Request [#2903](https://github.com/Alamofire/Alamofire/pull/2903).\r\n- Internal `URLRequest` validation and error. `GET` requests with body data will now produce an error.\r\n  - Added by [Jon Shier](https://github.com/jshier) in Pull Request [#2905](https://github.com/Alamofire/Alamofire/pull/2905).\r\n- Generic `Failure` constraint to `DataResponse` and `DownloadResponse`, making them `DataResponse<Success, Failure: Error>` and `DownloadResponse<Success, Failure: Error>`.\r\n  - Added by [philtre](https://github.com/philtre) in Pull Request [#2893](https://github.com/Alamofire/Alamofire/pull/2893).\r\n- Precondition to ensure `Session` can't be used with background `URLSessionConfiguration`s. Alamofire will explicitly support such functionality at some point in the future.\r\n  - Added by [Jon Shier](https://github.com/jshier) in Pull Request [#2917](https://github.com/Alamofire/Alamofire/pull/2917).\r\n- SwiftFormat configuration and updated styling.\r\n  - Added by [Jon Shier](https://github.com/jshier) in Pull Request [#2918](https://github.com/Alamofire/Alamofire/pull/2918).\r\n- `AFDataResponse<Success>` and `AFDownloadResponse<Success>` typealiases to help deal with the doubly generic responses.\r\n  - Added by [Jon Shier](https://github.com/jshier) in Pull Request [#2921](https://github.com/Alamofire/Alamofire/pull/2921).\r\n\r\n#### Updated\r\n\r\n- All internal `Result` usage to use the fully qualified type instead of `AFResult`.\r\n  - Updated by [philtre](https://github.com/philtre) in Pull Request [#2891](https://github.com/Alamofire/Alamofire/pull/2891).\r\n- `DataRequest` and `DownloadRequest` functional API, renaming `flatMap` to `tryMap`.\r\n  - Updated by [philtre](https://github.com/philtre) in Pull Request [#2892](https://github.com/Alamofire/Alamofire/pull/2892).\r\n- `HTTPMethod` to be a struct rather than an enum.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#2901](https://github.com/Alamofire/Alamofire/pull/2901).\r\n- All errors produced by Alamofire to be `AFError` by default. All responses will now start with an `AFError` `Failure` type.\r\n  - Updated by [philtre](https://github.com/philtre) in Pull Request [#2893](https://github.com/Alamofire/Alamofire/pull/2893).\r\n- `NetworkReachabilityManager` to simplify and modernize its API.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#2915](https://github.com/Alamofire/Alamofire/pull/2915).\r\n- `Usage.md` documentation to be fully up-to-date with Alamofire 5.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#2895](https://github.com/Alamofire/Alamofire/pull/2895).\r\n- Bundle identifiers to include the platform name, fixing ITMS-90806.\r\n  - Updated by [Jonathan](https://github.com/JonMo) in Pull Request [#2928](https://github.com/Alamofire/Alamofire/pull/2928).\r\n\r\n#### Fixed\r\n- Thread-safety issue with serialization queue usage.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#2885](https://github.com/Alamofire/Alamofire/pull/2885).",
+            "isDraft": false,
+            "publishedAt": "2019-09-04T04:28:28Z",
+            "tagName": "5.0.0-rc.1",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/5.0.0-rc.1"
+          },
+          {
+            "description": "Released on 2019-09-03. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/issues?utf8=✓&q=milestone%3A4.9.0).\r\n\r\n#### Added\r\n- API to cancel `DownloadRequest`s without producing resume data.\r\n  - Added by [ullstrm](https://github.com/ullstrm) in Pull Request [#2851](https://github.com/Alamofire/Alamofire/pull/2851).\r\n\r\n#### Updated\r\n- Bundle identifiers to include the platform name, fixing ITMS-90806.\r\n  - Updated by [Jonathan](https://github.com/JonMo) in Pull Request [#2930](https://github.com/Alamofire/Alamofire/pull/2930).\r\n\r\n#### Fixed\r\n- NetworkReachabilityManager behavior regression from 4.8.1.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#2931](https://github.com/Alamofire/Alamofire/pull/2931).\r\n- Memory leak when using `validate()`.\r\n  - Fixed by [Jon Shier](https://github.com/jshier) in Pull Request [#2931](https://github.com/Alamofire/Alamofire/pull/2931).",
+            "isDraft": false,
+            "publishedAt": "2019-09-04T00:47:09Z",
+            "tagName": "4.9.0",
+            "url": "https://github.com/Alamofire/Alamofire/releases/tag/4.9.0"
           }
         ]
       },
-      "stargazerCount": 34720,
+      "stargazerCount": 35831,
       "isInOrganization": true
     }
   }

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -101,6 +101,9 @@ class GithubTests: AppTestCase {
                               tagName: "5.4.3",
                               url: "https://github.com/Alamofire/Alamofire/releases/tag/5.4.3")
         ))
+        XCTAssertEqual(res.repository?.repositoryTopics.totalCount, 15)
+        XCTAssertEqual(res.repository?.repositoryTopics.nodes.first?.topic.name,
+                       "networking")
         XCTAssertEqual(res.repository?.stargazerCount, 35831)
         XCTAssertEqual(res.repository?.isInOrganization, true)
         // derived properties

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -94,12 +94,12 @@ class GithubTests: AppTestCase {
         XCTAssertEqual(res.repository?.openPullRequests.totalCount, 6)
         XCTAssertEqual(res.repository?.releases.nodes.count, 20)
         XCTAssertEqual(res.repository?.releases.nodes.first, .some(
-                        .init(description: "Released on 2020-11-04. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/74?closed=1).\r\n\r\n#### Added\r\n- `URLResponseSerializer` and attendant convenience methods so downloads can produce a non-optional `URL`.\r\n  - Added by[Jon Shier](https://github.com/jshier) in Pull Request [#3343](https://github.com/Alamofire/Alamofire/pull/3343).\r\n\r\n#### Updated\r\n- Handing of `file://` `URL`s, removing error added in 5.3.0 and adding support for `DownloadRequest`.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#3342](https://github.com/Alamofire/Alamofire/pull/3342).",
-                            descriptionHTML: "<p>Released on 2020-11-04. All issues associated with this milestone can be found using this <a href=\"https://github.com/Alamofire/Alamofire/milestone/74?closed=1\">filter</a>.</p>\n<h4>Added</h4>\n<ul>\n<li><code>URLResponseSerializer</code> and attendant convenience methods so downloads can produce a non-optional <code>URL</code>.\n<ul>\n<li>Added by<a href=\"https://github.com/jshier\">Jon Shier</a> in Pull Request <a href=\"https://github.com/Alamofire/Alamofire/pull/3343\" data-hovercard-type=\"pull_request\" data-hovercard-url=\"/Alamofire/Alamofire/pull/3343/hovercard\">#3343</a>.</li>\n</ul>\n</li>\n</ul>\n<h4>Updated</h4>\n<ul>\n<li>Handing of <code>file://</code> <code>URL</code>s, removing error added in 5.3.0 and adding support for <code>DownloadRequest</code>.\n<ul>\n<li>Updated by <a href=\"https://github.com/jshier\">Jon Shier</a> in Pull Request <a href=\"https://github.com/Alamofire/Alamofire/pull/3342\" data-hovercard-type=\"pull_request\" data-hovercard-url=\"/Alamofire/Alamofire/pull/3342/hovercard\">#3342</a>.</li>\n</ul>\n</li>\n</ul>",
-                              isDraft: false,
-                              publishedAt: iso8601.date(from: "2021-04-22T02:50:05Z")!,
-                              tagName: "5.4.3",
-                              url: "https://github.com/Alamofire/Alamofire/releases/tag/5.4.3")
+            .init(description: "Released on 2020-04-21. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/77?closed=1).\r\n\r\n#### Fixed\r\n- Change in multipart upload creation order.\r\n  - Fixed by [Christian Noon](https://github.com/cnoon) in Pull Request [#3438](https://github.com/Alamofire/Alamofire/pull/3438).\r\n- Typo in Alamofire 5 migration guide.\r\n  - Fixed by [DevYeom](https://github.com/DevYeom) in Pull Request [#3431](https://github.com/Alamofire/Alamofire/pull/3431).",
+                  descriptionHTML: "<p>mock descriptionHTML</>",
+                  isDraft: false,
+                  publishedAt: iso8601.date(from: "2021-04-22T02:50:05Z")!,
+                  tagName: "5.4.3",
+                  url: "https://github.com/Alamofire/Alamofire/releases/tag/5.4.3")
         ))
         XCTAssertEqual(res.repository?.repositoryTopics.totalCount, 15)
         XCTAssertEqual(res.repository?.repositoryTopics.nodes.first?.topic.name,

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -32,7 +32,7 @@ class GithubTests: AppTestCase {
         }
         do {
             let data = """
-            {"data":{"repository":{"closedIssues":{"nodes":[]},"closedPullRequests":{"nodes":[]},"createdAt":"2019-04-23T09:26:22Z","defaultBranchRef":{"name":"master"},"description":null,"forkCount":0,"isArchived":false,"isFork":false,"licenseInfo":null,"mergedPullRequests":{"nodes":[]},"name":"CRToastSwift","openIssues":{"totalCount":0},"openPullRequests":{"totalCount":0},"owner":{"login":"krugazor","avatarUrl": "https://avatars.githubusercontent.com/u/2742179?u=28d2ccb6a27c975e663738fe86af579ff74203ac&v=4","name": "Nicolas Zinovieff"},"releases":{"nodes":[]},"stargazerCount":3,"isInOrganization":false},"rateLimit":{"remaining":4753}}}
+            {"data":{"repository":{"closedIssues":{"nodes":[]},"closedPullRequests":{"nodes":[]},"createdAt":"2019-04-23T09:26:22Z","defaultBranchRef":{"name":"master"},"description":null,"forkCount":0,"isArchived":false,"isFork":false,"licenseInfo":null,"mergedPullRequests":{"nodes":[]},"name":"CRToastSwift","openIssues":{"totalCount":0},"openPullRequests":{"totalCount":0},"owner":{"login":"krugazor","avatarUrl": "https://avatars.githubusercontent.com/u/2742179?u=28d2ccb6a27c975e663738fe86af579ff74203ac&v=4","name": "Nicolas Zinovieff"},"releases":{"nodes":[]},"repositoryTopics":{"totalCount":0,"nodes":[]},"stargazerCount":3,"isInOrganization":false},"rateLimit":{"remaining":4753}}}
             """
             _ = try Github.decoder.decode(Response.self, from: Data(data.utf8))
         }

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -80,35 +80,35 @@ class GithubTests: AppTestCase {
 
         // validation
         XCTAssertEqual(res.repository?.closedIssues.nodes.first!.closedAt,
-                       iso8601.date(from: "2020-11-24T16:00:07Z"))
+                       iso8601.date(from: "2020-07-17T16:27:10Z"))
         XCTAssertEqual(res.repository?.closedPullRequests.nodes.first!.closedAt,
-                       iso8601.date(from: "2020-08-13T19:10:08Z"))
-        XCTAssertEqual(res.repository?.forkCount, 6480)
+                       iso8601.date(from: "2021-05-28T15:50:17Z"))
+        XCTAssertEqual(res.repository?.forkCount, 6727)
         XCTAssertEqual(res.repository?.mergedPullRequests.nodes.first!.closedAt,
-                       iso8601.date(from: "2020-11-04T21:27:43Z"))
+                       iso8601.date(from: "2021-06-07T22:47:01Z"))
         XCTAssertEqual(res.repository?.name, "Alamofire")
         XCTAssertEqual(res.repository?.owner.name, "Alamofire")
         XCTAssertEqual(res.repository?.owner.login, "Alamofire")
         XCTAssertEqual(res.repository?.owner.avatarUrl, "https://avatars.githubusercontent.com/u/7774181?v=4")
         XCTAssertEqual(res.repository?.openIssues.totalCount, 30)
         XCTAssertEqual(res.repository?.openPullRequests.totalCount, 6)
-        XCTAssertEqual(res.repository?.releases.nodes.count, 10)
+        XCTAssertEqual(res.repository?.releases.nodes.count, 20)
         XCTAssertEqual(res.repository?.releases.nodes.first, .some(
                         .init(description: "Released on 2020-11-04. All issues associated with this milestone can be found using this [filter](https://github.com/Alamofire/Alamofire/milestone/74?closed=1).\r\n\r\n#### Added\r\n- `URLResponseSerializer` and attendant convenience methods so downloads can produce a non-optional `URL`.\r\n  - Added by[Jon Shier](https://github.com/jshier) in Pull Request [#3343](https://github.com/Alamofire/Alamofire/pull/3343).\r\n\r\n#### Updated\r\n- Handing of `file://` `URL`s, removing error added in 5.3.0 and adding support for `DownloadRequest`.\r\n  - Updated by [Jon Shier](https://github.com/jshier) in Pull Request [#3342](https://github.com/Alamofire/Alamofire/pull/3342).",
                             descriptionHTML: "<p>Released on 2020-11-04. All issues associated with this milestone can be found using this <a href=\"https://github.com/Alamofire/Alamofire/milestone/74?closed=1\">filter</a>.</p>\n<h4>Added</h4>\n<ul>\n<li><code>URLResponseSerializer</code> and attendant convenience methods so downloads can produce a non-optional <code>URL</code>.\n<ul>\n<li>Added by<a href=\"https://github.com/jshier\">Jon Shier</a> in Pull Request <a href=\"https://github.com/Alamofire/Alamofire/pull/3343\" data-hovercard-type=\"pull_request\" data-hovercard-url=\"/Alamofire/Alamofire/pull/3343/hovercard\">#3343</a>.</li>\n</ul>\n</li>\n</ul>\n<h4>Updated</h4>\n<ul>\n<li>Handing of <code>file://</code> <code>URL</code>s, removing error added in 5.3.0 and adding support for <code>DownloadRequest</code>.\n<ul>\n<li>Updated by <a href=\"https://github.com/jshier\">Jon Shier</a> in Pull Request <a href=\"https://github.com/Alamofire/Alamofire/pull/3342\" data-hovercard-type=\"pull_request\" data-hovercard-url=\"/Alamofire/Alamofire/pull/3342/hovercard\">#3342</a>.</li>\n</ul>\n</li>\n</ul>",
                               isDraft: false,
-                              publishedAt: iso8601.date(from: "2020-11-04T21:40:10Z")!,
-                              tagName: "5.4.0",
-                              url: "https://github.com/Alamofire/Alamofire/releases/tag/5.4.0")
+                              publishedAt: iso8601.date(from: "2021-04-22T02:50:05Z")!,
+                              tagName: "5.4.3",
+                              url: "https://github.com/Alamofire/Alamofire/releases/tag/5.4.3")
         ))
-        XCTAssertEqual(res.repository?.stargazerCount, 34720)
+        XCTAssertEqual(res.repository?.stargazerCount, 35831)
         XCTAssertEqual(res.repository?.isInOrganization, true)
         // derived properties
         XCTAssertEqual(res.repository?.lastIssueClosedAt,
-                       iso8601.date(from: "2020-11-24T16:00:07Z"))
+                       iso8601.date(from: "2021-06-09T00:59:39Z"))
         // merged date is latest - expect that one to be reported back
         XCTAssertEqual(res.repository?.lastPullRequestClosedAt,
-                       iso8601.date(from: "2020-11-04T21:27:43Z"))
+                       iso8601.date(from: "2021-06-07T22:47:01Z"))
     }
 
     func test_fetchMetadata_badRequest() throws {

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -116,6 +116,7 @@ class IngestorTests: AppTestCase {
                                       tagName: "1.2.3",
                                       url: "https://example.com/1.2.3")
                             ],
+                            repositoryTopics: ["foo", "bar"],
                             name: "bar",
                             stars: 2,
                             summary: "package desc",
@@ -136,6 +137,7 @@ class IngestorTests: AppTestCase {
         )
         XCTAssertEqual(repo.defaultBranch, "main")
         XCTAssertEqual(repo.forks, 1)
+        XCTAssertEqual(repo.isInOrganization, true)
         XCTAssertEqual(repo.lastIssueClosedAt, Date(timeIntervalSince1970: 2))
         XCTAssertEqual(repo.lastPullRequestClosedAt, Date(timeIntervalSince1970: 3))
         XCTAssertEqual(repo.license, .mit)
@@ -157,8 +159,8 @@ class IngestorTests: AppTestCase {
         ])
         XCTAssertEqual(repo.name, "bar")
         XCTAssertEqual(repo.stars, 2)
-        XCTAssertEqual(repo.isInOrganization, true)
         XCTAssertEqual(repo.summary, "package desc")
+        XCTAssertEqual(repo.topics, ["foo", "bar"])
     }
     
     func test_updatePackage() throws {

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -138,6 +138,7 @@ class IngestorTests: AppTestCase {
         XCTAssertEqual(repo.defaultBranch, "main")
         XCTAssertEqual(repo.forks, 1)
         XCTAssertEqual(repo.isInOrganization, true)
+        XCTAssertEqual(repo.keywords, ["bar", "baz", "foo"])
         XCTAssertEqual(repo.lastIssueClosedAt, Date(timeIntervalSince1970: 2))
         XCTAssertEqual(repo.lastPullRequestClosedAt, Date(timeIntervalSince1970: 3))
         XCTAssertEqual(repo.license, .mit)
@@ -160,7 +161,6 @@ class IngestorTests: AppTestCase {
         XCTAssertEqual(repo.name, "bar")
         XCTAssertEqual(repo.stars, 2)
         XCTAssertEqual(repo.summary, "package desc")
-        XCTAssertEqual(repo.topics, ["bar", "baz", "foo"])
     }
     
     func test_updatePackage() throws {

--- a/Tests/AppTests/Mocks/GithubMetadata+mock.swift
+++ b/Tests/AppTests/Mocks/GithubMetadata+mock.swift
@@ -13,6 +13,7 @@ extension Github.Metadata {
                                   owner: "packageOwner",
                                   pullRequestsClosedAtDates: [],
                                   releases: [],
+                                  repositoryTopics: [],
                                   name: "packageName",
                                   stars: 2,
                                   summary: "desc",
@@ -21,18 +22,19 @@ extension Github.Metadata {
     static func mock(for package: Package) -> Self {
         let (owner, name) = try! Github.parseOwnerName(url: package.url)
         return .init(defaultBranch: "main",
-              forks: package.url.count,
-              issuesClosedAtDates: [],
-              license: .mit,
-              openIssues: 3,
-              openPullRequests: 0,
-              owner: owner,
-              pullRequestsClosedAtDates: [],
-              releases: [],
-              name: name,
-              stars: package.url.count + 1,
-              summary: "This is package " + package.url,
-              isInOrganization: false)
+                     forks: package.url.count,
+                     issuesClosedAtDates: [],
+                     license: .mit,
+                     openIssues: 3,
+                     openPullRequests: 0,
+                     owner: owner,
+                     pullRequestsClosedAtDates: [],
+                     releases: [],
+                     repositoryTopics: [],
+                     name: name,
+                     stars: package.url.count + 1,
+                     summary: "This is package " + package.url,
+                     isInOrganization: false)
     }
 
     init(defaultBranch: String,
@@ -44,11 +46,18 @@ extension Github.Metadata {
          owner: String,
          pullRequestsClosedAtDates: [Date],
          releases: [ReleaseNodes.ReleaseNode] = [],
+         repositoryTopics: [String] = [],
          name: String,
          stars: Int,
          summary: String,
          isInOrganization: Bool
     ) {
+        let topics = repositoryTopics
+            .map {
+                RepositoryTopicNodes.RepositoryTopic(
+                    topic: RepositoryTopicNodes.RepositoryTopic.Topic(name: $0)
+                )
+            }
         self = .init(
             repository: .init(closedIssues: .init(closedAtDates: issuesClosedAtDates),
                               closedPullRequests: .init(closedAtDates: pullRequestsClosedAtDates),
@@ -64,6 +73,8 @@ extension Github.Metadata {
                               openPullRequests: .init(totalCount: openPullRequests),
                               owner: .init(login: owner, name: owner, avatarUrl: "https://avatars.githubusercontent.com/u/61124617?s=200&v=4"),
                               releases: .init(nodes: releases),
+                              repositoryTopics: .init(totalCount: topics.count,
+                                                      nodes: topics),
                               stargazerCount: stars,
                               isInOrganization: isInOrganization)
         )

--- a/Tests/AppTests/PackageCollectionControllerTests.swift
+++ b/Tests/AppTests/PackageCollectionControllerTests.swift
@@ -36,11 +36,11 @@ class PackageCollectionControllerTests: AppTestCase {
             try Target(version: v, name: "t1").save(on: app.db).wait()
         }
         try Repository(package: p,
-                       summary: "summary 1",
                        defaultBranch: "main",
                        license: .mit,
                        licenseUrl: "https://foo/mit",
-                       owner: "foo").create(on: app.db).wait()
+                       owner: "foo",
+                       summary: "summary 1").create(on: app.db).wait()
 
         // MUT
         try app.test(

--- a/Tests/AppTests/PackageCollectionTests.swift
+++ b/Tests/AppTests/PackageCollectionTests.swift
@@ -107,10 +107,10 @@ class PackageCollectionTests: AppTestCase {
             try p.save(on: app.db).wait()
             do {
                 let r = try Repository(package: p,
-                                       summary: "summary",
                                        license: .mit,
                                        licenseUrl: "https://foo/mit",
-                                       readmeUrl: "readmeUrl")
+                                       readmeUrl: "readmeUrl",
+                                       summary: "summary")
                 try r.save(on: app.db).wait()
             }
             do {
@@ -166,9 +166,9 @@ class PackageCollectionTests: AppTestCase {
                 .save(on: app.db).wait()
         }
         try Repository(package: pkg,
-                       summary: "summary",
                        license: .mit,
-                       licenseUrl: "https://foo/mit").create(on: app.db).wait()
+                       licenseUrl: "https://foo/mit",
+                       summary: "summary").create(on: app.db).wait()
 
         // MUT
         let res = try PackageCollection.generate(db: self.app.db,
@@ -241,17 +241,17 @@ class PackageCollectionTests: AppTestCase {
         // unrelated package
         _ = try savePackage(on: app.db, "https://github.com/bar/1")
         try Repository(package: p1,
-                       summary: "summary 1",
                        defaultBranch: "main",
                        license: .mit,
                        licenseUrl: "https://foo/mit",
-                       owner: "foo").create(on: app.db).wait()
+                       owner: "foo",
+                       summary: "summary 1").create(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "summary 2",
                        defaultBranch: "main",
                        license: .mit,
                        licenseUrl: "https://foo/mit",
-                       owner: "foo").create(on: app.db).wait()
+                       owner: "foo",
+                       summary: "summary 2").create(on: app.db).wait()
 
         // MUT
         let res = try PackageCollection.generate(db: self.app.db,
@@ -272,11 +272,11 @@ class PackageCollectionTests: AppTestCase {
         // setup
         let p = try savePackage(on: app.db, "https://github.com/foo/1")
         try Repository(package: p,
-                       summary: "summary",
                        defaultBranch: "main",
                        license: .mit,
                        licenseUrl: "https://foo/mit",
-                       owner: "foo").create(on: app.db).wait()
+                       owner: "foo",
+                       summary: "summary").create(on: app.db).wait()
         do {  // default branch revision
             let v = try Version(id: UUID(),
                                 package: p,
@@ -420,11 +420,11 @@ class PackageCollectionTests: AppTestCase {
         }
         // Owner "Foo"
         try Repository(package: pkg,
-                       summary: "summary 1",
                        defaultBranch: "main",
                        license: .mit,
                        licenseUrl: "https://foo/mit",
-                       owner: "Foo").create(on: app.db).wait()
+                       owner: "Foo",
+                       summary: "summary 1").create(on: app.db).wait()
 
         // MUT
         let res = try PackageCollection.generate(db: self.app.db,

--- a/Tests/AppTests/PackageShowModelTests.swift
+++ b/Tests/AppTests/PackageShowModelTests.swift
@@ -11,13 +11,13 @@ class PackageShowModelTests: SnapshotTestCase {
         // setup package without package name
         var pkg = try savePackage(on: app.db, "1".url)
         try Repository(package: pkg,
-                       summary: "summary",
                        defaultBranch: "main",
+                       forks: 42,
                        license: .mit,
                        name: "bar",
                        owner: "foo",
                        stars: 17,
-                       forks: 42).save(on: app.db).wait()
+                       summary: "summary").save(on: app.db).wait()
         let version = try App.Version(package: pkg,
                                       packageName: nil,
                                       reference: .branch("main"))
@@ -40,13 +40,13 @@ class PackageShowModelTests: SnapshotTestCase {
         // setup
         var pkg = try savePackage(on: app.db, "1".url)
         try Repository(package: pkg,
-                       summary: "summary",
                        defaultBranch: "main",
+                       forks: 42,
                        license: .mit,
                        name: "bar",
                        owner: "foo",
                        stars: 17,
-                       forks: 42).save(on: app.db).wait()
+                       summary: "summary").save(on: app.db).wait()
         let version = try App.Version(package: pkg,
                                       packageName: "test package",
                                       reference: .branch("main"))

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -181,13 +181,13 @@ final class PackageTests: AppTestCase {
         // setup
         let pkg = try savePackage(on: app.db, "1".url)
         try Repository(package: pkg,
-                       summary: "summary",
                        defaultBranch: "main",
+                       forks: 42,
                        license: .mit,
                        name: "bar",
                        owner: "foo",
                        stars: 17,
-                       forks: 42).save(on: app.db).wait()
+                       summary: "summary").save(on: app.db).wait()
         let version = try App.Version(package: pkg,
                                       packageName: "test package",
                                       reference: .branch("main"))
@@ -204,13 +204,13 @@ final class PackageTests: AppTestCase {
         // setup
         let pkg = try savePackage(on: app.db, "1".url)
         try Repository(package: pkg,
-                       summary: "summary",
                        defaultBranch: "main",
+                       forks: 42,
                        license: .mit,
                        name: "bar",
                        owner: "foo",
                        stars: 17,
-                       forks: 42).save(on: app.db).wait()
+                       summary: "summary").save(on: app.db).wait()
         let version = try App.Version(package: pkg,
                                       packageName: "test package",
                                       reference: .branch("main"))
@@ -506,8 +506,8 @@ final class PackageTests: AppTestCase {
         let pkg = try savePackage(on: app.db, "1")
         try Repository(package: pkg,
                        commitCount: 1433,
-                       firstCommitDate: Date(timeIntervalSince1970: 0),
-                       defaultBranch: "default").create(on: app.db).wait()
+                       defaultBranch: "default",
+                       firstCommitDate: .t0).create(on: app.db).wait()
         try (0..<10).forEach {
             try Version(package: pkg, reference: .tag(.init($0, 0, 0))).create(on: app.db).wait()
         }

--- a/Tests/AppTests/RSSTests.swift
+++ b/Tests/AppTests/RSSTests.swift
@@ -53,7 +53,10 @@ class RSSTests: SnapshotTestCase {
             // re-write creation date to something stable for snapshotting
             pkg.createdAt = Date(timeIntervalSince1970: TimeInterval(100*$0))
             try pkg.save(on: app.db).wait()
-            try Repository(package: pkg, summary: "Summary", name: "pkg-\($0)", owner: "owner-\($0)").create(on: app.db).wait()
+            try Repository(package: pkg,
+                           name: "pkg-\($0)",
+                           owner: "owner-\($0)",
+                           summary: "Summary").create(on: app.db).wait()
             try Version(package: pkg, packageName: "pkg-\($0)").save(on: app.db).wait()
         }
         // make sure to refresh the materialized view
@@ -72,7 +75,10 @@ class RSSTests: SnapshotTestCase {
         try (1...10).forEach {
             let pkg = Package(id: UUID(), url: "\($0)".asGithubUrl.url)
             try pkg.save(on: app.db).wait()
-            try Repository(package: pkg, summary: "Summary", name: "pkg-\($0)", owner: "owner-\($0)").create(on: app.db).wait()
+            try Repository(package: pkg,
+                           name: "pkg-\($0)",
+                           owner: "owner-\($0)",
+                           summary: "Summary").create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: TimeInterval($0)),
                         packageName: "pkg-\($0)",
@@ -113,9 +119,9 @@ class RSSTests: SnapshotTestCase {
             let pkg = Package(id: UUID(), url: "\($0)".asGithubUrl.url)
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "Summary",
                            name: "pkg-\($0)",
-                           owner: "owner-\($0)")
+                           owner: "owner-\($0)",
+                           summary: "Summary")
                 .create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: TimeInterval($0)),
@@ -149,9 +155,9 @@ class RSSTests: SnapshotTestCase {
             let pkg = Package(id: UUID(), url: "\($0)".asGithubUrl.url)
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "Summary",
                            name: "pkg-\($0)",
-                           owner: "owner-\($0)")
+                           owner: "owner-\($0)",
+                           summary: "Summary")
                 .create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: TimeInterval($0)),
@@ -185,9 +191,9 @@ class RSSTests: SnapshotTestCase {
             let pkg = Package(id: UUID(), url: "\($0)".asGithubUrl.url)
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "Summary",
                            name: "pkg-\($0)",
-                           owner: "owner-\($0)")
+                           owner: "owner-\($0)",
+                           summary: "Summary")
                 .create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: TimeInterval($0)),
@@ -222,9 +228,9 @@ class RSSTests: SnapshotTestCase {
             let pkg = Package(id: UUID(), url: "\($0)".asGithubUrl.url)
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "Summary",
                            name: "pkg-\($0)",
-                           owner: "owner-\($0)")
+                           owner: "owner-\($0)",
+                           summary: "Summary")
                 .create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: TimeInterval($0)),

--- a/Tests/AppTests/RecentViewsTests.swift
+++ b/Tests/AppTests/RecentViewsTests.swift
@@ -11,27 +11,27 @@ class RecentViewsTests: AppTestCase {
             let pkg = Package(id: UUID(), url: "1")
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "pkg 1",
                            name: "1",
-                           owner: "foo").create(on: app.db).wait()
+                           owner: "foo",
+                           summary: "pkg 1").create(on: app.db).wait()
             try Version(package: pkg, packageName: "1").save(on: app.db).wait()
         }
         do {  // 2nd package should not be selected, because it has no package name
             let pkg = Package(id: UUID(), url: "2")
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "pkg 2",
                            name: "2",
-                           owner: "foo").create(on: app.db).wait()
+                           owner: "foo",
+                           summary: "pkg 2").create(on: app.db).wait()
             try Version(package: pkg).save(on: app.db).wait()
         }
         do {  // 3rd package is eligible
             let pkg = Package(id: UUID(), url: "3")
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "pkg 3",
                            name: "3",
-                           owner: "foo").create(on: app.db).wait()
+                           owner: "foo",
+                           summary: "pkg 3").create(on: app.db).wait()
             try Version(package: pkg, packageName: "3").save(on: app.db).wait()
         }
         // make sure to refresh the materialized view
@@ -51,10 +51,10 @@ class RecentViewsTests: AppTestCase {
             let pkg = Package(id: UUID(), url: "1")
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "pkg 1",
                            defaultBranch: "default",
                            name: "1",
-                           owner: "foo").create(on: app.db).wait()
+                           owner: "foo",
+                           summary: "pkg 1").create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: 0),
                         packageName: "1",
@@ -65,10 +65,10 @@ class RecentViewsTests: AppTestCase {
             let pkg = Package(id: UUID(), url: "2")
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "pkg 2",
                            defaultBranch: "default",
                            name: "2",
-                           owner: "foo").create(on: app.db).wait()
+                           owner: "foo",
+                           summary: "pkg 2").create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: 0),
                         packageName: "2",
@@ -79,10 +79,10 @@ class RecentViewsTests: AppTestCase {
             let pkg = Package(id: UUID(), url: "3")
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "pkg 3",
                            defaultBranch: "default",
                            name: "3",
-                           owner: "foo").create(on: app.db).wait()
+                           owner: "foo",
+                           summary: "pkg 3").create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: 0),
                         reference: .branch("default"),
@@ -92,10 +92,10 @@ class RecentViewsTests: AppTestCase {
             let pkg = Package(id: UUID(), url: "4")
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "pkg 4",
                            defaultBranch: "default",
                            name: "4",
-                           owner: "foo").create(on: app.db).wait()
+                           owner: "foo",
+                           summary: "pkg 4").create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: 0),
                         packageName: "4").save(on: app.db).wait()
@@ -104,10 +104,10 @@ class RecentViewsTests: AppTestCase {
             let pkg = Package(id: UUID(), url: "5")
             try pkg.save(on: app.db).wait()
             try Repository(package: pkg,
-                           summary: "pkg 5",
                            defaultBranch: "default",
                            name: "5",
-                           owner: "foo").create(on: app.db).wait()
+                           owner: "foo",
+                           summary: "pkg 5").create(on: app.db).wait()
             try Version(package: pkg,
                         commitDate: Date(timeIntervalSince1970: 1),
                         packageName: "5",
@@ -183,9 +183,9 @@ class RecentViewsTests: AppTestCase {
         let pkg = Package(id: UUID(), url: "1")
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg,
-                       summary: "pkg summary",
                        name: "bar",
-                       owner: "foo").create(on: app.db).wait()
+                       owner: "foo",
+                       summary: "pkg summary").create(on: app.db).wait()
         try Version(package: pkg,
                     commitDate: Date(timeIntervalSince1970: 0),
                     packageName: "pkg-bar").save(on: app.db).wait()
@@ -208,9 +208,9 @@ class RecentViewsTests: AppTestCase {
         let pkg = Package(id: UUID(), url: "1")
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg,
-                       summary: "pkg summary",
                        name: "bar",
-                       owner: "foo").create(on: app.db).wait()
+                       owner: "foo",
+                       summary: "pkg summary").create(on: app.db).wait()
         try Version(package: pkg,
                     commitDate: Date(timeIntervalSince1970: 0),
                     packageName: "pkg-bar",

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -20,6 +20,7 @@ final class RepositoryTests: AppTestCase {
                                   forks: 17,
                                   forkedFrom: nil,
                                   isArchived: true,
+                                  keywords: ["foo", "bar"],
                                   lastCommitDate: Date(timeIntervalSince1970: 1),
                                   lastIssueClosedAt: Date(timeIntervalSince1970: 2),
                                   lastPullRequestClosedAt: Date(timeIntervalSince1970: 3),
@@ -37,8 +38,7 @@ final class RepositoryTests: AppTestCase {
                                           url: "https://example.com/release/1.2.3")
                                   ],
                                   stars: 42,
-                                  summary: "desc",
-                                  topics: ["foo", "bar"])
+                                  summary: "desc")
         
         try repo.save(on: app.db).wait()
         
@@ -49,14 +49,15 @@ final class RepositoryTests: AppTestCase {
                             .init(name: "Foo", url: "fooUrl"),
                             .init(name: "Bar", url: "barUrl")])
             XCTAssertEqual(r.commitCount, 123)
+            XCTAssertEqual(r.defaultBranch, "branch")
             XCTAssertEqual(r.firstCommitDate, Date(timeIntervalSince1970: 0))
             XCTAssertEqual(r.forks, 17)
             XCTAssertEqual(r.forkedFrom, nil)
             XCTAssertEqual(r.isArchived, true)
+            XCTAssertEqual(r.keywords, ["foo", "bar"])
             XCTAssertEqual(r.lastCommitDate, Date(timeIntervalSince1970: 1))
             XCTAssertEqual(r.lastIssueClosedAt, Date(timeIntervalSince1970: 2))
             XCTAssertEqual(r.lastPullRequestClosedAt, Date(timeIntervalSince1970: 3))
-            XCTAssertEqual(r.defaultBranch, "branch")
             XCTAssertEqual(r.license, .mit)
             XCTAssertEqual(r.licenseUrl, "https://github.com/foo/bar/blob/main/LICENSE")
             XCTAssertEqual(r.openIssues, 3)
@@ -72,7 +73,6 @@ final class RepositoryTests: AppTestCase {
             ])
             XCTAssertEqual(r.stars, 42)
             XCTAssertEqual(r.summary, "desc")
-            XCTAssertEqual(r.topics, ["foo", "bar"])
         }
     }
     

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -14,13 +14,15 @@ final class RepositoryTests: AppTestCase {
                                   authors: [
                                     .init(name: "Foo", url: "fooUrl"),
                                     .init(name: "Bar", url: "barUrl")],
-                                  summary: "desc",
                                   commitCount: 123,
+                                  defaultBranch: "branch",
                                   firstCommitDate: Date(timeIntervalSince1970: 0),
+                                  forks: 17,
+                                  forkedFrom: nil,
+                                  isArchived: true,
                                   lastCommitDate: Date(timeIntervalSince1970: 1),
                                   lastIssueClosedAt: Date(timeIntervalSince1970: 2),
                                   lastPullRequestClosedAt: Date(timeIntervalSince1970: 3),
-                                  defaultBranch: "branch",
                                   license: .mit,
                                   licenseUrl: "https://github.com/foo/bar/blob/main/LICENSE",
                                   openIssues: 3,
@@ -34,10 +36,9 @@ final class RepositoryTests: AppTestCase {
                                           tagName: "1.2.3",
                                           url: "https://example.com/release/1.2.3")
                                   ],
-                                  isArchived: true,
                                   stars: 42,
-                                  forks: 17,
-                                  forkedFrom: nil)
+                                  summary: "desc",
+                                  topics: ["foo", "bar"])
         
         try repo.save(on: app.db).wait()
         
@@ -47,9 +48,11 @@ final class RepositoryTests: AppTestCase {
             XCTAssertEqual(r.authors, [
                             .init(name: "Foo", url: "fooUrl"),
                             .init(name: "Bar", url: "barUrl")])
-            XCTAssertEqual(r.summary, "desc")
             XCTAssertEqual(r.commitCount, 123)
             XCTAssertEqual(r.firstCommitDate, Date(timeIntervalSince1970: 0))
+            XCTAssertEqual(r.forks, 17)
+            XCTAssertEqual(r.forkedFrom, nil)
+            XCTAssertEqual(r.isArchived, true)
             XCTAssertEqual(r.lastCommitDate, Date(timeIntervalSince1970: 1))
             XCTAssertEqual(r.lastIssueClosedAt, Date(timeIntervalSince1970: 2))
             XCTAssertEqual(r.lastPullRequestClosedAt, Date(timeIntervalSince1970: 3))
@@ -67,10 +70,9 @@ final class RepositoryTests: AppTestCase {
                       tagName: "1.2.3",
                       url: "https://example.com/release/1.2.3")
             ])
-            XCTAssertEqual(r.isArchived, true)
             XCTAssertEqual(r.stars, 42)
-            XCTAssertEqual(r.forks, 17)
-            XCTAssertEqual(r.forkedFrom, nil)
+            XCTAssertEqual(r.summary, "desc")
+            XCTAssertEqual(r.topics, ["foo", "bar"])
         }
     }
     

--- a/Tests/AppTests/SearchTests.swift
+++ b/Tests/AppTests/SearchTests.swift
@@ -89,12 +89,14 @@ class SearchTests: AppTestCase {
         // setup
         let p1 = try savePackage(on: app.db, "1")
         let p2 = try savePackage(on: app.db, "2")
-        try Repository(package: p1, summary: "some package", defaultBranch: "main").save(on: app.db).wait()
+        try Repository(package: p1,
+                       defaultBranch: "main",
+                       summary: "some package").save(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "bar package",
                        defaultBranch: "main",
                        name: "name 2",
-                       owner: "owner 2").save(on: app.db).wait()
+                       owner: "owner 2",
+                       summary: "bar package").save(on: app.db).wait()
         try Version(package: p1, packageName: "Foo", reference: .branch("main")).save(on: app.db).wait()
         try Version(package: p2, packageName: "Bar", reference: .branch("main")).save(on: app.db).wait()
         try Search.refresh(on: app.db).wait()
@@ -122,15 +124,15 @@ class SearchTests: AppTestCase {
         let p1 = try savePackage(on: app.db, "1")
         let p2 = try savePackage(on: app.db, "2")
         try Repository(package: p1,
-                       summary: "package 1 description",
                        defaultBranch: "main",
                        name: "package 1",
-                       owner: "owner").save(on: app.db).wait()
+                       owner: "owner",
+                       summary: "package 1 description").save(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "package 2 description",
                        defaultBranch: "main",
                        name: "package 2",
-                       owner: "owner").save(on: app.db).wait()
+                       owner: "owner",
+                       summary: "package 2 description").save(on: app.db).wait()
         try Version(package: p1, packageName: "Foo", reference: .branch("main")).save(on: app.db).wait()
         try Version(package: p2, packageName: "Bar", reference: .branch("main")).save(on: app.db).wait()
         try Search.refresh(on: app.db).wait()
@@ -157,15 +159,16 @@ class SearchTests: AppTestCase {
         // setup
         let p1 = try savePackage(on: app.db, "1")
         let p2 = try savePackage(on: app.db, "2")
-        try Repository(package: p1, summary: "some 'package'",
+        try Repository(package: p1,
                        defaultBranch: "main",
                        name: "name 1",
-                       owner: "owner 1").save(on: app.db).wait()
+                       owner: "owner 1",
+                       summary: "some 'package'").save(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "bar package",
                        defaultBranch: "main",
                        name: "name 2",
-                       owner: "owner 2").save(on: app.db).wait()
+                       owner: "owner 2",
+                       summary: "bar package").save(on: app.db).wait()
         try Version(package: p1, packageName: "Foo", reference: .branch("main")).save(on: app.db).wait()
         try Version(package: p2, packageName: "Bar", reference: .branch("main")).save(on: app.db).wait()
         try Search.refresh(on: app.db).wait()
@@ -289,8 +292,11 @@ class SearchTests: AppTestCase {
         try (0..<10).shuffled().forEach {
             let p = Package(id: UUID(), url: "\($0)".url, score: $0)
             try p.save(on: app.db).wait()
-            try Repository(package: p, summary: "\($0)", defaultBranch: "main",
-                           name: "\($0)", owner: "foo").save(on: app.db).wait()
+            try Repository(package: p,
+                           defaultBranch: "main",
+                           name: "\($0)",
+                           owner: "foo",
+                           summary: "\($0)").save(on: app.db).wait()
             try Version(package: p, packageName: "Foo", reference: .branch("main")).save(on: app.db).wait()
         }
         try Search.refresh(on: app.db).wait()
@@ -315,20 +321,20 @@ class SearchTests: AppTestCase {
         let p3 = Package(id: UUID(), url: "3", score: 30)
         try [p1, p2, p3].save(on: app.db).wait()
         try Repository(package: p1,
-                       summary: "",
                        defaultBranch: "main",
                        name: "1",
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "").save(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "",
                        defaultBranch: "main",
                        name: "2",
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "").save(on: app.db).wait()
         try Repository(package: p3,
-                       summary: "link",
                        defaultBranch: "main",
                        name: "3",
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "link").save(on: app.db).wait()
         try Version(package: p1, packageName: "Ink", reference: .branch("main"))
             .save(on: app.db).wait()
         try Version(package: p2, packageName: "inkInName", reference: .branch("main"))
@@ -355,20 +361,20 @@ class SearchTests: AppTestCase {
         let p3 = Package(id: UUID(), url: "3", score: 30)
         try [p1, p2, p3].save(on: app.db).wait()
         try Repository(package: p1,
-                       summary: "",
                        defaultBranch: "main",
                        name: "1",
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "").save(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "",
                        defaultBranch: "main",
                        name: "2",
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "").save(on: app.db).wait()
         try Repository(package: p3,
-                       summary: "foo bar",
                        defaultBranch: "main",
                        name: "3",
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "foo bar").save(on: app.db).wait()
         try Version(package: p1, packageName: "Foo bar", reference: .branch("main"))
             .save(on: app.db).wait()
         try Version(package: p2, packageName: "foobar", reference: .branch("main"))
@@ -393,20 +399,20 @@ class SearchTests: AppTestCase {
         let p3 = Package(id: UUID(), url: "3", score: 30)
         try [p1, p2, p3].save(on: app.db).wait()
         try Repository(package: p1,
-                       summary: "",
                        defaultBranch: "main",
                        name: "1",
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "").save(on: app.db).wait()
         try Repository(package: p2,
-                       summary: "",
                        defaultBranch: "main",
                        name: nil,
-                       owner: "foo").save(on: app.db).wait()
+                       owner: "foo",
+                       summary: "").save(on: app.db).wait()
         try Repository(package: p3,
-                       summary: "foo bar",
                        defaultBranch: "main",
                        name: "3",
-                       owner: nil).save(on: app.db).wait()
+                       owner: nil,
+                       summary: "foo bar").save(on: app.db).wait()
         try Version(package: p1, packageName: nil, reference: .branch("main"))
             .save(on: app.db).wait()
         try Version(package: p2, packageName: "foo2", reference: .branch("main"))

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -104,9 +104,9 @@ class TwitterTests: AppTestCase {
         let pkg = Package(url: "1".asGithubUrl.url, status: .ok)
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg,
-                       summary: "This is a test package",
                        name: "repoName",
-                       owner: "owner").save(on: app.db).wait()
+                       owner: "owner",
+                       summary: "This is a test package").save(on: app.db).wait()
         let version = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
         try version.save(on: app.db).wait()
 
@@ -126,9 +126,9 @@ class TwitterTests: AppTestCase {
         let pkg = Package(url: "1".asGithubUrl.url, status: .new)
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg,
-                       summary: "This is a test package",
                        name: "repoName",
-                       owner: "owner").save(on: app.db).wait()
+                       owner: "owner",
+                       summary: "This is a test package").save(on: app.db).wait()
         let version = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
         try version.save(on: app.db).wait()
 
@@ -149,9 +149,9 @@ class TwitterTests: AppTestCase {
         let pkg = Package(url: "1".asGithubUrl.url)
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg,
-                       summary: "This is a test package",
                        name: "repoName",
-                       owner: "repoOwner").save(on: app.db).wait()
+                       owner: "repoOwner",
+                       summary: "This is a test package").save(on: app.db).wait()
         let v1 = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
         try v1.save(on: app.db).wait()
         let v2 = try Version(package: pkg,
@@ -188,9 +188,9 @@ class TwitterTests: AppTestCase {
         let pkg = Package(url: "1".asGithubUrl.url, status: .ok)
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg,
-                       summary: "This is a test package",
                        name: "repoName",
-                       owner: "repoOwner").save(on: app.db).wait()
+                       owner: "repoOwner",
+                       summary: "This is a test package").save(on: app.db).wait()
         let v1 = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
         try v1.save(on: app.db).wait()
         let v2 = try Version(package: pkg, packageName: "MyPackage", reference: .tag(2, 0, 0))
@@ -307,9 +307,9 @@ class TwitterTests: AppTestCase {
         let pkg = Package(url: "1".asGithubUrl.url)
         try pkg.save(on: app.db).wait()
         try Repository(package: pkg,
-                       summary: "This is a test package",
                        name: "repoName",
-                       owner: "repoOwner").save(on: app.db).wait()
+                       owner: "repoOwner",
+                       summary: "This is a test package").save(on: app.db).wait()
         let v = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
         try v.save(on: app.db).wait()
         Current.twitterCredentials = {


### PR DESCRIPTION
- adds `repositories.topics` to db schema
- extends Github GraphQL query to fetch topics
- populates `repositories.topics` from GH metadata

I've got these changes as three separate branches in case we need to break it down further.

I'll deploy this from the branch to get test data into the staging db and we can then decide if we want to merge or roll back while I test topic search.