### PR TITLE
Add g-emoji CSS styling for README

### DIFF
--- a/Resources/Styles/readme.scss
+++ b/Resources/Styles/readme.scss
@@ -77,3 +77,12 @@ spi-readme {
     margin: 20px 0;
   }
 }
+
+g-emoji {
+    font-family: Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
+    font-style: normal !important;
+    font-weight: 400;
+    line-height: 1;
+    vertical-align: -.075em;
+    margin-right: -10px;
+}

--- a/Resources/emoji.json
+++ b/Resources/emoji.json
@@ -13396,7 +13396,7 @@
   , "description": "piñata"
   , "category": "Activities"
   , "aliases": [
-      "pi_ata"
+      "pinata"
     ]
   , "tags": [
     ]
@@ -15291,11 +15291,11 @@
   , "description": "envelope"
   , "category": "Objects"
   , "aliases": [
-      "email"
-    , "envelope"
+      "envelope"
     ]
   , "tags": [
       "letter"
+    , "email"
     ]
   , "unicode_version": ""
   , "ios_version": "6.0"
@@ -15305,7 +15305,8 @@
   , "description": "e-mail"
   , "category": "Objects"
   , "aliases": [
-      "e-mail"
+      "email"
+    , "e-mail"
     ]
   , "tags": [
     ]


### PR DESCRIPTION
Also updated the emoji.json while I was there.
Styling taken from GitHub.

Closes #1195 

| Before | After |
| --- | --- |
| ![Captured 2021-07-05 at 2 24 07](https://user-images.githubusercontent.com/15193942/124478052-aa7eb780-dd9c-11eb-81b2-e785db5e91f7.png) | ![Captured 2021-07-05 at 2 23 53](https://user-images.githubusercontent.com/15193942/124478013-a2bf1300-dd9c-11eb-9d44-b45b6ae8e510.png) |
