### PR TITLE
add owner_name as collectionName and overview.

### DIFF
--- a/Sources/App/Controllers/PackageCollectionController.swift
+++ b/Sources/App/Controllers/PackageCollectionController.swift
@@ -11,7 +11,8 @@ struct PackageCollectionController {
             db: req.db,
             filterBy: .author(owner),
             authorName: "\(owner) via the Swift Package Index",
-            collectionName: "Packages by \(owner)"
+            collectionName: "Packages by \(owner)",
+            ownerName: owner
         )
     }
 }

--- a/Sources/App/Controllers/PackageCollectionController.swift
+++ b/Sources/App/Controllers/PackageCollectionController.swift
@@ -11,8 +11,7 @@ struct PackageCollectionController {
             db: req.db,
             filterBy: .author(owner),
             authorName: "\(owner) via the Swift Package Index",
-            collectionName: "Packages by \(owner)",
-            ownerName: owner
+            collectionName: "Packages by \(owner)"
         )
     }
 }

--- a/Sources/App/Core/PackageCollection+generate.swift
+++ b/Sources/App/Core/PackageCollection+generate.swift
@@ -65,8 +65,10 @@ extension PackageCollection {
             .and(ownerQuery.first())
             .map { packages, repository in
                 var name = collectionName
+                var overview = String()
                 if let ownerName = repository?.ownerName {
                     name = "Packages by \(ownerName)"
+                    overview = "A collection of packages authored by \(ownerName) from the Swift Package Index"
                 }
                 
                 return PackageCollection.init(

--- a/Sources/App/Core/PackageCollection+generate.swift
+++ b/Sources/App/Core/PackageCollection+generate.swift
@@ -50,7 +50,11 @@ extension PackageCollection {
         // generate ownerName from [App.Package]
         
         func ownerName(packages: [App.Package]) -> String {
-            let names = packages.map { $0.repository?.ownerName ?? $0.repository?.owner ?? "" }
+            let groupedPackagesByName = Dictionary(
+                grouping: packages,
+                by: { $0.repository?.ownerName ?? $0.repository?.owner })
+            
+            let names = groupedPackagesByName.enumerated().compactMap { $0.element.key }
             switch names.count {
             case 0:
                 // shouldn't be possible really


### PR DESCRIPTION
[use owner fullname](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1160)
[add overview](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1159)

I think this is not done yet, i just want to update you some progress and need to ask more about the issue.
I'm not sure that should i change a PackageCollection.generate func signature ? 
because i saw this has used by collection API route (only development env) to.

Result: 
<img width="948" alt="Screen Shot 2564-06-24 at 17 35 08" src="https://user-images.githubusercontent.com/3895283/123248915-a76d0700-d512-11eb-88ff-1b0e29924db4.png">
