### PR TITLE
Tidy up

### DIFF
--- a/Sources/App/Controllers/API/Package+Badge.swift
+++ b/Sources/App/Controllers/API/Package+Badge.swift
@@ -166,21 +166,21 @@ extension Package {
             Set(
                 platforms
                     .map { p -> Value in
-            switch p {
-                case .ios:
-                    return .init(0, "iOS")
-                case .macosSpm, .macosXcodebuild, .macosSpmArm, .macosXcodebuildArm:
-                    return .init(1, "macOS")
-                case .linux:
-                    return .init(2, "Linux")
-                case .tvos:
-                    return .init(3, "tvOS")
-                case .watchos:
-                    return .init(4, "watchOS")
-            }
-        }
+                        switch p {
+                            case .ios:
+                                return .init(0, "iOS")
+                            case .macosSpm, .macosXcodebuild, .macosSpmArm, .macosXcodebuildArm:
+                                return .init(1, "macOS")
+                            case .linux:
+                                return .init(2, "Linux")
+                            case .tvos:
+                                return .init(3, "tvOS")
+                            case .watchos:
+                                return .init(4, "watchOS")
+                        }
+                    }
+                )
             )
-        )
             .sorted {
                 $0.index < $1.index
             }

--- a/Sources/App/Controllers/API/Package+Badge.swift
+++ b/Sources/App/Controllers/API/Package+Badge.swift
@@ -7,12 +7,13 @@ extension Package {
         case available([Value])
         case pending
         
-        var values: [Value] {
-            if case .available(let values) = self {
-                return values
+        var values: [Value]? {
+            switch self {
+                case .available(let values):
+                    return values
+                case .pending:
+                    return nil
             }
-            
-            return []
         }
     }
 

--- a/Sources/App/Controllers/API/Package+Badge.swift
+++ b/Sources/App/Controllers/API/Package+Badge.swift
@@ -15,9 +15,10 @@ extension Package {
             return []
         }
     }
-    
-    /// Returns a list of compatible swift versions across a package's significant versions.
-    /// - Returns: Array of compatible `SwiftVersion`s
+
+
+    /// Returns swift versions compatibility across a package's significant versions.
+    /// - Returns: A `CompatibilityResult` of `SwiftVersion`
     func swiftVersionCompatibility() -> CompatibilityResult<SwiftVersion> {
         let allBuilds = allSignificantBuilds()
         if allBuilds.allSatisfy { $0.status == .pending } { return .pending }
@@ -40,8 +41,8 @@ extension Package {
     }
 
 
-    /// Returns a list of compatible platforms across a package's significant versions.
-    /// - Returns: Array of compatible `Platform`s
+    /// Returns platform compatibility across a package's significant versions.
+    /// - Returns: A `CompatibilityResult` of `Platform`
     func platformCompatibility() -> CompatibilityResult<Build.Platform> {
         let allBuilds = allSignificantBuilds()
         if allBuilds.allSatisfy { $0.status == .pending } { return .pending }
@@ -92,23 +93,23 @@ extension Package {
                 label = "Swift Compatibility"
         }
 
-        let (message, success) = badgeMessage(badgeType: badgeType)
+        let (message, compatible) = badgeMessage(badgeType: badgeType)
         return Badge(schemaVersion: 1,
                      label: label,
                      message: message,
-                     isError: !success,
-                     color: success ? "F05138" : "inactive",
+                     isError: !compatible,
+                     color: compatible ? "F05138" : "inactive",
                      cacheSeconds: cacheSeconds,
                      logoSvg: Package.loadSVGLogo())
     }
 
 
-    func badgeMessage(badgeType: BadgeType) -> (title: String, success: Bool) {
+    func badgeMessage(badgeType: BadgeType) -> (message: String, compatible: Bool) {
         switch badgeType {
             case .platforms:
                 switch platformCompatibility() {
                     case .available(let platforms):
-                        if let message = Self._badgeMessage(platforms: platforms) {
+                        if let message = Self.badgeMessage(platforms: platforms) {
                             return (message, true)
                         } else {
                             return ("unavailable", false)
@@ -119,7 +120,7 @@ extension Package {
             case .swiftVersions:
                 switch swiftVersionCompatibility() {
                     case .available(let versions):
-                        if let message = Self._badgeMessage(swiftVersions: versions) {
+                        if let message = Self.badgeMessage(swiftVersions: versions) {
                             return (message, true)
                         } else {
                             return ("unavailable", false)
@@ -150,7 +151,7 @@ extension Package {
     }
 
 
-    static func _badgeMessage(platforms: [Build.Platform]) -> String? {
+    static func badgeMessage(platforms: [Build.Platform]) -> String? {
         guard !platforms.isEmpty else { return nil }
         struct Value: Hashable {
             var index: Int
@@ -187,7 +188,7 @@ extension Package {
     }
 
 
-    static func _badgeMessage(swiftVersions: [SwiftVersion]) -> String? {
+    static func badgeMessage(swiftVersions: [SwiftVersion]) -> String? {
         guard !swiftVersions.isEmpty else { return nil }
         return swiftVersions
             .map(\.displayName)

--- a/Sources/App/Controllers/API/Package+Badge.swift
+++ b/Sources/App/Controllers/API/Package+Badge.swift
@@ -94,18 +94,18 @@ extension Package {
                 label = "Swift Compatibility"
         }
 
-        let (message, compatible) = badgeMessage(badgeType: badgeType)
+        let (message, success) = badgeMessage(badgeType: badgeType)
         return Badge(schemaVersion: 1,
                      label: label,
                      message: message,
-                     isError: !compatible,
-                     color: compatible ? "F05138" : "inactive",
+                     isError: !success,
+                     color: success ? "F05138" : "inactive",
                      cacheSeconds: cacheSeconds,
                      logoSvg: Package.loadSVGLogo())
     }
 
 
-    func badgeMessage(badgeType: BadgeType) -> (message: String, compatible: Bool) {
+    func badgeMessage(badgeType: BadgeType) -> (message: String, success: Bool) {
         switch badgeType {
             case .platforms:
                 switch platformCompatibility() {

--- a/Sources/App/Controllers/API/Package+Badge.swift
+++ b/Sources/App/Controllers/API/Package+Badge.swift
@@ -107,28 +107,29 @@ extension Package {
         switch badgeType {
             case .platforms:
                 switch platformCompatibility() {
-                case .available(let platforms):
-                    if let message = _badgeMessage(platforms: platforms) {
-                        return (message, true)
-                    } else {
-                        return ("unavailable", false)
-                    }
-                case .pending:
-                    return ("pending", false)
+                    case .available(let platforms):
+                        if let message = Self._badgeMessage(platforms: platforms) {
+                            return (message, true)
+                        } else {
+                            return ("unavailable", false)
+                        }
+                    case .pending:
+                        return ("pending", false)
                 }
             case .swiftVersions:
                 switch swiftVersionCompatibility() {
-                case .available(let versions):
-                    if let message = _badgeMessage(swiftVersions: versions) {
-                        return (message, true)
-                    } else {
-                        return ("unavailable", false)
-                    }
-                case .pending:
-                    return ("pending", false)
+                    case .available(let versions):
+                        if let message = Self._badgeMessage(swiftVersions: versions) {
+                            return (message, true)
+                        } else {
+                            return ("unavailable", false)
+                        }
+                    case .pending:
+                        return ("pending", false)
                 }
         }
     }
+    
 
     /// Returns all builds for a packages significant versions
     /// - Returns: Array of `Build`s
@@ -139,6 +140,7 @@ extension Package {
             $0.append(contentsOf: $1.$builds.value ?? [])
         }
     }
+
     
     static private func loadSVGLogo() -> String? {
         let pathToFile = Current.fileManager.workingDirectory()
@@ -147,50 +149,50 @@ extension Package {
         return try? String(contentsOfFile: pathToFile)
     }
 
-}
 
-
-func _badgeMessage(platforms: [Build.Platform]) -> String? {
-    guard !platforms.isEmpty else { return nil }
-    struct Value: Hashable {
-        var index: Int
-        var value: String
-        init(_ index: Int, _ value: String) {
-            self.index = index
-            self.value = value
+    static func _badgeMessage(platforms: [Build.Platform]) -> String? {
+        guard !platforms.isEmpty else { return nil }
+        struct Value: Hashable {
+            var index: Int
+            var value: String
+            init(_ index: Int, _ value: String) {
+                self.index = index
+                self.value = value
+            }
         }
-    }
-    return Array(
-        Set(
-            platforms
-                .map { p -> Value in
-                    switch p {
-                        case .ios:
-                            return .init(0, "iOS")
-                        case .macosSpm, .macosXcodebuild, .macosSpmArm, .macosXcodebuildArm:
-                            return .init(1, "macOS")
-                        case .linux:
-                            return .init(2, "Linux")
-                        case .tvos:
-                            return .init(3, "tvOS")
-                        case .watchos:
-                            return .init(4, "watchOS")
-                    }
-                }
+        return Array(
+            Set(
+                platforms
+                    .map { p -> Value in
+            switch p {
+                case .ios:
+                    return .init(0, "iOS")
+                case .macosSpm, .macosXcodebuild, .macosSpmArm, .macosXcodebuildArm:
+                    return .init(1, "macOS")
+                case .linux:
+                    return .init(2, "Linux")
+                case .tvos:
+                    return .init(3, "tvOS")
+                case .watchos:
+                    return .init(4, "watchOS")
+            }
+        }
+            )
         )
-    )
-    .sorted {
-        $0.index < $1.index
+            .sorted {
+                $0.index < $1.index
+            }
+            .map { $0.value }
+            .joined(separator: " | ")
     }
-    .map { $0.value }
-    .joined(separator: " | ")
-}
 
 
-func _badgeMessage(swiftVersions: [SwiftVersion]) -> String? {
-    guard !swiftVersions.isEmpty else { return nil }
-    return swiftVersions
-        .map(\.displayName)
-        .sorted { $0 > $1 }
-        .joined(separator: " | ")
+    static func _badgeMessage(swiftVersions: [SwiftVersion]) -> String? {
+        guard !swiftVersions.isEmpty else { return nil }
+        return swiftVersions
+            .map(\.displayName)
+            .sorted { $0 > $1 }
+            .joined(separator: " | ")
+    }
+
 }

--- a/Sources/App/Controllers/API/Package+Badge.swift
+++ b/Sources/App/Controllers/API/Package+Badge.swift
@@ -21,7 +21,7 @@ extension Package {
     /// - Returns: A `CompatibilityResult` of `SwiftVersion`
     func swiftVersionCompatibility() -> CompatibilityResult<SwiftVersion> {
         let allBuilds = allSignificantBuilds()
-        if allBuilds.allSatisfy { $0.status == .pending } { return .pending }
+        if allBuilds.allSatisfy({ $0.status == .pending }) { return .pending }
         
         let builds = allBuilds
             .filter { $0.status == .ok }
@@ -45,7 +45,7 @@ extension Package {
     /// - Returns: A `CompatibilityResult` of `Platform`
     func platformCompatibility() -> CompatibilityResult<Build.Platform> {
         let allBuilds = allSignificantBuilds()
-        if allBuilds.allSatisfy { $0.status == .pending } { return .pending }
+        if allBuilds.allSatisfy({ $0.status == .pending }) { return .pending }
         
         let builds = allBuilds
             .filter { $0.status == .ok }

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -721,14 +721,14 @@ final class PackageTests: AppTestCase {
     }
 
     func test_badgeMessage_swiftVersions() throws {
-        XCTAssertEqual(_badgeMessage(swiftVersions: [.v5_2, .v5_1, .v5_4]), "5.4 | 5.2 | 5.1")
-        XCTAssertNil(_badgeMessage(swiftVersions: []))
+        XCTAssertEqual(Package._badgeMessage(swiftVersions: [.v5_2, .v5_1, .v5_4]), "5.4 | 5.2 | 5.1")
+        XCTAssertNil(Package._badgeMessage(swiftVersions: []))
     }
 
     func test_badgeMessage_platforms() throws {
-        XCTAssertEqual(_badgeMessage(platforms: [.linux, .ios, .macosXcodebuild, .macosSpm]),
+        XCTAssertEqual(Package._badgeMessage(platforms: [.linux, .ios, .macosXcodebuild, .macosSpm]),
                        "iOS | macOS | Linux")
-        XCTAssertNil(_badgeMessage(platforms: []))
+        XCTAssertNil(Package._badgeMessage(platforms: []))
     }
 
     func test_swiftVersionCompatibility() throws {

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -721,14 +721,14 @@ final class PackageTests: AppTestCase {
     }
 
     func test_badgeMessage_swiftVersions() throws {
-        XCTAssertEqual(Package._badgeMessage(swiftVersions: [.v5_2, .v5_1, .v5_4]), "5.4 | 5.2 | 5.1")
-        XCTAssertNil(Package._badgeMessage(swiftVersions: []))
+        XCTAssertEqual(Package.badgeMessage(swiftVersions: [.v5_2, .v5_1, .v5_4]), "5.4 | 5.2 | 5.1")
+        XCTAssertNil(Package.badgeMessage(swiftVersions: []))
     }
 
     func test_badgeMessage_platforms() throws {
-        XCTAssertEqual(Package._badgeMessage(platforms: [.linux, .ios, .macosXcodebuild, .macosSpm]),
+        XCTAssertEqual(Package.badgeMessage(platforms: [.linux, .ios, .macosXcodebuild, .macosSpm]),
                        "iOS | macOS | Linux")
-        XCTAssertNil(Package._badgeMessage(platforms: []))
+        XCTAssertNil(Package.badgeMessage(platforms: []))
     }
 
     func test_swiftVersionCompatibility() throws {

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -756,7 +756,7 @@ final class PackageTests: AppTestCase {
         }
 
         // MUT
-        let res = p.swiftVersionCompatibility().values
+        let res = try XCTUnwrap(p.swiftVersionCompatibility().values)
 
         // validate
         XCTAssertEqual(res.sorted(), [.v5_2, .v5_3])
@@ -818,7 +818,7 @@ final class PackageTests: AppTestCase {
         }
 
         // MUT
-        let res = p.swiftVersionCompatibility().values
+        let res = try XCTUnwrap(p.swiftVersionCompatibility().values)
 
         // validate
         XCTAssertEqual(res.sorted(), [ .v5_3 ])
@@ -849,7 +849,7 @@ final class PackageTests: AppTestCase {
         }
 
         // MUT
-        let res = p.platformCompatibility().values
+        let res = try XCTUnwrap(p.platformCompatibility().values)
 
         // validate
         XCTAssertEqual(res.sorted(), [.macosXcodebuild, .linux])
@@ -911,7 +911,7 @@ final class PackageTests: AppTestCase {
         }
 
         // MUT
-        let res = p.platformCompatibility().values
+        let res = try XCTUnwrap(p.platformCompatibility().values)
 
         // validate
         XCTAssertEqual(res.sorted(), [ .linux ])


### PR DESCRIPTION
While reviewing James' PR I noticed there were two top-level functions `_badgeMessage` from my original implementation that should have been static functions on `Package`, really.

I wanted to clean that up and while I was in there I noticed the doc strings had drifted and that `values` should be `[Value]?` so `pending` can map to `nil` exclusively (whereas `[]` could also be `.available([])`.

Just small stuff that I thought I'd just fix up real quick rather than go back and forth in the existing PR. Hope you don't mind, James!