### PR TITLE
Fallback to commit message for release notes

### DIFF
--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -240,6 +240,7 @@ extension Github {
                     forkCount
                     isArchived
                     isFork
+                    isInOrganization
                     licenseInfo {
                       name
                       key
@@ -275,6 +276,9 @@ extension Github {
                         publishedAt
                         tagName
                         url
+                        tagCommit {
+                          message
+                        }
                       }
                     }
                     repositoryTopics(first: 20) {
@@ -286,7 +290,6 @@ extension Github {
                       }
                     }
                     stargazerCount
-                    isInOrganization
                   }
                 }
                 """)
@@ -369,12 +372,17 @@ extension Github {
             var nodes: [ReleaseNode]
 
             struct ReleaseNode: Decodable, Equatable {
+                struct Commit: Decodable, Equatable {
+                    var message: String
+                }
+                
                 var description: String?
                 var descriptionHTML: String?
                 var isDraft: Bool
                 var publishedAt: Date?
                 var tagName: String
                 var url: String
+                var tagCommit: Commit?
             }
         }
 

--- a/Sources/App/Models/Release.swift
+++ b/Sources/App/Models/Release.swift
@@ -14,7 +14,7 @@ struct Release: Codable, Equatable {
 extension Release {
     init(from node: Github.Metadata.ReleaseNodes.ReleaseNode) {
         description = node.description
-        descriptionHTML = node.descriptionHTML
+        descriptionHTML = node.descriptionHTML ?? node.tagCommit?.message
         isDraft = node.isDraft
         publishedAt = node.publishedAt
         tagName = node.tagName

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -113,6 +113,50 @@ class GithubTests: AppTestCase {
         XCTAssertEqual(res.repository?.lastPullRequestClosedAt,
                        iso8601.date(from: "2021-06-07T22:47:01Z"))
     }
+    
+    func test_releaseMetadata_commitMessageFallback() throws {
+        do { // If description is available, it'll always be used
+            let node = Github.Metadata.ReleaseNodes.ReleaseNode(
+                description: "description",
+                descriptionHTML: "description",
+                isDraft: false,
+                publishedAt: nil,
+                tagName: "1.0.0",
+                url: "some url",
+                tagCommit: .init(message: "message")
+            )
+            let release = Release(from: node)
+            XCTAssertEqual(release.descriptionHTML, "description")
+        }
+        
+        do { // Fallback to commit message when there is no description
+            let node = Github.Metadata.ReleaseNodes.ReleaseNode(
+                description: nil,
+                descriptionHTML: nil,
+                isDraft: false,
+                publishedAt: nil,
+                tagName: "1.0.0",
+                url: "some url",
+                tagCommit: .init(message: "message")
+            )
+            let release = Release(from: node)
+            XCTAssertEqual(release.descriptionHTML, "message")
+        }
+        
+        do { // Output is nil when no description and no commit exists
+            let node = Github.Metadata.ReleaseNodes.ReleaseNode(
+                description: nil,
+                descriptionHTML: nil,
+                isDraft: false,
+                publishedAt: nil,
+                tagName: "1.0.0",
+                url: "some url",
+                tagCommit: nil
+            )
+            let release = Release(from: node)
+            XCTAssertEqual(release.descriptionHTML, nil)
+        }
+    }
 
     func test_fetchMetadata_badRequest() throws {
         Current.githubToken = { "secr3t" }


### PR DESCRIPTION
Requires #1213 first
Closes #1223 

Spoke to Dave briefly about this on Discord.

Some repositories generate releases via GitHub but do not provide release notes. In this case, GitHub will often fallback to the message of the underlying tag.

An example of this would be https://github.com/Snowy1803/PulsrMarkdown/releases/tag/v0.1 which currently shows "There are no release notes" with what is deployed on 1213.