### PR TITLE
Add support for light/dark mode images in READMEs

### DIFF
--- a/Resources/Styles/readme.scss
+++ b/Resources/Styles/readme.scss
@@ -101,3 +101,15 @@ g-emoji {
     vertical-align: -.075em;
     margin-right: -10px;
 }
+
+@media (prefers-color-scheme: light) {
+  [href$="#gh-dark-mode-only"] {
+    display: none;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  [href$="#gh-light-mode-only"] {
+    display: none;
+  }
+}


### PR DESCRIPTION
Closes #1398 / #1397 

Example for testing manually: http://localhost:8080/FluxorOrg/Fluxor

Wonder if it's possible to do a snapshot test to prove this works. I don't think that strictly mocks out the media mode though?