### PR TITLE
Unique, lowercased, sorted topics

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -201,7 +201,7 @@ func insertOrUpdateRepository(on database: Database,
                 .map(Release.init(from:)) ?? []
             repo.stars = repository.stargazerCount
             repo.summary = repository.description
-            repo.topics = repository.topics
+            repo.topics = Set(repository.topics.map { $0.lowercased() }).sorted()
             return repo.save(on: database)
         }
 }

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -116,7 +116,7 @@ class IngestorTests: AppTestCase {
                                       tagName: "1.2.3",
                                       url: "https://example.com/1.2.3")
                             ],
-                            repositoryTopics: ["foo", "bar"],
+                            repositoryTopics: ["foo", "bar", "Bar", "baz"],
                             name: "bar",
                             stars: 2,
                             summary: "package desc",
@@ -160,7 +160,7 @@ class IngestorTests: AppTestCase {
         XCTAssertEqual(repo.name, "bar")
         XCTAssertEqual(repo.stars, 2)
         XCTAssertEqual(repo.summary, "package desc")
-        XCTAssertEqual(repo.topics, ["foo", "bar"])
+        XCTAssertEqual(repo.topics, ["bar", "baz", "foo"])
     }
     
     func test_updatePackage() throws {


### PR DESCRIPTION
Normalise topics so we can search via `'foo' = any(topics)` rather than `ilike`. This would mean we discard any cases for topic display. At a glance, topics are already lowercased and uniqued on the Github side. This is just ensuring that on our end so we can assume it for queries.

Does that make sense, @daveverwer ?

This is just a PR into the topics branch, so ok to merge. I'll then deploy from the branch again and grab another snapshot when it's ingested.