### PR TITLE
Add support for none/other license searches

### DIFF
--- a/Sources/App/Core/SearchFilter/Filters/LicenseSearchFilter.swift
+++ b/Sources/App/Core/SearchFilter/Filters/LicenseSearchFilter.swift
@@ -25,12 +25,12 @@ import SQLKit
 /// ```
 struct LicenseSearchFilter: SearchFilter {
     enum FilterType: Equatable {
-        case appStoreCompatible
+        case kind(License.Kind)
         case license(License)
         
         init?(rawValue: String) {
-            if rawValue == "compatible" {
-                self = .appStoreCompatible
+            if let kind = License.Kind(rawValue: rawValue) {
+                self = .kind(kind)
             } else if let license = License(rawValue: rawValue) {
                 self = .license(license)
             } else {
@@ -59,11 +59,11 @@ struct LicenseSearchFilter: SearchFilter {
     
     func `where`(_ builder: SQLPredicateGroupBuilder) -> SQLPredicateGroupBuilder {
         switch filterType {
-            case .appStoreCompatible:
+            case .kind(let kind):
                 return builder.where(
                     SQLIdentifier("license"),
                     comparison.binaryOperator(isSet: true),
-                    License.withKind { $0 == .compatibleWithAppStore }
+                    License.withKind { $0 == kind }
                 )
                 
             case .license(let license):
@@ -77,8 +77,8 @@ struct LicenseSearchFilter: SearchFilter {
     
     func createViewModel() -> SearchFilterViewModel {
         switch filterType {
-        case .appStoreCompatible:
-            return .init(key: Self.key, comparison: comparison, value: "App Store compatible")
+        case .kind(let kind):
+            return .init(key: Self.key, comparison: comparison, value: kind.userFacingString)
         case .license(let license):
             return .init(key: Self.key, comparison: comparison, value: license.shortName)
         }

--- a/Sources/App/Core/SearchFilter/SearchFilter.swift
+++ b/Sources/App/Core/SearchFilter/SearchFilter.swift
@@ -67,8 +67,8 @@ enum SearchFilterComparison: String, Codable, Equatable {
     
     var userFacingString: String {
         switch self {
-        case .match: return "matches"
-        case .negativeMatch: return "does not match"
+        case .match: return "is"
+        case .negativeMatch: return "is not"
         case .greaterThan: return "is greater than"
         case .greaterThanOrEqual: return "is greather than or equal to"
         case .lessThan: return "is less than"

--- a/Sources/App/Models/License.swift
+++ b/Sources/App/Models/License.swift
@@ -154,10 +154,10 @@ enum License: String, Codable, Equatable, CaseIterable {
         
         var userFacingString: String {
             switch self {
-            case .none: return License.none.shortName
-            case .other: return License.other.shortName
-            case .incompatibleWithAppStore: return "App Store incompatible"
-            case .compatibleWithAppStore: return "App Store compatible"
+            case .none: return "not defined"
+            case .other: return "unknown"
+            case .incompatibleWithAppStore: return "incompatible with the App Store"
+            case .compatibleWithAppStore: return "compatible with the App Store"
             }
         }
     }

--- a/Sources/App/Models/License.swift
+++ b/Sources/App/Models/License.swift
@@ -151,6 +151,15 @@ enum License: String, Codable, Equatable, CaseIterable {
         case other
         case incompatibleWithAppStore = "incompatible"
         case compatibleWithAppStore = "compatible"
+        
+        var userFacingString: String {
+            switch self {
+            case .none: return License.none.shortName
+            case .other: return License.other.shortName
+            case .incompatibleWithAppStore: return "App Store incompatible"
+            case .compatibleWithAppStore: return "App Store compatible"
+            }
+        }
     }
     
     static func withKind(_ predicate: (Kind) -> Bool) -> [String] {

--- a/Tests/AppTests/SearchFilterTests.swift
+++ b/Tests/AppTests/SearchFilterTests.swift
@@ -141,26 +141,32 @@ class SearchFilterTests: AppTestCase {
             "license matches App Store compatible"
         )
         
-        do {
-            let filter = try LicenseSearchFilter(value: "compatible", comparison: .match)
+        func createLicenseQuery(input: String, comparison: SearchFilterComparison = .match) throws -> String {
+            let filter = try LicenseSearchFilter(value: input, comparison: comparison)
             let builder = SQLSelectBuilder(on: app.db as! SQLDatabase)
                 .where(searchFilters: [filter])
-            let sql = renderSQL(builder, resolveBinds: true)
-            _assertInlineSnapshot(matching: sql, as: .lines, with: """
-            SELECT  WHERE ("license" IN ('afl-3.0', 'apache-2.0', 'artistic-2.0', 'bsd-2-clause', 'bsd-3-clause', 'bsd-3-clause-clear', 'bsl-1.0', 'cc', 'cc0-1.0', 'afl-3.0'0, 'afl-3.0'1, 'afl-3.0'2, 'afl-3.0'3, 'afl-3.0'4, 'afl-3.0'5, 'afl-3.0'6, 'afl-3.0'7, 'afl-3.0'8, 'afl-3.0'9, 'apache-2.0'0, 'apache-2.0'1, 'apache-2.0'2, 'apache-2.0'3, 'apache-2.0'4))
-            """)
+            return renderSQL(builder, resolveBinds: true)
         }
         
-        do {
-            let filter = try LicenseSearchFilter(value: "mit", comparison: .match)
-            let builder = SQLSelectBuilder(on: app.db as! SQLDatabase)
-                .where(searchFilters: [filter])
-            let sql = renderSQL(builder, resolveBinds: true)
-            _assertInlineSnapshot(matching: sql, as: .lines, with: """
-            SELECT  WHERE ("license" = 'mit')
-            """)
-        }
+        try _assertInlineSnapshot(matching: createLicenseQuery(input: "compatible"), as: .lines, with: """
+        SELECT  WHERE ("license" IN ('afl-3.0', 'apache-2.0', 'artistic-2.0', 'bsd-2-clause', 'bsd-3-clause', 'bsd-3-clause-clear', 'bsl-1.0', 'cc', 'cc0-1.0', 'afl-3.0'0, 'afl-3.0'1, 'afl-3.0'2, 'afl-3.0'3, 'afl-3.0'4, 'afl-3.0'5, 'afl-3.0'6, 'afl-3.0'7, 'afl-3.0'8, 'afl-3.0'9, 'apache-2.0'0, 'apache-2.0'1, 'apache-2.0'2, 'apache-2.0'3, 'apache-2.0'4))
+        """)
         
+        try _assertInlineSnapshot(matching: createLicenseQuery(input: "mit"), as: .lines, with: """
+        SELECT  WHERE ("license" = 'mit')
+        """)
+        
+        try _assertInlineSnapshot(matching: createLicenseQuery(input: "incompatible"), as: .lines, with: """
+        SELECT  WHERE ("license" IN ('agpl-3.0', 'gpl', 'gpl-2.0', 'gpl-3.0', 'lgpl', 'lgpl-2.1', 'lgpl-3.0'))
+        """)
+        
+        try _assertInlineSnapshot(matching: createLicenseQuery(input: "none"), as: .lines, with: """
+        SELECT  WHERE ("license" IN ('none'))
+        """)
+        
+        try _assertInlineSnapshot(matching: createLicenseQuery(input: "other"), as: .lines, with: """
+        SELECT  WHERE ("license" IN ('other'))
+        """)
     }
     
     func test_lastCommitFilter() throws {

--- a/Tests/AppTests/SearchFilterTests.swift
+++ b/Tests/AppTests/SearchFilterTests.swift
@@ -135,7 +135,7 @@ class SearchFilterTests: AppTestCase {
     func test_licenseFilter() throws {
         XCTAssertEqual(LicenseSearchFilter.key, "license")
         XCTAssertThrowsError(try LicenseSearchFilter(value: "compatible", comparison: .greaterThan))
-        XCTAssertEqual(try LicenseSearchFilter(value: "compatible", comparison: .match).filterType, .appStoreCompatible)
+        XCTAssertEqual(try LicenseSearchFilter(value: "compatible", comparison: .match).filterType, .kind(.compatibleWithAppStore))
         XCTAssertEqual(
             try LicenseSearchFilter(value: "compatible", comparison: .match).createViewModel().description,
             "license matches App Store compatible"

--- a/Tests/AppTests/SearchFilterTests.swift
+++ b/Tests/AppTests/SearchFilterTests.swift
@@ -120,7 +120,7 @@ class SearchFilterTests: AppTestCase {
         XCTAssertEqual(try StarsSearchFilter(value: "1", comparison: .match).value, 1)
         XCTAssertEqual(
             try StarsSearchFilter(value: "1", comparison: .match).createViewModel().description,
-            "stars matches 1"
+            "stars is 1"
         )
         
         let filter = try StarsSearchFilter(value: "1", comparison: .greaterThan)
@@ -138,7 +138,7 @@ class SearchFilterTests: AppTestCase {
         XCTAssertEqual(try LicenseSearchFilter(value: "compatible", comparison: .match).filterType, .kind(.compatibleWithAppStore))
         XCTAssertEqual(
             try LicenseSearchFilter(value: "compatible", comparison: .match).createViewModel().description,
-            "license matches App Store compatible"
+            "license is compatible with the App Store"
         )
         
         func createLicenseQuery(input: String, comparison: SearchFilterComparison = .match) throws -> String {
@@ -174,7 +174,7 @@ class SearchFilterTests: AppTestCase {
         XCTAssertEqual(try LastCommitSearchFilter(value: "1970-01-01", comparison: .match).date, .t0)
         XCTAssertEqual(
             try LastCommitSearchFilter(value: "1970-01-01", comparison: .match).createViewModel().description,
-            "last commit matches 1 Jan 1970"
+            "last commit is 1 Jan 1970"
         )
 
         let filter = try LastCommitSearchFilter(value: "1970-01-01", comparison: .match)
@@ -191,7 +191,7 @@ class SearchFilterTests: AppTestCase {
         XCTAssertEqual(try LastActivitySearchFilter(value: "1970-01-01", comparison: .match).date, .t0)
         XCTAssertEqual(
             try LastActivitySearchFilter(value: "1970-01-01", comparison: .match).createViewModel().description,
-            "last activity matches 1 Jan 1970"
+            "last activity is 1 Jan 1970"
         )
 
         let filter = try LastActivitySearchFilter(value: "1970-01-01", comparison: .match)
@@ -207,7 +207,7 @@ class SearchFilterTests: AppTestCase {
         XCTAssertThrowsError(try AuthorSearchFilter(value: "sherlouk", comparison: .greaterThan))
         XCTAssertEqual(
             try AuthorSearchFilter(value: "sherlouk", comparison: .match).createViewModel().description,
-            "author matches sherlouk"
+            "author is sherlouk"
         )
 
         let filter = try AuthorSearchFilter(value: "sherlouk", comparison: .match)
@@ -223,7 +223,7 @@ class SearchFilterTests: AppTestCase {
         XCTAssertThrowsError(try KeywordSearchFilter(value: "cache", comparison: .greaterThan))
         XCTAssertEqual(
             try KeywordSearchFilter(value: "cache", comparison: .match).createViewModel().description,
-            "keywords matches cache"
+            "keywords is cache"
         )
 
         let filter = try KeywordSearchFilter(value: "cache", comparison: .match)

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow_withFilters.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow_withFilters.1.txt
@@ -79,7 +79,7 @@
               <ul class="filter_list">
                 <li>
                   <span class="filter-key">license</span> 
-                  <span class="filter-comparison">matches</span> 
+                  <span class="filter-comparison">is</span> 
                   <span class="filter-value">mit</span>
                 </li>
               </ul>


### PR DESCRIPTION
Non-breaking tweak to filters here. Instead of handling `appStoreCompatible` directly, we use the LicenseKind enum which already exists.

By making this change, it also means we get access to the three other values: `incompatible` (this is technically a duplicate of the already functional `license:!compatible`), `none` (no license), and `other` (unknown license).

http://localhost:8080/search?query=license%3Aother
http://localhost:8080/search?query=license%3Anone

Things we couldn't do before:
```
license:!none // any license
license:none // no license
license:other // unknown license
license:!other license!none // any known license
```

edit:// correction. `license:!compatible` and `license:incompatible` are actually slightly different in a rather subtle and maybe mildly confusing way.

!compatible means that it is **not** one of the handful of known licenses that we have marked as compatible.
incompatible means that it is explicitly one of the handful of known licenses that we know is not compatible.

This means that for packages with a license of `none` or `other`, they are !compatible but not incompatible. Say that 3 times quickly.

I don't think this is a distinction we need to worry about?