### PR TITLE
Seven less optionals on Repository!

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -365,7 +365,7 @@ func updateRepository(on database: Database, package: Joined<Package, Repository
         )
     }
 
-    repo.commitCount = try? Current.git.commitCount(gitDirectory)
+    repo.commitCount = (try? Current.git.commitCount(gitDirectory)) ?? 0
     repo.firstCommitDate = try? Current.git.firstCommitDate(gitDirectory)
     repo.lastCommitDate = try? Current.git.lastCommitDate(gitDirectory)
 

--- a/Sources/App/Core/Score.swift
+++ b/Sources/App/Core/Score.swift
@@ -60,14 +60,13 @@ enum Score {
     static func compute(package: Joined<Package, Repository>, versions: [Version]) -> Int {
         guard
             let defaultVersion = versions.latest(for: .defaultBranch),
-            let repo = package.repository,
-            let starsCount = repo.stars
+            let repo = package.repository
         else { return 0 }
         return Score.compute(
             .init(supportsLatestSwiftVersion: defaultVersion.supportsMajorSwiftVersion(SwiftVersion.latestMajor),
                   licenseKind: repo.license.licenseKind,
                   releaseCount: versions.releases.count,
-                  likeCount: starsCount,
+                  likeCount: repo.stars,
                   isArchived: repo.isArchived ?? false)
         )
     }

--- a/Sources/App/Core/Score.swift
+++ b/Sources/App/Core/Score.swift
@@ -67,7 +67,7 @@ enum Score {
                   licenseKind: repo.license.licenseKind,
                   releaseCount: versions.releases.count,
                   likeCount: repo.stars,
-                  isArchived: repo.isArchived ?? false)
+                  isArchived: repo.isArchived)
         )
     }
 }

--- a/Sources/App/Migrations/037/UpdateRepositoryCommitCountNotNullable.swift
+++ b/Sources/App/Migrations/037/UpdateRepositoryCommitCountNotNullable.swift
@@ -1,0 +1,52 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateRepositoryCommitCountNotNullable: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"UPDATE "repositories" SET "commit_count" = 0 WHERE "commit_count" IS NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "commit_count" SET DEFAULT 0"#
+                ).run()
+            }.flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "commit_count" SET NOT NULL"#
+                ).run()
+            }
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"ALTER TABLE "repositories" ALTER COLUMN "commit_count" DROP NOT NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "commit_count" DROP DEFAULT"#
+                ).run()
+            }
+        }
+    }
+}

--- a/Sources/App/Migrations/037/UpdateRepositoryForksNotNullable.swift
+++ b/Sources/App/Migrations/037/UpdateRepositoryForksNotNullable.swift
@@ -1,0 +1,52 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateRepositoryForksNotNullable: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"UPDATE "repositories" SET "forks" = 0 WHERE "forks" IS NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "forks" SET DEFAULT 0"#
+                ).run()
+            }.flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "forks" SET NOT NULL"#
+                ).run()
+            }
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"ALTER TABLE "repositories" ALTER COLUMN "forks" DROP NOT NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "forks" DROP DEFAULT"#
+                ).run()
+            }
+        }
+    }
+}

--- a/Sources/App/Migrations/037/UpdateRepositoryIsArchivedNotNullable.swift
+++ b/Sources/App/Migrations/037/UpdateRepositoryIsArchivedNotNullable.swift
@@ -1,0 +1,52 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateRepositoryIsArchivedNotNullable: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"UPDATE "repositories" SET "is_archived" = false WHERE "is_archived" IS NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "is_archived" SET DEFAULT false"#
+                ).run()
+            }.flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "is_archived" SET NOT NULL"#
+                ).run()
+            }
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"ALTER TABLE "repositories" ALTER COLUMN "is_archived" DROP NOT NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "is_archived" DROP DEFAULT"#
+                ).run()
+            }
+        }
+    }
+}

--- a/Sources/App/Migrations/037/UpdateRepositoryIsInOrganizationNotNullable.swift
+++ b/Sources/App/Migrations/037/UpdateRepositoryIsInOrganizationNotNullable.swift
@@ -1,0 +1,52 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateRepositoryIsInOrganizationNotNullable: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"UPDATE "repositories" SET "is_in_organization" = false WHERE "is_in_organization" IS NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "is_in_organization" SET DEFAULT false"#
+                ).run()
+            }.flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "is_in_organization" SET NOT NULL"#
+                ).run()
+            }
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"ALTER TABLE "repositories" ALTER COLUMN "is_in_organization" DROP NOT NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "is_in_organization" DROP DEFAULT"#
+                ).run()
+            }
+        }
+    }
+}

--- a/Sources/App/Migrations/037/UpdateRepositoryOpenIssuesNotNullable.swift
+++ b/Sources/App/Migrations/037/UpdateRepositoryOpenIssuesNotNullable.swift
@@ -1,0 +1,52 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateRepositoryOpenIssuesNotNullable: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"UPDATE "repositories" SET "open_issues" = 0 WHERE "open_issues" IS NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "open_issues" SET DEFAULT 0"#
+                ).run()
+            }.flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "open_issues" SET NOT NULL"#
+                ).run()
+            }
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"ALTER TABLE "repositories" ALTER COLUMN "open_issues" DROP NOT NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "open_issues" DROP DEFAULT"#
+                ).run()
+            }
+        }
+    }
+}

--- a/Sources/App/Migrations/037/UpdateRepositoryOpenPullRequestsNotNullable.swift
+++ b/Sources/App/Migrations/037/UpdateRepositoryOpenPullRequestsNotNullable.swift
@@ -1,0 +1,52 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateRepositoryOpenPullRequestsNotNullable: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"UPDATE "repositories" SET "open_pull_requests" = 0 WHERE "open_pull_requests" IS NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "open_pull_requests" SET DEFAULT 0"#
+                ).run()
+            }.flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "open_pull_requests" SET NOT NULL"#
+                ).run()
+            }
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"ALTER TABLE "repositories" ALTER COLUMN "open_pull_requests" DROP NOT NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "open_pull_requests" DROP DEFAULT"#
+                ).run()
+            }
+        }
+    }
+}

--- a/Sources/App/Migrations/037/UpdateRepositoryStarsNotNullable.swift
+++ b/Sources/App/Migrations/037/UpdateRepositoryStarsNotNullable.swift
@@ -1,0 +1,52 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateRepositoryStarsNotNullable: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"UPDATE "repositories" SET "stars" = 0 WHERE "stars" IS NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "stars" SET DEFAULT 0"#
+                ).run()
+            }.flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "stars" SET NOT NULL"#
+                ).run()
+            }
+        }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.transaction { tx in
+            guard let db = tx as? SQLDatabase else {
+                fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+            }
+            return db.raw(
+                #"ALTER TABLE "repositories" ALTER COLUMN "stars" DROP NOT NULL"#
+            ).run().flatMap {
+                db.raw(
+                    #"ALTER TABLE "repositories" ALTER COLUMN "stars" DROP DEFAULT"#
+                ).run()
+            }
+        }
+    }
+}

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -61,7 +61,7 @@ final class Repository: Model, Content {
     var isArchived: Bool
 
     @Field(key: "is_in_organization")
-    var isInOrganization: Bool?
+    var isInOrganization: Bool
 
     @Field(key: "keywords")
     var keywords: [String]
@@ -127,7 +127,7 @@ final class Repository: Model, Content {
          forks: Int = 0,
          forkedFrom: Repository? = nil,
          isArchived: Bool = false,
-         isInOrganization: Bool? = nil,
+         isInOrganization: Bool = false,
          keywords: [String] = [],
          lastCommitDate: Date? = nil,
          lastIssueClosedAt: Date? = nil,

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -124,7 +124,7 @@ final class Repository: Model, Content {
          commitCount: Int? = nil,
          defaultBranch: String? = nil,
          firstCommitDate: Date? = nil,
-         forks: Int? = nil,
+         forks: Int = 0,
          forkedFrom: Repository? = nil,
          isArchived: Bool? = nil,
          isInOrganization: Bool? = nil,

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -88,7 +88,7 @@ final class Repository: Model, Content {
     var openIssues: Int?
 
     @Field(key: "open_pull_requests")
-    var openPullRequests: Int?
+    var openPullRequests: Int
 
     @Field(key: "owner")
     var owner: String?
@@ -136,7 +136,7 @@ final class Repository: Model, Content {
          licenseUrl: String? = nil,
          name: String? = nil,
          openIssues: Int = 0,
-         openPullRequests: Int? = nil,
+         openPullRequests: Int = 0,
          owner: String? = nil,
          ownerName: String? = nil,
          ownerAvatarUrl: String? = nil,

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -135,7 +135,7 @@ final class Repository: Model, Content {
          license: License = .none,
          licenseUrl: String? = nil,
          name: String? = nil,
-         openIssues: Int? = nil,
+         openIssues: Int = 0,
          openPullRequests: Int? = nil,
          owner: String? = nil,
          ownerName: String? = nil,

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -55,7 +55,7 @@ final class Repository: Model, Content {
     var firstCommitDate: Date?
     
     @Field(key: "forks")
-    var forks: Int?
+    var forks: Int
 
     @Field(key: "is_archived")
     var isArchived: Bool?
@@ -85,7 +85,7 @@ final class Repository: Model, Content {
     var name: String?
 
     @Field(key: "open_issues")
-    var openIssues: Int?
+    var openIssues: Int
 
     @Field(key: "open_pull_requests")
     var openPullRequests: Int

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -58,7 +58,7 @@ final class Repository: Model, Content {
     var forks: Int
 
     @Field(key: "is_archived")
-    var isArchived: Bool?
+    var isArchived: Bool
 
     @Field(key: "is_in_organization")
     var isInOrganization: Bool?
@@ -126,7 +126,7 @@ final class Repository: Model, Content {
          firstCommitDate: Date? = nil,
          forks: Int = 0,
          forkedFrom: Repository? = nil,
-         isArchived: Bool? = nil,
+         isArchived: Bool = false,
          isInOrganization: Bool? = nil,
          keywords: [String] = [],
          lastCommitDate: Date? = nil,

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -46,7 +46,7 @@ final class Repository: Model, Content {
     var authors: [Author]
     
     @Field(key: "commit_count")
-    var commitCount: Int?
+    var commitCount: Int
     
     @Field(key: "default_branch")
     var defaultBranch: String?
@@ -121,7 +121,7 @@ final class Repository: Model, Content {
     init(id: Id? = nil,
          package: Package,
          authors: [Author] = [],
-         commitCount: Int? = nil,
+         commitCount: Int = 0,
          defaultBranch: String? = nil,
          firstCommitDate: Date? = nil,
          forks: Int = 0,

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -109,7 +109,7 @@ final class Repository: Model, Content {
     var releases: [Release]
 
     @Field(key: "stars")
-    var stars: Int?
+    var stars: Int
 
     @Field(key: "summary")
     var summary: String?
@@ -143,7 +143,7 @@ final class Repository: Model, Content {
          readmeUrl: String? = nil,
          readmeHtmlUrl: String? = nil,
          releases: [Release] = [],
-         stars: Int? = nil,
+         stars: Int = 0,
          summary: String? = nil
     ) throws {
         self.id = id

--- a/Sources/App/Views/PackageController/PackageResult+ModelSupport.swift
+++ b/Sources/App/Views/PackageController/PackageResult+ModelSupport.swift
@@ -27,14 +27,13 @@ extension PackageController.PackageResult {
         let releases = versions.filter({ $0.reference?.isRelease ?? false })
         guard
             let repo = repository,
-            let commitCount = repo.commitCount,
             let defaultBranch = repo.defaultBranch,
             let firstCommitDate = repo.firstCommitDate,
-            let commitCountString = Self.numberFormatter.string(from: NSNumber(value: commitCount)),
+            let commitCountString = Self.numberFormatter.string(from: NSNumber(value: repo.commitCount)),
             let releaseCountString = Self.numberFormatter.string(from: NSNumber(value: releases.count))
         else { return nil }
         let cl = Link(
-            label: commitCountString + " commit".pluralized(for: commitCount),
+            label: commitCountString + " commit".pluralized(for: repo.commitCount),
             url: package.url.droppingGitExtension + "/commits/\(defaultBranch)")
         let rl = Link(
             label: releaseCountString + " release".pluralized(for: releases.count),

--- a/Sources/App/Views/PackageController/PackageResult+ModelSupport.swift
+++ b/Sources/App/Views/PackageController/PackageResult+ModelSupport.swift
@@ -46,17 +46,16 @@ extension PackageController.PackageResult {
     func activity() -> PackageShow.Model.Activity? {
         guard
             let repo = repository,
-            repo.openIssues != nil || repo.openPullRequests != nil || repo.lastPullRequestClosedAt != nil
+            repo.lastPullRequestClosedAt != nil
         else { return nil }
-        let openIssues = repo.openIssues.map {
-            Link(label: pluralizedCount($0, singular: "open issue"), url: package.url.droppingGitExtension + "/issues")
-        }
-        let openPRs = repo.openPullRequests.map {
-            Link(label: pluralizedCount($0, singular: "open pull request"), url: package.url.droppingGitExtension + "/pulls")
-        }
+
+        let openIssues = Link(label: pluralizedCount(repo.openIssues, singular: "open issue"),
+                              url: package.url.droppingGitExtension + "/issues")
+        let openPRs = Link(label: pluralizedCount(repo.openPullRequests, singular: "open pull request"),
+                           url: package.url.droppingGitExtension + "/pulls")
         let lastIssueClosed = repo.lastIssueClosedAt.map { "\(date: $0, relativeTo: Current.date())" }
         let lastPRClosed = repo.lastPullRequestClosedAt.map { "\(date: $0, relativeTo: Current.date())" }
-        return .init(openIssuesCount: repo.openIssues ?? 0,
+        return .init(openIssuesCount: repo.openIssues,
                      openIssues: openIssues,
                      openPullRequests: openPRs,
                      lastIssueClosedAt: lastIssueClosed,

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -124,7 +124,7 @@ extension PackageShow {
                 title: versions.packageName() ?? repositoryName,
                 url: result.package.url,
                 score: result.package.score,
-                isArchived: repository.isArchived ?? false
+                isArchived: repository.isArchived
             )
 
         }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -184,6 +184,7 @@ public func configure(_ app: Application) throws {
     do {  // Migration 037 - make repositories.stars and repositories.forks required
         app.migrations.add(UpdateRepositoryStarsNotNullable())
         app.migrations.add(UpdateRepositoryForksNotNullable())
+        app.migrations.add(UpdateRepositoryCommitCountNotNullable())
     }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -181,6 +181,9 @@ public func configure(_ app: Application) throws {
     do {  // Migration 036 - make packages.score required
         app.migrations.add(UpdatePackageScoreNotNullable())
     }
+    do {  // Migration 037 - make repositories.stars required
+        app.migrations.add(UpdateRepositoryStarsNotNullable())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -181,8 +181,9 @@ public func configure(_ app: Application) throws {
     do {  // Migration 036 - make packages.score required
         app.migrations.add(UpdatePackageScoreNotNullable())
     }
-    do {  // Migration 037 - make repositories.stars required
+    do {  // Migration 037 - make repositories.stars and repositories.forks required
         app.migrations.add(UpdateRepositoryStarsNotNullable())
+        app.migrations.add(UpdateRepositoryForksNotNullable())
     }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -188,6 +188,7 @@ public func configure(_ app: Application) throws {
         app.migrations.add(UpdateRepositoryOpenIssuesNotNullable())
         app.migrations.add(UpdateRepositoryOpenPullRequestsNotNullable())
         app.migrations.add(UpdateRepositoryIsArchivedNotNullable())
+        app.migrations.add(UpdateRepositoryIsInOrganizationNotNullable())
     }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -186,6 +186,7 @@ public func configure(_ app: Application) throws {
         app.migrations.add(UpdateRepositoryForksNotNullable())
         app.migrations.add(UpdateRepositoryCommitCountNotNullable())
         app.migrations.add(UpdateRepositoryOpenIssuesNotNullable())
+        app.migrations.add(UpdateRepositoryOpenPullRequestsNotNullable())
     }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -181,12 +181,13 @@ public func configure(_ app: Application) throws {
     do {  // Migration 036 - make packages.score required
         app.migrations.add(UpdatePackageScoreNotNullable())
     }
-    do {  // Migration 037 - make repositories.stars and repositories.forks required
+    do {  // Migration 037 - make several columns on repositories required
         app.migrations.add(UpdateRepositoryStarsNotNullable())
         app.migrations.add(UpdateRepositoryForksNotNullable())
         app.migrations.add(UpdateRepositoryCommitCountNotNullable())
         app.migrations.add(UpdateRepositoryOpenIssuesNotNullable())
         app.migrations.add(UpdateRepositoryOpenPullRequestsNotNullable())
+        app.migrations.add(UpdateRepositoryIsArchivedNotNullable())
     }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -185,6 +185,7 @@ public func configure(_ app: Application) throws {
         app.migrations.add(UpdateRepositoryStarsNotNullable())
         app.migrations.add(UpdateRepositoryForksNotNullable())
         app.migrations.add(UpdateRepositoryCommitCountNotNullable())
+        app.migrations.add(UpdateRepositoryOpenIssuesNotNullable())
     }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -44,7 +44,7 @@ class IngestorTests: AppTestCase {
             XCTAssertNotNil($0.description)
             XCTAssertEqual($0.defaultBranch, "main")
             XCTAssert($0.forks != nil && $0.forks! > 0)
-            XCTAssert($0.stars != nil && $0.stars! > 0)
+            XCTAssert($0.stars > 0)
         }
         // assert packages have been updated
         (try Package.query(on: app.db).all().wait()).forEach {

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -43,7 +43,7 @@ class IngestorTests: AppTestCase {
             XCTAssertNotNil($0.updatedAt)
             XCTAssertNotNil($0.description)
             XCTAssertEqual($0.defaultBranch, "main")
-            XCTAssert($0.forks != nil && $0.forks! > 0)
+            XCTAssert($0.forks > 0)
             XCTAssert($0.stars > 0)
         }
         // assert packages have been updated


### PR DESCRIPTION
I've done my chores for today! 🧹

⚠️ SCHEMA CHANGE ⚠️

This changes the following fields to have default values and `NOT NULL` constraints in the database, removing several optionals in the `Repositories` model:

* `stars`
* `forks`
* `commit_count`
* `open_issues`
* `open_pull_requests`
* `is_archived`
* `is_organization`

I also checked the `packages`, `versions`, `products`, and `targets` tables/models but they don't have any suitable fields.