### PR TITLE
Pull the package name from the default version

### DIFF
--- a/Sources/App/Controllers/AuthorController.swift
+++ b/Sources/App/Controllers/AuthorController.swift
@@ -19,7 +19,7 @@ import Vapor
 
 struct AuthorController {
 
-    private func query(on database: Database, owner: String) -> EventLoopFuture<[Package]> {
+    static func query(on database: Database, owner: String) -> EventLoopFuture<[Package]> {
         Package.query(on: database)
             .with(\.$repositories)
             .with(\.$versions)
@@ -44,7 +44,7 @@ struct AuthorController {
             return req.eventLoop.future(error: Abort(.notFound))
         }
 
-        return query(on: req.db, owner: owner)
+        return Self.query(on: req.db, owner: owner)
             .map {
                 AuthorShow.Model(
                     owner: $0.first?.repository?.owner ?? owner,

--- a/Sources/App/Controllers/AuthorController.swift
+++ b/Sources/App/Controllers/AuthorController.swift
@@ -22,6 +22,7 @@ struct AuthorController {
     private func query(on database: Database, owner: String) -> EventLoopFuture<[Package]> {
         Package.query(on: database)
             .with(\.$repositories)
+            .with(\.$versions)
             .join(Repository.self, on: \Repository.$package.$id == \Package.$id)
             .filter(
                 DatabaseQuery.Field.path(Repository.path(for: \.$owner), schema: Repository.schema),

--- a/Sources/App/Views/PackageInfo.swift
+++ b/Sources/App/Views/PackageInfo.swift
@@ -26,7 +26,7 @@ extension PackageInfo {
             return nil
         }
 
-        self.init(title: repoName,
+        self.init(title: package.name() ?? repoName,
                   description: package.repository?.summary ?? "",
                   url: SiteURL.package(.value(repoOwner),
                                        .value(repoName),

--- a/Tests/AppTests/Controllers/AuthorControllerTests.swift
+++ b/Tests/AppTests/Controllers/AuthorControllerTests.swift
@@ -63,4 +63,11 @@ class AuthorControllerTests: AppTestCase {
         })
     }
 
+    func test_query_package_name() throws {
+        // Ensure package.name is populated by query
+        let packages = try AuthorController.query(on: app.db, owner: "owner")
+            .wait()
+        XCTAssertEqual(packages.map { $0.name() }, ["Test package"])
+    }
+
 }

--- a/Tests/AppTests/PackageInfoTests.swift
+++ b/Tests/AppTests/PackageInfoTests.swift
@@ -1,0 +1,55 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import App
+
+import XCTest
+
+
+class PackageInfoTests: AppTestCase {
+
+    func test_title_package_name() throws {
+        // Ensure title is populated from package.name()
+        // setup
+        let p = try savePackage(on: app.db, "1")
+        try Repository(package: p, name: "repo name", owner: "owner")
+            .save(on: app.db).wait()
+        try Version(package: p, latest: .defaultBranch, packageName: "package name")
+            .save(on: app.db).wait()
+        try p.$repositories.load(on: app.db).wait()
+        try p.$versions.load(on: app.db).wait()
+
+        // MUT
+        let pkgInfo = PackageInfo(package: p)
+
+        // validate
+        XCTAssertEqual(pkgInfo?.title, "package name")
+    }
+
+    func test_title_repo_name() throws {
+        // Ensure title is populated from repoName if package.name() is nil
+        // setup
+        let p = try savePackage(on: app.db, "1")
+        try Repository(package: p, name: "repo name", owner: "owner")
+            .save(on: app.db).wait()
+        try p.$repositories.load(on: app.db).wait()
+        try p.$versions.load(on: app.db).wait()
+
+        // MUT
+        let pkgInfo = PackageInfo(package: p)
+
+        // validate
+        XCTAssertEqual(pkgInfo?.title, "repo name")
+    }
+}


### PR DESCRIPTION
Fixes #1259 

There will be a performance impact with this fix, but it really shouldn't be too bad.

There is a lack of tests for the pieces of the app that this covers. No explicit tests for `PackageInfo` and the `AuthorController` has some minimal tests, but nothing that tests the logic really. There's an argument for adding better tests for both of those things, but I'm not surethis PR is the right place for that.