### PR TITLE
Explore avoiding mock builder

### DIFF
--- a/Sources/App/Core/Extensions/SQLSelectBuilder+ext.swift
+++ b/Sources/App/Core/Extensions/SQLSelectBuilder+ext.swift
@@ -19,4 +19,12 @@ extension SQLSelectBuilder {
     func column(_ expression: SQLExpression, as alias: String) -> Self {
         column(SQLAlias(expression, as: SQLIdentifier(alias)))
     }
+
+    func `where`(searchFilters: [SearchFilter]) -> Self {
+        self.where(group: { builder in
+            searchFilters
+                .prefix(20) // just to impose some form of limit
+                .reduce(builder) { $1.query($0) }
+        })
+    }
 }

--- a/Sources/App/Core/Extensions/SQLSelectBuilder+ext.swift
+++ b/Sources/App/Core/Extensions/SQLSelectBuilder+ext.swift
@@ -24,7 +24,7 @@ extension SQLSelectBuilder {
         self.where(group: { builder in
             searchFilters
                 .prefix(20) // just to impose some form of limit
-                .reduce(builder) { $1.query($0) }
+                .reduce(builder) { $1.where($0) }
         })
     }
 }

--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -147,18 +147,10 @@ enum Search {
             .where(isNotNull(packageName))
             .where(isNotNull(repoOwner))
             .where(isNotNull(repoName))
-            .where(group: matchesPackageFilters(filters: filters))
+            .where(searchFilters: filters)
             .orderBy(sortOrder)
             .offset(offset)
             .limit(limit)
-    }
-    
-    static func matchesPackageFilters(filters: [SearchFilter]) -> (SQLPredicateGroupBuilder) -> SQLPredicateGroupBuilder {
-        { builder in
-            filters
-                .prefix(20) // just to impose some form of limit
-                .reduce(builder) { $1.where($0) }
-        }
     }
 
     static func keywordMatchQueryBuilder(on database: Database,


### PR DESCRIPTION
Explored avoiding `MockPredicateBuilder`. I typically try to avoid mock objects as I find it really easy to end up write a "null" test where you're injecting assumptions on both sides and rather use the live objects where possible.

It's possible here but I'm not sure I love how it makes the SQL assertions a bit longer (and weirder).

What's worth keeping is moving `matchesPackageFilters` to an extension on `SQLSelectBuilder.