### PR TITLE
Record resolved dependencies

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -715,8 +715,14 @@ func updateVersions(on database: Database,
             },
             on: database.eventLoop
         )
-        // FIXME: replace .map($0.0, $0.1) with something more readable
-            .transform(to: (pkg, versionsAndManifests.map { ($0.0, $0.1) }))
+            .transform(
+                to: (
+                    pkg,
+                    versionsAndManifests.map { version, manifest, _ in
+                        (version, manifest)
+                    }
+                )
+            )
     }
 }
 

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -662,7 +662,7 @@ func getResolvedDependencies(at path: String) -> [ResolvedDependency]? {
     //    object:
     //      pins:
     //        - package: String
-    //          repositryURL: URL
+    //          repositoryURL: URL
     //          state:
     //            branch: String?
     //            revision: CommitHash
@@ -683,15 +683,11 @@ func getResolvedDependencies(at path: String) -> [ResolvedDependency]? {
     }
 
     let filePath = path + "/Package.resolved"
-    guard Current.fileManager.fileExists(atPath: filePath) else {
-        return nil
-    }
-    let fileUrl = URL(fileURLWithPath: filePath)
-    // FIXME: use Current.fileManager
-    guard let json = try? Data.init(contentsOf: fileUrl) else {
-        return nil
-    }
-    guard let packageResolved = try? JSONDecoder().decode(PackageResolved.self, from: json) else {
+    guard Current.fileManager.fileExists(atPath: filePath),
+          let json = try? Current.fileManager.contentsOfFile(filePath),
+          let packageResolved = try? JSONDecoder()
+            .decode(PackageResolved.self, from: json)
+    else {
         return nil
     }
     return packageResolved.object.pins.map {

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -705,9 +705,9 @@ func getResolvedDependencies(at path: String) -> [ResolvedDependency]? {
 /// - Returns: the input data for further processing, wrapped in a future
 func updateVersions(on database: Database,
                     packageResults: [Result<(Package, [(Version, Manifest, [ResolvedDependency]?)]), Error>]) -> EventLoopFuture<[Result<(Package, [(Version, Manifest)]), Error>]> {
-    packageResults.whenAllComplete(on: database.eventLoop) { (pkg, versionsAndManifests) in
+    packageResults.whenAllComplete(on: database.eventLoop) { (pkg, pkgInfo) in
         EventLoopFuture.andAllComplete(
-            versionsAndManifests.map { version, manifest, resolvedDependencies in
+            pkgInfo.map { version, manifest, resolvedDependencies in
                 updateVersion(on: database,
                               version: version,
                               manifest: manifest,
@@ -718,7 +718,7 @@ func updateVersions(on database: Database,
             .transform(
                 to: (
                     pkg,
-                    versionsAndManifests.map { version, manifest, _ in
+                    pkgInfo.map { version, manifest, _ in
                         (version, manifest)
                     }
                 )

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -84,7 +84,7 @@ func recordError(database: Database,
     switch error {
         case let .analysisError(id, _):
             return setStatus(id: id, status: .analysisFailed)
-        case .envVariableNotSet, .fileNotFound, .shellCommandFailed:
+        case .envVariableNotSet, .shellCommandFailed:
             return database.eventLoop.future()
         case let .genericError(id, _):
             return setStatus(id: id, status: .ingestionFailed)

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -84,7 +84,7 @@ func recordError(database: Database,
     switch error {
         case let .analysisError(id, _):
             return setStatus(id: id, status: .analysisFailed)
-        case .envVariableNotSet, .shellCommandFailed:
+        case .envVariableNotSet, .fileNotFound, .shellCommandFailed:
             return database.eventLoop.future()
         case let .genericError(id, _):
             return setStatus(id: id, status: .ingestionFailed)

--- a/Sources/App/Commands/ReAnalyzeVersions.swift
+++ b/Sources/App/Commands/ReAnalyzeVersions.swift
@@ -173,7 +173,7 @@ func reAnalyzeVersions(client: Client,
                             before: cutoffDate)
             .flatMap { setUpdatedAt(on: tx, packageVersions: $0) }
             .flatMap { mergeReleaseInfo(on: tx, packageVersions: $0) }
-            .map { getManifests(packageAndVersions: $0) }
+            .map { getPackageInfo(packageAndVersions: $0) }
             .flatMap { updateVersions(on: tx, packageResults: $0) }
             .flatMap { updateProducts(on: tx, packageResults: $0) }
             .flatMap { updateTargets(on: tx, packageResults: $0) }

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -131,6 +131,7 @@ extension AppEnvironment {
 struct FileManager {
     var attributesOfItem: (_ path: String) throws -> [FileAttributeKey : Any]
     var contentsOfDirectory: (_ path: String) throws -> [String]
+    var contentsOfFile: (_ path: String) throws -> Data
     var checkoutsDirectory: () -> String
     var createDirectory: (String, Bool, [FileAttributeKey : Any]?) throws -> Void
     var fileExists: (String) -> Bool
@@ -155,6 +156,9 @@ struct FileManager {
     static let live: Self = .init(
         attributesOfItem: Foundation.FileManager.default.attributesOfItem,
         contentsOfDirectory: Foundation.FileManager.default.contentsOfDirectory,
+        contentsOfFile: { path in
+            try Data(contentsOf: URL(fileURLWithPath: path))
+        },
         checkoutsDirectory: { Environment.get("CHECKOUTS_DIR") ?? DirectoryConfiguration.detect().workingDirectory + "SPI-checkouts" },
         createDirectory: Foundation.FileManager.default.createDirectory,
         fileExists: Foundation.FileManager.default.fileExists,

--- a/Sources/App/Core/AppError.swift
+++ b/Sources/App/Core/AppError.swift
@@ -18,7 +18,6 @@ import Vapor
 enum AppError: LocalizedError {
     case analysisError(Package.Id?, _ message: String)
     case envVariableNotSet(_ variable: String)
-    case fileNotFound(path: String)
     case invalidPackageUrl(Package.Id?, _ url: String)
     case invalidPackageCachePath(Package.Id?, _ path: String)
     case invalidRevision(Version.Id?, _ revision: String?)
@@ -34,8 +33,6 @@ enum AppError: LocalizedError {
                 return "Analysis failed: \(message) (id: \(id))"
             case let .envVariableNotSet(value):
                 return "Environment variable not set: \(value)"
-            case let .fileNotFound(value):
-                return "File not found: \(value)"
             case let .invalidPackageUrl(id, value):
                 return "Invalid packge URL: \(value) (id: \(id))"
             case let .invalidPackageCachePath(id, value):

--- a/Sources/App/Core/AppError.swift
+++ b/Sources/App/Core/AppError.swift
@@ -18,6 +18,7 @@ import Vapor
 enum AppError: LocalizedError {
     case analysisError(Package.Id?, _ message: String)
     case envVariableNotSet(_ variable: String)
+    case fileNotFound(path: String)
     case invalidPackageUrl(Package.Id?, _ url: String)
     case invalidPackageCachePath(Package.Id?, _ path: String)
     case invalidRevision(Version.Id?, _ revision: String?)
@@ -33,10 +34,12 @@ enum AppError: LocalizedError {
                 return "Analysis failed: \(message) (id: \(id))"
             case let .envVariableNotSet(value):
                 return "Environment variable not set: \(value)"
+            case let .fileNotFound(value):
+                return "File not found: \(value)"
             case let .invalidPackageUrl(id, value):
                 return "Invalid packge URL: \(value) (id: \(id))"
             case let .invalidPackageCachePath(id, value):
-                return "Invalid packge cache path: \(value) (id: \(id)"
+                return "Invalid packge cache path: \(value) (id: \(id))"
             case let .invalidRevision(id, value):
                 return "Invalid revision: \(value ?? "nil") (id: \(id))"
             case let .metadataRequestFailed(id, status, uri):

--- a/Sources/App/Migrations/033/UpdateVersionAddResolvedDependencies.swift
+++ b/Sources/App/Migrations/033/UpdateVersionAddResolvedDependencies.swift
@@ -1,0 +1,33 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateVersionAddResolvedDependencies: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("versions")
+            .field("resolved_dependencies",
+                   .array(of: .json),
+                   .sql(.default("{}"))
+            )
+            .update()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("versions")
+            .deleteField("resolved_dependencies")
+            .update()
+    }
+}

--- a/Sources/App/Models/ResolvedDependency.swift
+++ b/Sources/App/Models/ResolvedDependency.swift
@@ -15,5 +15,6 @@
 import Foundation
 
 struct ResolvedDependency: Codable {
-    var url: String
+    var packageName: String
+    var repositoryURL: String
 }

--- a/Sources/App/Models/ResolvedDependency.swift
+++ b/Sources/App/Models/ResolvedDependency.swift
@@ -1,0 +1,19 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+struct ResolvedDependency: Codable {
+    var url: String
+}

--- a/Sources/App/Models/Version.swift
+++ b/Sources/App/Models/Version.swift
@@ -105,6 +105,7 @@ final class Version: Model, Content {
          reference: Reference? = nil,
          releaseNotes: String? = nil,
          releaseNotesHTML: String? = nil,
+         resolvedDependencies: [ResolvedDependency] = [],
          supportedPlatforms: [Platform] = [],
          swiftVersions: [SwiftVersion] = [],
          toolsVersion: String? = nil,
@@ -119,6 +120,7 @@ final class Version: Model, Content {
         self.reference = reference
         self.releaseNotes = releaseNotes
         self.releaseNotesHTML = releaseNotesHTML
+        self.resolvedDependencies = resolvedDependencies
         self.supportedPlatforms = supportedPlatforms
         self.swiftVersions = swiftVersions
         self.toolsVersion = toolsVersion

--- a/Sources/App/Models/Version.swift
+++ b/Sources/App/Models/Version.swift
@@ -66,6 +66,9 @@ final class Version: Model, Content {
     @Field(key: "release_notes_html")
     var releaseNotesHTML: String?
 
+    @Field(key: "resolved_dependencies")
+    var resolvedDependencies: [ResolvedDependency]
+
     // TODO: rename to minimumPlatformVersions?
     @Field(key: "supported_platforms")
     var supportedPlatforms: [Platform]

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -157,6 +157,9 @@ public func configure(_ app: Application) throws {
     do {  // Migration 032 - add [license, stars, last_commit_date, supported_platforms, swift_versions] to search
         app.migrations.add(UpdateSearch2())
     }
+    do {  // Migration 033 - add resolved_dependencies to versions
+        app.migrations.add(UpdateVersionAddResolvedDependencies())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -610,7 +610,39 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(v.id, version.id)
         XCTAssertEqual(m.name, "SPI-Server")
     }
-    
+
+    func test_getResolvedDependencies() throws {
+        // setup
+        Current.fileManager.contentsOfFile = { _ in
+            Data(
+                #"""
+                {
+                  "object": {
+                    "pins": [
+                      {
+                        "package": "Bar",
+                        "repositoryURL": "https://github.com/foo/bar",
+                        "state": {
+                          "branch": null,
+                          "revision": "fca5fe8e7b8218d563f99daadffd86dbf11dd98b",
+                          "version": "1.2.3"
+                        }
+                      }
+                    ],
+                    "version": 1
+                  }
+                }
+                """#.utf8
+            )
+        }
+
+        // MUT
+        let deps = getResolvedDependencies(at: "path")
+
+        // validate
+        XCTAssertEqual(deps?.map(\.packageName), ["Bar"])
+    }
+
     func test_getManifests() throws {
         // setup
         let queue = DispatchQueue(label: "serial")

--- a/Tests/AppTests/Mocks/AppFileManager+mock.swift
+++ b/Tests/AppTests/Mocks/AppFileManager+mock.swift
@@ -23,6 +23,7 @@ extension App.FileManager {
         .init(
             attributesOfItem: { _ in [:] },
             contentsOfDirectory: { _ in [] },
+            contentsOfFile: { _ in fatalError("override me") },
             checkoutsDirectory: { DirectoryConfiguration.detect().workingDirectory + "SPI-checkouts" },
             createDirectory: { path, _, _ in
                 print("ℹ️ MOCK: imagine we're creating a directory at path: \(path)")

--- a/Tests/AppTests/Mocks/AppFileManager+mock.swift
+++ b/Tests/AppTests/Mocks/AppFileManager+mock.swift
@@ -23,7 +23,7 @@ extension App.FileManager {
         .init(
             attributesOfItem: { _ in [:] },
             contentsOfDirectory: { _ in [] },
-            contentsOfFile: { _ in fatalError("override me") },
+            contentsOfFile: { _ in .init() },
             checkoutsDirectory: { DirectoryConfiguration.detect().workingDirectory + "SPI-checkouts" },
             createDirectory: { path, _, _ in
                 print("ℹ️ MOCK: imagine we're creating a directory at path: \(path)")

--- a/Tests/AppTests/VersionTests.swift
+++ b/Tests/AppTests/VersionTests.swift
@@ -36,6 +36,7 @@ class VersionTests: AppTestCase {
         v.publishedAt = Date(timeIntervalSince1970: 1)
         v.reference = .branch("branch")
         v.releaseNotes = "release notes"
+        v.resolvedDependencies = [.init(url: "url")]
         v.supportedPlatforms = [.ios("13"), .macos("10.15")]
         v.swiftVersions = ["4.0", "5.2"].asSwiftVersions
         v.url = pkg.versionUrl(for: v.reference!)
@@ -51,6 +52,7 @@ class VersionTests: AppTestCase {
             XCTAssertEqual(v.publishedAt, Date(timeIntervalSince1970: 1))
             XCTAssertEqual(v.reference, .branch("branch"))
             XCTAssertEqual(v.releaseNotes, "release notes")
+            XCTAssertEqual(v.resolvedDependencies.map(\.url), ["url"])
             XCTAssertEqual(v.supportedPlatforms, [.ios("13"), .macos("10.15")])
             XCTAssertEqual(v.swiftVersions, ["4.0", "5.2"].asSwiftVersions)
             XCTAssertEqual(v.url, "https://github.com/foo/1/tree/branch")

--- a/Tests/AppTests/VersionTests.swift
+++ b/Tests/AppTests/VersionTests.swift
@@ -36,7 +36,8 @@ class VersionTests: AppTestCase {
         v.publishedAt = Date(timeIntervalSince1970: 1)
         v.reference = .branch("branch")
         v.releaseNotes = "release notes"
-        v.resolvedDependencies = [.init(url: "url")]
+        v.resolvedDependencies = [.init(packageName: "foo",
+                                        repositoryURL: "http://foo") ]
         v.supportedPlatforms = [.ios("13"), .macos("10.15")]
         v.swiftVersions = ["4.0", "5.2"].asSwiftVersions
         v.url = pkg.versionUrl(for: v.reference!)
@@ -52,7 +53,8 @@ class VersionTests: AppTestCase {
             XCTAssertEqual(v.publishedAt, Date(timeIntervalSince1970: 1))
             XCTAssertEqual(v.reference, .branch("branch"))
             XCTAssertEqual(v.releaseNotes, "release notes")
-            XCTAssertEqual(v.resolvedDependencies.map(\.url), ["url"])
+            XCTAssertEqual(v.resolvedDependencies.map(\.packageName),
+                           ["foo"])
             XCTAssertEqual(v.supportedPlatforms, [.ios("13"), .macos("10.15")])
             XCTAssertEqual(v.swiftVersions, ["4.0", "5.2"].asSwiftVersions)
             XCTAssertEqual(v.url, "https://github.com/foo/1/tree/branch")


### PR DESCRIPTION
⚠️ Schema change ⚠️

This will populate `versions.resolved_dependencies` for packages that ship with `Package.resolved` by simply reading the file and writing a reduced data set to that column.

About 25% of packages come with their own `Package.swift`, meaning we don't need to do any costly package resolution in the analysis stage.

Since our builders do package resolution anyway, in the next step I'll extend them to send this same info along with the build report and the server to update `versions.resolved_dependencies` from it.

We should let this run a bit on staging before deploying. I'd like to look at the data and see if queries on it work as expected.