### PR TITLE
Switch search filter to use binds instead of string literals

### DIFF
--- a/Sources/App/Core/SearchFilter/Filters/AuthorSearchFilter.swift
+++ b/Sources/App/Core/SearchFilter/Filters/AuthorSearchFilter.swift
@@ -41,7 +41,7 @@ struct AuthorSearchFilter: SearchFilter {
         builder.where(
             SQLIdentifier("repo_owner"),
             comparison == .match ? SQLRaw("ILIKE") : SQLRaw("NOT ILIKE"),
-            SQLLiteral.string(value)
+            SQLBind(value)
         )
     }
     

--- a/Sources/App/Core/SearchFilter/Filters/KeywordSearchFilter.swift
+++ b/Sources/App/Core/SearchFilter/Filters/KeywordSearchFilter.swift
@@ -41,7 +41,7 @@ struct KeywordSearchFilter: SearchFilter {
         builder.where(
             SQLIdentifier("keyword"),
             comparison == .match ? SQLRaw("ILIKE") : SQLRaw("NOT ILIKE"),
-            SQLLiteral.string("%\(value)%")
+            SQLBind("%\(value)%")
         )
     }
     


### PR DESCRIPTION
Who doesn't love a bit of SQL injection in the morning? (It's the afternoon James)

Technically, we have protection elsewhere which meant this couldn't ever happen... but I've switched over to using a bind instead of a string literal for a little bit of added protection.

Checked and does all still work, even with wildcards (%) in filters, but you can't execute your own commands now. Suppose that's a win?