### PR TITLE
Search Filter Metrics

### DIFF
--- a/Sources/App/Core/AppMetrics.swift
+++ b/Sources/App/Core/AppMetrics.swift
@@ -105,6 +105,22 @@ enum AppMetrics {
     static var apiSearchGetTotal: PromCounter<Int, EmptyLabels>? {
         counter("spi_api_search_get_total", EmptyLabels.self)
     }
+    
+    static var apiSearchGetWithFilterTotal: PromCounter<Int, EmptyLabels>? {
+        counter("spi_api_search_get_with_filter_total", EmptyLabels.self)
+    }
+    
+    static func apiSearchGetWithFilterTotal(key: String) -> PromCounter<Int, EmptyLabels>? {
+        counter("spi_api_search_get_with_filter_\(key)_total", EmptyLabels.self)
+    }
+    
+    static var searchTermsCount: PromGauge<Int, EmptyLabels>? {
+        gauge("spi_search_terms_count", EmptyLabels.self)
+    }
+    
+    static var searchFiltersCount: PromGauge<Int, EmptyLabels>? {
+        gauge("spi_search_filters_count", EmptyLabels.self)
+    }
 
     static var buildCandidatesCount: PromGauge<Int, EmptyLabels>? {
         gauge("spi_build_candidates_count", EmptyLabels.self)

--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -278,10 +278,6 @@ enum Search {
         let (sanitizedTerms, filters) = SearchFilterParser().split(terms: sanitize(terms))
         
         // Metrics
-        if filters.isEmpty == false {
-            AppMetrics.apiSearchGetWithFilterTotal?.inc()
-        }
-        
         AppMetrics.searchTermsCount?.set(sanitizedTerms.count)
         AppMetrics.searchFiltersCount?.set(filters.count)
         

--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -277,6 +277,14 @@ enum Search {
         let page = page.clamped(to: 1...)
         let (sanitizedTerms, filters) = SearchFilterParser().split(terms: sanitize(terms))
         
+        // Metrics
+        if filters.isEmpty == false {
+            AppMetrics.apiSearchGetWithFilterTotal?.inc()
+        }
+        
+        AppMetrics.searchTermsCount?.set(sanitizedTerms.count)
+        AppMetrics.searchFiltersCount?.set(filters.count)
+        
         guard let query = query(database,
                                 sanitizedTerms,
                                 filters: filters,

--- a/Sources/App/Core/SearchFilter/SearchFilterParser.swift
+++ b/Sources/App/Core/SearchFilter/SearchFilterParser.swift
@@ -77,9 +77,13 @@ struct SearchFilterParser {
         guard !stringValue.isEmpty else { return nil }
         
         // Filter
-        return try? allFilters
-            .first(where: { $0.key == components[0] })?
-            .init(value: stringValue, comparison: comparison.value)
+        guard let matchingFilter = allFilters.first(where: { $0.key == components[0] }) else {
+            return nil
+        }
+        
+        AppMetrics.apiSearchGetWithFilterTotal(key: matchingFilter.key)?.inc()
+        
+        return try? matchingFilter.init(value: stringValue, comparison: comparison.value)
     }
     
 }


### PR DESCRIPTION
Based on https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/discussions/1403#discussioncomment-1728037

Adds four new metrics. The intention is to track the usage of each filter (and filters in general) as well as how many filters/terms are used in each search query. We already track the number of searches in order to build a percentage.

Not sure if the gauge is correctly implemented but the counters seem fine. Looking for some reviews to guide on this.