### PR TITLE
Keyword pagination

### DIFF
--- a/Sources/App/Controllers/API/API+SearchController.swift
+++ b/Sources/App/Controllers/API/API+SearchController.swift
@@ -11,7 +11,7 @@ extension API {
             return search(database: req.db,
                           query: query,
                           page: page,
-                          pageSize: Constants.searchPageSize)
+                          pageSize: Constants.resultsPageSize)
         }
     }
 }

--- a/Sources/App/Controllers/SearchController.swift
+++ b/Sources/App/Controllers/SearchController.swift
@@ -11,7 +11,7 @@ struct SearchController {
         return API.search(database: req.db,
                           query: query,
                           page: page,
-                          pageSize: Constants.searchPageSize)
+                          pageSize: Constants.resultsPageSize)
             .map { SearchShow.Model.init(page: page, query: query, response: $0) }
             .map { SearchShow.View.init(path: req.url.path, model: $0).document() }
     }

--- a/Sources/App/Core/Constants.swift
+++ b/Sources/App/Core/Constants.swift
@@ -33,7 +33,7 @@ enum Constants {
     static let rssFeedMaxItemCount = 100
     static let rssTTL: TimeInterval = .minutes(60)
     
-    static let searchPageSize = 20
+    static let resultsPageSize = 20
 
     // analyzer settings
     static let gitCheckoutMaxAge: TimeInterval = .days(30)

--- a/Sources/App/Core/Extensions/QueryBuilder+paginate.swift
+++ b/Sources/App/Core/Extensions/QueryBuilder+paginate.swift
@@ -1,0 +1,20 @@
+import Fluent
+
+
+extension QueryBuilder {
+    /// Add `offset` and `limit` to the query corresponding to the give page. NB: the number of elements returned can be up to `pageSize + 1`. Therefore ensure to limit the results via `.prefix(pageSize)`.
+    /// The point of this is to be able to tell if there are more results without having to run a count or any other subsequent query.
+    /// - Parameters:
+    ///   - page: requested page, first page is 1
+    ///   - pageSize: number of elements per page
+    /// - Returns: a `QueryBuilder`
+    func paginate(page: Int, pageSize: Int) -> Self {
+        // page is one-based, clamp it to ensure we get a >=0 offset
+        let page = page.clamped(to: 1...)
+        let offset = (page - 1) * pageSize
+        let limit = pageSize + 1  // fetch one more so we can determine `hasMoreResults`
+        return self
+            .offset(offset)
+            .limit(limit)
+    }
+}

--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -206,7 +206,7 @@ enum Search {
             return nil
         }
 
-        // page is one-based, clamp it to ensure we get a 0-based offset
+        // page is one-based, clamp it to ensure we get a >=0 offset
         let page = page.clamped(to: 1...)
         let offset = (page - 1) * pageSize
         let limit = pageSize + 1  // fetch one more so we can determine `hasMoreResults`

--- a/Sources/App/Views/Keyword/KeywordShow+Model.swift
+++ b/Sources/App/Views/Keyword/KeywordShow+Model.swift
@@ -2,12 +2,17 @@ extension KeywordShow {
     struct Model {
         var keyword: String
         var packages: [PackageInfo]
+        var page: Int
+        var hasMoreResults: Bool
 
-        internal init(
-            keyword: String,
-            packages: [PackageInfo]) {
+        internal init(keyword: String,
+                      packages: [PackageInfo],
+                      page: Int,
+                      hasMoreResults: Bool) {
             self.keyword = keyword
             self.packages = packages
+            self.page = page
+            self.hasMoreResults = hasMoreResults
         }
     }
 }

--- a/Sources/App/Views/Keyword/KeywordShow+View.swift
+++ b/Sources/App/Views/Keyword/KeywordShow+View.swift
@@ -41,9 +41,11 @@ enum KeywordShow {
                         }
                     )
                 ),
-//                .p(
-//                    .strong("\(model.packages.count) \("package".pluralized(for: model.packages.count)).")
-//                ),
+                .if(model.page == 1 && !model.hasMoreResults,
+                    .p(
+                        .strong("\(model.packages.count) \("package".pluralized(for: model.packages.count)).")
+                    )
+                ),
                 .ul(
                     .class("pagination"),
                     .if(model.page > 1, .previousPage(model: model)),

--- a/Sources/App/Views/Keyword/KeywordShow+View.swift
+++ b/Sources/App/Views/Keyword/KeywordShow+View.swift
@@ -41,11 +41,47 @@ enum KeywordShow {
                         }
                     )
                 ),
-                .p(
-                    .strong("\(model.packages.count) \("package".pluralized(for: model.packages.count)).")
+//                .p(
+//                    .strong("\(model.packages.count) \("package".pluralized(for: model.packages.count)).")
+//                ),
+                .ul(
+                    .class("pagination"),
+                    .if(model.page > 1, .previousPage(model: model)),
+                    .if(model.hasMoreResults, .nextPage(model: model))
                 )
             )
         }
     }
 
+}
+
+
+fileprivate extension Node where Context == HTML.ListContext {
+    static func previousPage(model: KeywordShow.Model) -> Node<HTML.ListContext> {
+        let parameters = [
+            QueryParameter(key: "page", value: model.page - 1)
+        ]
+        return .li(
+            .class("previous"),
+            .a(
+                .href(SiteURL.keywords(.value(model.keyword))
+                        .relativeURL(parameters: parameters)),
+                "Previous Page"
+            )
+        )
+    }
+
+    static func nextPage(model: KeywordShow.Model) -> Node<HTML.ListContext> {
+        let parameters = [
+            QueryParameter(key: "page", value: model.page + 1)
+        ]
+        return .li(
+            .class("next"),
+            .a(
+                .href(SiteURL.keywords(.value(model.keyword))
+                        .relativeURL(parameters: parameters)),
+                "Next Page"
+            )
+        )
+    }
 }

--- a/Sources/App/Views/Search/SearchShow+View.swift
+++ b/Sources/App/Views/Search/SearchShow+View.swift
@@ -67,8 +67,8 @@ extension SearchShow {
                     ),
                     .ul(
                         .class("pagination"),
-                        .if(model.page > 1, .previousSearchPage(model: model)),
-                        .if(model.response.hasMoreResults, .nextSearchPage(model: model))
+                        .if(model.page > 1, .previousPage(model: model)),
+                        .if(model.response.hasMoreResults, .nextPage(model: model))
                     )
                 )
             )
@@ -76,8 +76,9 @@ extension SearchShow {
     }
 }
 
+
 fileprivate extension Node where Context == HTML.ListContext {
-    static func previousSearchPage(model: SearchShow.Model) -> Node<HTML.ListContext> {
+    static func previousPage(model: SearchShow.Model) -> Node<HTML.ListContext> {
         let parameters = [
             QueryParameter(key: "query", value: model.query),
             QueryParameter(key: "page", value: model.page - 1)
@@ -91,7 +92,7 @@ fileprivate extension Node where Context == HTML.ListContext {
         )
     }
 
-    static func nextSearchPage(model: SearchShow.Model) -> Node<HTML.ListContext> {
+    static func nextPage(model: SearchShow.Model) -> Node<HTML.ListContext> {
         let parameters = [
             QueryParameter(key: "query", value: model.query),
             QueryParameter(key: "page", value: model.page + 1)

--- a/Tests/AppTests/KeywordControllerTests.swift
+++ b/Tests/AppTests/KeywordControllerTests.swift
@@ -5,9 +5,8 @@ import XCTest
 
 class KeywordControllerTests: AppTestCase {
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-
+    func test_query() throws {
+        // setup
         do {
             let p = Package(id: .id0, url: "0".asGithubUrl.url)
             let r = try Repository(id: UUID(),
@@ -37,23 +36,76 @@ class KeywordControllerTests: AppTestCase {
             try p.save(on: app.db).wait()
             try r.save(on: app.db).wait()
         }
-    }
-
-    func test_query() throws {
         // MUT
-        let packages = try KeywordController.query(on: app.db,
+        let res = try KeywordController.query(on: app.db,
                                                    keyword: "foo",
                                                    page: 1,
                                                    pageSize: 10).wait()
 
         // validation
-        XCTAssertEqual(packages.map(\.id), [.id1])
+        XCTAssertEqual(res.packages.map(\.id), [.id1])
+        XCTAssertEqual(res.hasMoreResults, false)
     }
 
-    // TODO: test pagination
+    func test_query_pagination() throws {
+        // setup
+        for (idx, id) in UUID.mockAll.prefix(9).enumerated() {
+            let p = Package(id: id, url: "\(idx)".asGithubUrl.url, score: 10 - idx)
+            let r = try Repository(id: UUID(),
+                                   package: p,
+                                   keywords: ["foo"],
+                                   name: "\(idx)",
+                                   owner: "owner")
+            try p.save(on: app.db).wait()
+            try r.save(on: app.db).wait()
+        }
+        do {  // first page
+            // MUT
+            let res = try KeywordController.query(on: app.db,
+                                                  keyword: "foo",
+                                                  page: 1,
+                                                  pageSize: 3).wait()
+            // validate
+            XCTAssertEqual(res.packages.map(\.id), [.id0, .id1, .id2])
+            XCTAssertEqual(res.hasMoreResults, true)
+        }
+        do {  // second page
+            // MUT
+            let res = try KeywordController.query(on: app.db,
+                                                  keyword: "foo",
+                                                  page: 2,
+                                                  pageSize: 3).wait()
+            // validate
+            XCTAssertEqual(res.packages.map(\.id), [.id3, .id4, .id5])
+            XCTAssertEqual(res.hasMoreResults, true)
+        }
+        do {  // last page
+            // MUT
+            let res = try KeywordController.query(on: app.db,
+                                                  keyword: "foo",
+                                                  page: 3,
+                                                  pageSize: 3).wait()
+            // validate
+            XCTAssertEqual(res.packages.map(\.id), [.id6, .id7, .id8])
+            XCTAssertEqual(res.hasMoreResults, false)
+        }
+    }
 
     func test_show_keyword() throws {
+        // setup
+        do {
+            let p = Package(id: .id1, url: "1".asGithubUrl.url)
+            let r = try Repository(id: UUID(),
+                                   package: p,
+                                   keywords: ["foo"],
+                                   name: "1",
+                                   owner: "owner")
+            try p.save(on: app.db).wait()
+            try r.save(on: app.db).wait()
+        }
+        // MUT
         try app.test(.GET, "/keywords/foo") {
+            // validate
             XCTAssertEqual($0.status, .ok)
         }
     }

--- a/Tests/AppTests/KeywordControllerTests.swift
+++ b/Tests/AppTests/KeywordControllerTests.swift
@@ -41,11 +41,16 @@ class KeywordControllerTests: AppTestCase {
 
     func test_query() throws {
         // MUT
-        let packages = try KeywordController.query(on: app.db, keyword: "foo").wait()
+        let packages = try KeywordController.query(on: app.db,
+                                                   keyword: "foo",
+                                                   page: 1,
+                                                   pageSize: 10).wait()
 
         // validation
         XCTAssertEqual(packages.map(\.id), [.id1])
     }
+
+    // TODO: test pagination
 
     func test_show_keyword() throws {
         try app.test(.GET, "/keywords/foo") {

--- a/Tests/AppTests/Mocks/KeywordShow+mock.swift
+++ b/Tests/AppTests/Mocks/KeywordShow+mock.swift
@@ -10,6 +10,6 @@ extension KeywordShow.Model {
             description: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas nec orci scelerisque, interdum purus a, tempus turpis.",
             url: ""
         ) }
-        return .init(keyword: "networking", packages: packages)
+        return .init(keyword: "networking", packages: packages, page: 1, hasMoreResults: false)
     }
 }

--- a/Tests/AppTests/Mocks/UUID+mock.swift
+++ b/Tests/AppTests/Mocks/UUID+mock.swift
@@ -13,7 +13,9 @@ extension UUID {
     static var id8: Self { UUID(uuidString: "9c288246-ac47-4a35-9730-60c281ae590b")! }
     static var id9: Self { UUID(uuidString: "5dcceaa7-5eed-44a7-8309-93758208c178")! }
 
-    static func mockId(at index: Int) -> UUID {
-        [id0, id1, id2, id3, id4, id5, id6, id7, id8, id9][index]
+    static func mockId(at index: Int) -> UUID { mockAll[index] }
+
+    static var mockAll: [Self] {
+        [id0, id1, id2, id3, id4, id5, id6, id7, id8, id9]
     }
 }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_KeywordShow.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_KeywordShow.1.txt
@@ -133,6 +133,7 @@
         <p>
           <strong>10 packages.</strong>
         </p>
+        <ul class="pagination"></ul>
       </div>
     </main>
     <footer>


### PR DESCRIPTION
Fixes #1217

This adds pagination to the keyword package list.

I briefly looked into extending this to author package lists as well but a) it can't really be factored out and b) there are currently only 6 authors where it'd even paginate:

<img width="269" alt="CleanShot 2021-07-07 at 13 57 53@2x" src="https://user-images.githubusercontent.com/65520/124756301-99fd4700-df2c-11eb-9fd2-5bb860a7c28c.png">

It's just not worth adding for authors.