### PR TITLE
Add fixtureUrl, rename loadData → fixtureData

### DIFF
--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -80,7 +80,7 @@ class GithubTests: AppTestCase {
 
     func test_fetchMetadata() throws {
         Current.githubToken = { "secr3t" }
-        let data = try XCTUnwrap(try loadData(for: "github-graphql-resource.json"))
+        let data = try XCTUnwrap(try fixtureData(for: "github-graphql-resource.json"))
         let client = MockClient { _, resp in
             resp.status = .ok
             resp.body = makeBody(data)
@@ -269,7 +269,7 @@ class GithubTests: AppTestCase {
         // setup
         Current.githubToken = { "secr3t" }
         let pkg = Package(url: "https://github.com/PSPDFKit/PSPDFKit-SP")
-        let data = try XCTUnwrap(try loadData(for: "github-license-response.json"))
+        let data = try XCTUnwrap(try fixtureData(for: "github-license-response.json"))
         let client = MockClient { _, resp in
             resp.status = .ok
             resp.body = makeBody(data)
@@ -300,7 +300,7 @@ class GithubTests: AppTestCase {
         // setup
         Current.githubToken = { "secr3t" }
         let pkg = Package(url: "https://github.com/daveverwer/leftpad")
-        let data = try XCTUnwrap(try loadData(for: "github-readme-response.json"))
+        let data = try XCTUnwrap(try fixtureData(for: "github-readme-response.json"))
         let client = MockClient { _, resp in
             resp.status = .ok
             resp.body = makeBody(data)

--- a/Tests/AppTests/ManifestTests.swift
+++ b/Tests/AppTests/ManifestTests.swift
@@ -95,7 +95,7 @@ class ManifestTests: XCTestCase {
     }
     
     func test_decode_basic() throws {
-        let data = try loadData(for: "manifest-1.json")
+        let data = try fixtureData(for: "manifest-1.json")
         let m = try JSONDecoder().decode(Manifest.self, from: data)
         XCTAssertEqual(m.name, "SPI-Server")
         XCTAssertEqual(m.platforms, [.init(platformName: .macos, version: "10.15")])
@@ -110,7 +110,7 @@ class ManifestTests: XCTestCase {
     }
 
     func test_decode_products_complex() throws {
-        let data = try loadData(for: "SwiftNIO.json")
+        let data = try fixtureData(for: "SwiftNIO.json")
         let m = try JSONDecoder().decode(Manifest.self, from: data)
         XCTAssertEqual(m.products, [
             .init(name: "NIOEchoServer",

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -72,9 +72,13 @@ func _resetDb(_ app: Application) throws {
 }
 
 
-func loadData(for fixture: String) throws -> Data {
-    let url = fixturesDirectory().appendingPathComponent(fixture)
-    return try Data(contentsOf: url)
+func fixtureData(for fixture: String) throws -> Data {
+    try Data(contentsOf: fixtureUrl(for: fixture))
+}
+
+
+func fixtureUrl(for fixture: String) -> URL {
+    fixturesDirectory().appendingPathComponent(fixture)
 }
 
 

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -384,7 +384,7 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
     }
     
     func test_MarkdownPageStyling() throws {
-        let data = try XCTUnwrap(try loadData(for: "markdown-test.md"))
+        let data = try XCTUnwrap(try fixtureData(for: "markdown-test.md"))
         let markdown = try XCTUnwrap(String(data: data, encoding: .utf8))
         let html = MarkdownParser().parse(markdown).html
         let page = { MarkdownPage(path: "", html: html).document() }


### PR DESCRIPTION
Just some fixture test utils tweaks needed for the collection signing. I wanted to pull those out so that PR, which is quite sensitive, has a little noise as possible.