### PR TITLE
Add a last activity filter

### DIFF
--- a/Sources/App/Core/SearchFilter.swift
+++ b/Sources/App/Core/SearchFilter.swift
@@ -37,7 +37,7 @@ struct SearchFilterParser {
     static var allSearchFilters: [SearchFilter.Type] = [
         StarsSearchFilter.self,
         LicenseSearchFilter.self,
-        LastCommitSearchFilter.self,
+        LastActiveSearchFilter.self,
     ]
     
     /// Separates search terms from filter syntax.
@@ -227,20 +227,20 @@ struct LicenseSearchFilter: SearchFilter {
     }
 }
 
-// MARK: Last Commit Date
+// MARK: Last Active Date
 
-/// Filters by the date in which the package's main branch was last updated.
+/// Filters by the date this package was last updated via a commit or an issue/PR being merged/closed.
 ///
 /// Dates must be provided in the `YYYY-MM-DD` format.
 ///
 /// Examples:
 /// ```
-/// last_commit:2020-07-01  - Updated on exactly July 1st 2020
-/// last_commit:!2020-07-01 - Updated on any day other than July 1st 2020
-/// last_commit:>2020-07-01 - Updated on any day more recent than July 1st 2020
-/// last_commit:<2020-07-01 - Updated on any day older than July 1st 2020
+/// last_active:2020-07-01  - Last active on exactly July 1st 2020
+/// last_active:!2020-07-01 - Last active on any day other than July 1st 2020
+/// last_active:>2020-07-01 - Last active on any day more recent than July 1st 2020
+/// last_active:<2020-07-01 - Last active on any day older than July 1st 2020
 /// ```
-struct LastCommitSearchFilter: SearchFilter {
+struct LastActiveSearchFilter: SearchFilter {
     static var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
@@ -250,7 +250,7 @@ struct LastCommitSearchFilter: SearchFilter {
         return formatter
     }()
     
-    static var key: String = "last_commit"
+    static var key: String = "last_active"
     
     let comparison: SearchFilterComparison
     let date: Date
@@ -266,7 +266,7 @@ struct LastCommitSearchFilter: SearchFilter {
     
     func `where`(_ builder: SQLPredicateGroupBuilder) -> SQLPredicateGroupBuilder {
         builder.where(
-            SQLIdentifier("last_commit_date"),
+            SQLIdentifier("last_activity_at"),
             comparison.binaryOperator(),
             date
         )

--- a/Sources/App/Core/SearchFilter.swift
+++ b/Sources/App/Core/SearchFilter.swift
@@ -235,10 +235,10 @@ struct LicenseSearchFilter: SearchFilter {
 ///
 /// Examples:
 /// ```
-/// last_activity:2020-07-01  - Last active on exactly July 1st 2020
-/// last_activity:!2020-07-01 - Last active on any day other than July 1st 2020
-/// last_activity:>2020-07-01 - Last active on any day more recent than July 1st 2020
-/// last_activity:<2020-07-01 - Last active on any day older than July 1st 2020
+/// last_activity:2020-07-01  - Last maintenance activity on exactly July 1st 2020
+/// last_activity:!2020-07-01 - Last maintenance activity on any day other than July 1st 2020
+/// last_activity:>2020-07-01 - Last maintenance activity on any day more recent than July 1st 2020
+/// last_activity:<2020-07-01 - Last maintenance activity on any day older than July 1st 2020
 /// ```
 struct LastActivitySearchFilter: SearchFilter {
     static var dateFormatter: DateFormatter = {

--- a/Sources/App/Core/SearchFilter.swift
+++ b/Sources/App/Core/SearchFilter.swift
@@ -37,7 +37,7 @@ struct SearchFilterParser {
     static var allSearchFilters: [SearchFilter.Type] = [
         StarsSearchFilter.self,
         LicenseSearchFilter.self,
-        LastActiveSearchFilter.self,
+        LastActivitySearchFilter.self,
     ]
     
     /// Separates search terms from filter syntax.
@@ -235,12 +235,12 @@ struct LicenseSearchFilter: SearchFilter {
 ///
 /// Examples:
 /// ```
-/// last_active:2020-07-01  - Last active on exactly July 1st 2020
-/// last_active:!2020-07-01 - Last active on any day other than July 1st 2020
-/// last_active:>2020-07-01 - Last active on any day more recent than July 1st 2020
-/// last_active:<2020-07-01 - Last active on any day older than July 1st 2020
+/// last_activity:2020-07-01  - Last active on exactly July 1st 2020
+/// last_activity:!2020-07-01 - Last active on any day other than July 1st 2020
+/// last_activity:>2020-07-01 - Last active on any day more recent than July 1st 2020
+/// last_activity:<2020-07-01 - Last active on any day older than July 1st 2020
 /// ```
-struct LastActiveSearchFilter: SearchFilter {
+struct LastActivitySearchFilter: SearchFilter {
     static var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
@@ -250,7 +250,7 @@ struct LastActiveSearchFilter: SearchFilter {
         return formatter
     }()
     
-    static var key: String = "last_active"
+    static var key: String = "last_activity"
     
     let comparison: SearchFilterComparison
     let date: Date

--- a/Tests/AppTests/AppTestCase.swift
+++ b/Tests/AppTests/AppTestCase.swift
@@ -65,7 +65,7 @@ extension AppTestCase {
         query?.serialize(to: &serializer)
         return serializer.binds.reduce(into: []) { result, bind in
             if let bind = bind as? String { result.append(bind) }
-            if let bind = bind as? Date { result.append(LastActiveSearchFilter.dateFormatter.string(from: bind)) }
+            if let bind = bind as? Date { result.append(LastActivitySearchFilter.dateFormatter.string(from: bind)) }
             if let bind = bind as? Int { result.append(String(bind)) }
         }
     }

--- a/Tests/AppTests/AppTestCase.swift
+++ b/Tests/AppTests/AppTestCase.swift
@@ -65,7 +65,7 @@ extension AppTestCase {
         query?.serialize(to: &serializer)
         return serializer.binds.reduce(into: []) { result, bind in
             if let bind = bind as? String { result.append(bind) }
-            if let bind = bind as? Date { result.append(LastCommitSearchFilter.dateFormatter.string(from: bind)) }
+            if let bind = bind as? Date { result.append(LastActiveSearchFilter.dateFormatter.string(from: bind)) }
             if let bind = bind as? Int { result.append(String(bind)) }
         }
     }

--- a/Tests/AppTests/SearchFilterTests.swift
+++ b/Tests/AppTests/SearchFilterTests.swift
@@ -26,7 +26,7 @@ class SearchFilterTests: AppTestCase {
                 .allSearchFilters
                 .map { $0.key }
                 .sorted(),
-            [ "last_commit", "license", "stars" ]
+            [ "last_active", "license", "stars" ]
         )
     }
     
@@ -149,16 +149,16 @@ class SearchFilterTests: AppTestCase {
     }
     
     func test_lastCommitFilter() throws {
-        XCTAssertEqual(LastCommitSearchFilter.key, "last_commit")
-        XCTAssertThrowsError(try LastCommitSearchFilter(value: "23rd June 2021", comparison: .match))
-        XCTAssertEqual(try LastCommitSearchFilter(value: "1970-01-01", comparison: .match).date, .t0)
+        XCTAssertEqual(LastActiveSearchFilter.key, "last_active")
+        XCTAssertThrowsError(try LastActiveSearchFilter(value: "23rd June 2021", comparison: .match))
+        XCTAssertEqual(try LastActiveSearchFilter(value: "1970-01-01", comparison: .match).date, .t0)
 
-        let filter = try LastCommitSearchFilter(value: "1970-01-01", comparison: .match)
+        let filter = try LastActiveSearchFilter(value: "1970-01-01", comparison: .match)
         let builder = SQLSelectBuilder(on: app.db as! SQLDatabase)
             .where(searchFilters: [filter])
         let sql = renderSQL(builder, resolveBinds: true)
         _assertInlineSnapshot(matching: sql, as: .lines, with: """
-        SELECT  WHERE ("last_commit_date" = '1970-01-01')
+        SELECT  WHERE ("last_activity_at" = '1970-01-01')
         """)
     }
     

--- a/Tests/AppTests/SearchFilterTests.swift
+++ b/Tests/AppTests/SearchFilterTests.swift
@@ -26,7 +26,7 @@ class SearchFilterTests: AppTestCase {
                 .allSearchFilters
                 .map { $0.key }
                 .sorted(),
-            [ "last_active", "license", "stars" ]
+            [ "last_activity", "license", "stars" ]
         )
     }
     
@@ -149,11 +149,11 @@ class SearchFilterTests: AppTestCase {
     }
     
     func test_lastCommitFilter() throws {
-        XCTAssertEqual(LastActiveSearchFilter.key, "last_active")
-        XCTAssertThrowsError(try LastActiveSearchFilter(value: "23rd June 2021", comparison: .match))
-        XCTAssertEqual(try LastActiveSearchFilter(value: "1970-01-01", comparison: .match).date, .t0)
+        XCTAssertEqual(LastActivitySearchFilter.key, "last_activity")
+        XCTAssertThrowsError(try LastActivitySearchFilter(value: "23rd June 2021", comparison: .match))
+        XCTAssertEqual(try LastActivitySearchFilter(value: "1970-01-01", comparison: .match).date, .t0)
 
-        let filter = try LastActiveSearchFilter(value: "1970-01-01", comparison: .match)
+        let filter = try LastActivitySearchFilter(value: "1970-01-01", comparison: .match)
         let builder = SQLSelectBuilder(on: app.db as! SQLDatabase)
             .where(searchFilters: [filter])
         let sql = renderSQL(builder, resolveBinds: true)


### PR DESCRIPTION
Merge after #1389
Fixes #1303 

I can see an argument to have both of these available, but I think until the feature is finished we should keep things simple. Changing this from last commit to last activity as I think that's a more useful filter parameter.