### PR TITLE
Joined tweaks

### DIFF
--- a/Sources/App/Controllers/PackageController.swift
+++ b/Sources/App/Controllers/PackageController.swift
@@ -125,7 +125,7 @@ extension PackageController.PackageResult {
     var versions: [Version] { package.versions }
 
     static func query(on database: Database, owner: String, repository: String) -> EventLoopFuture<Self> {
-        M.query(on: database)
+        Joined<Package, Repository>.query(on: database)
             .with(\.$versions) {
                 $0.with(\.$products)
                 $0.with(\.$builds)

--- a/Sources/App/Core/Joined.swift
+++ b/Sources/App/Core/Joined.swift
@@ -15,7 +15,7 @@
 import FluentKit
 
 
-struct Joined<M: Model, R: Model>: Joiner {
+struct Joined<M: Model, R: Model>: ModelInitializable {
     private(set) var model: M
 }
 

--- a/Sources/App/Core/Joined3.swift
+++ b/Sources/App/Core/Joined3.swift
@@ -15,7 +15,7 @@
 import FluentKit
 
 
-struct Joined3<M: Model, R1: Model, R2: Model>: Joiner {
+struct Joined3<M: Model, R1: Model, R2: Model>: ModelInitializable {
     private(set) var model: M
 }
 

--- a/Sources/App/Core/Joined4.swift
+++ b/Sources/App/Core/Joined4.swift
@@ -15,7 +15,7 @@
 import FluentKit
 
 
-struct Joined4<M: Model, R1: Model, R2: Model, R3: Model>: Joiner {
+struct Joined4<M: Model, R1: Model, R2: Model, R3: Model>: ModelInitializable {
     private(set) var model: M
 }
 

--- a/Sources/App/Core/JoinedQueryBuilder.swift
+++ b/Sources/App/Core/JoinedQueryBuilder.swift
@@ -16,7 +16,7 @@ import FluentKit
 
 
 /// JoinedQueryBuilder is a wrapper around QueryBuilder to allow Joined to be used like a Model query without actually being a Model
-struct JoinedQueryBuilder<J: Joiner> {
+struct JoinedQueryBuilder<J: ModelInitializable> {
     var queryBuilder: QueryBuilder<J.M>
 
     @discardableResult func filter(_ filter: ModelValueFilter<J.M>) -> Self {

--- a/Sources/App/Core/ModelInitializable.swift
+++ b/Sources/App/Core/ModelInitializable.swift
@@ -15,7 +15,7 @@
 import FluentKit
 
 
-protocol Joiner {
+protocol ModelInitializable {
     associatedtype M: Model
     init(model: M)
 }

--- a/Sources/App/Core/ModelInitializable.swift
+++ b/Sources/App/Core/ModelInitializable.swift
@@ -15,6 +15,10 @@
 import FluentKit
 
 
+// Ideally, this protocal wouldn't be necessary and the initialisers private,
+// in order to prevent mis-use (instantiating a not properly populated Joined
+// or Ref). However, this is not possible for reasons outlined here:
+// https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1367#issue-1051671014
 protocol ModelInitializable {
     associatedtype M: Model
     init(model: M)

--- a/Tests/AppTests/JoinedQueryBuilderTests.swift
+++ b/Tests/AppTests/JoinedQueryBuilderTests.swift
@@ -69,7 +69,7 @@ class JoinedQueryBuilderTests: AppTestCase {
 
 }
 
-extension Package: Joiner {
+extension Package: ModelInitializable {
     convenience public init(model: Package) {
         self.init(id: model.id,
                   url: model.url.url,


### PR DESCRIPTION
Minor cleanup of the `Joined` mechanics, outcome of an exploration if the `.init(model:)` initialisers could be made private.

The reason for that was to prevent misuse: you can currently instantiate a `Joined` via its `init(model:)` initialiser and then crash when accessing the relation, because it wasn't properly populated by a query.

However, it is really hard, probably impossible without turning this into a module where we could use `internal` as an access level (and even that I'm not sure would work) to make the initialiser only accessible from within properly populating `query` methods, because in order to do its work it need to be an extension on the type in the same file as the private initialiser.

This ruins composability of our `JoinedQueryBuilder`. For instance, `.page()` is the last modifier in a chain and in order to apply it, the whole query chain needs to be in an extension on the `Joined` or `Ref` type (so it can access the private `.init(model:)`

However, the deal breaker is probably `PackageController.PackageResult.query`. `PackageController.PackageResult` is a `Ref<Joined<...>, Ref<...>>`, which means its query needs to have access to both `Ref.init(model:)` and `Joined.init(model:)` - both of which we want to make private. But the extension can't live in both files at the same time.

All of this I mention just to leave a record that it's been explored.