### PR TITLE
Add metrics for package collection GET requests

### DIFF
--- a/Sources/App/Controllers/API/API+PackageCollectionController.swift
+++ b/Sources/App/Controllers/API/API+PackageCollectionController.swift
@@ -21,6 +21,8 @@ extension API {
     struct PackageCollectionController {
 
         func generate(req: Request) throws -> EventLoopFuture<SignedCollection> {
+            AppMetrics.apiPackageCollectionGetTotal?.inc()
+
             // First try decoding "owner" type DTO
             if let dto = try? req.content.decode(PostPackageCollectionOwnerDTO.self) {
                 return SignedCollection.generate(

--- a/Sources/App/Controllers/PackageCollectionController.swift
+++ b/Sources/App/Controllers/PackageCollectionController.swift
@@ -17,6 +17,8 @@ import Vapor
 
 struct PackageCollectionController {
     func generate(req: Request) throws -> EventLoopFuture<SignedCollection> {
+        AppMetrics.packageCollectionGetTotal?.inc()
+
         guard let owner = req.parameters.get("owner") else {
             return req.eventLoop.future(error: Abort(.notFound))
         }

--- a/Sources/App/Core/AppMetrics.swift
+++ b/Sources/App/Core/AppMetrics.swift
@@ -94,6 +94,10 @@ enum AppMetrics {
         counter("spi_api_build_report_total", Labels.Build.self)
     }
 
+    static var apiPackageCollectionGetTotal: PromCounter<Int, EmptyLabels>? {
+        counter("spi_api_package_collection_get_total", EmptyLabels.self)
+    }
+
     static var apiSearchGetTotal: PromCounter<Int, EmptyLabels>? {
         counter("spi_api_search_get_total", EmptyLabels.self)
     }
@@ -137,6 +141,11 @@ enum AppMetrics {
     static var ingestMetadataFailureCount: PromGauge<Int, EmptyLabels>? {
         gauge("spi_ingest_metadata_failure_count", EmptyLabels.self)
     }
+
+    static var packageCollectionGetTotal: PromCounter<Int, EmptyLabels>? {
+        counter("spi_package_collection_get_total", EmptyLabels.self)
+    }
+
 }
 
 


### PR DESCRIPTION
This will over-count actual requests until we understand how/why #1340 is happening.

I've had a look into whether the request would allow us to tell the pre-fetch from an actual prefetch but it's doesn't look like it'd be reliable. There was a small difference in the user-agent string, which I've detailed in the linked issue.