### PR TITLE
Fix search filter operator typo

### DIFF
--- a/Sources/App/Core/SearchFilter/SearchFilter.swift
+++ b/Sources/App/Core/SearchFilter/SearchFilter.swift
@@ -70,7 +70,7 @@ enum SearchFilterComparison: String, Codable, Equatable {
         case .match: return "is"
         case .negativeMatch: return "is not"
         case .greaterThan: return "is greater than"
-        case .greaterThanOrEqual: return "is greather than or equal to"
+        case .greaterThanOrEqual: return "is greater than or equal to"
         case .lessThan: return "is less than"
         case .lessThanOrEqual: return "is less than or equal to"
         }


### PR DESCRIPTION
Closed #1419 off the back of Sven's review, but it contained a minor typo fix - so opening that up separately so we can get it through.