### PR TITLE
Search platform compatibility

### DIFF
--- a/Sources/App/Migrations/040/UpdatePackageAppPlatformCompatibility.swift
+++ b/Sources/App/Migrations/040/UpdatePackageAppPlatformCompatibility.swift
@@ -1,0 +1,30 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+
+
+struct UpdatePackageAppPlatformCompatibility: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("packages")
+            .field("platform_compatibility", .array(of: .string), .sql(.default("{}")))
+            .update()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("packages")
+            .deleteField("platform_compatibility")
+            .update()
+    }
+}

--- a/Sources/App/Models/Build+Platform.swift
+++ b/Sources/App/Models/Build+Platform.swift
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 extension Build {
-    enum Platform: String, Codable, Equatable {
+    enum Platform: String, Codable, Equatable, CaseIterable {
         case ios
         case macosSpmArm        = "macos-spm-arm"
         case macosXcodebuildArm = "macos-xcodebuild-arm"

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -36,7 +36,7 @@ final class Package: Model, Content {
     // data fields
 
     @Field(key: "platform_compatibility")
-    var platformCompatibility: [PlatformCompatibility]
+    var platformCompatibility: Set<PlatformCompatibility>
 
     @OptionalEnum(key: "processing_stage")
     var processingStage: ProcessingStage?
@@ -64,7 +64,7 @@ final class Package: Model, Content {
          url: URL,
          score: Int = 0,
          status: Status = .new,
-         platformCompatibility: [PlatformCompatibility] = [],
+         platformCompatibility: Set<PlatformCompatibility> = .init(),
          processingStage: ProcessingStage? = nil) {
         self.id = id
         self.url = url.absoluteString

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -254,7 +254,8 @@ extension Package {
                 AND b.status = 'ok'
                 GROUP BY b.platform
                 HAVING count(*) > 0
-            )
+            ),
+            updated_at = NOW()
             WHERE p.id = \#(bind: id)
             """#
         ).run()

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -34,7 +34,10 @@ final class Package: Model, Content {
     var updatedAt: Date?
     
     // data fields
-    
+
+    @Field(key: "platform_compatibility")
+    var platformCompatibility: [PlatformCompatibility]
+
     @OptionalEnum(key: "processing_stage")
     var processingStage: ProcessingStage?
     
@@ -61,11 +64,13 @@ final class Package: Model, Content {
          url: URL,
          score: Int = 0,
          status: Status = .new,
+         platformCompatibility: [PlatformCompatibility] = [],
          processingStage: ProcessingStage? = nil) {
         self.id = id
         self.url = url.absoluteString
         self.score = score
         self.status = status
+        self.platformCompatibility = platformCompatibility
         self.processingStage = processingStage
     }
 }
@@ -82,6 +87,17 @@ extension Package: Equatable {
 extension Package: Hashable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+    }
+}
+
+
+extension Package {
+    enum PlatformCompatibility: String, Codable {
+        case ios
+        case macos
+        case linux
+        case tvos
+        case watchos
     }
 }
 

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -96,8 +96,6 @@ extension Package {
     enum PlatformCompatibility: String, Codable {
         case ios
         case macos
-        // TODO: decide if we want to include macosArm here
-        case macosArm
         case linux
         case tvos
         case watchos

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -95,6 +95,8 @@ extension Package {
     enum PlatformCompatibility: String, Codable {
         case ios
         case macos
+        // TODO: decide if we want to include macosArm here
+        case macosArm
         case linux
         case tvos
         case watchos

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -197,6 +197,9 @@ public func configure(_ app: Application) throws {
     do {  // Migration 039 - rename id to package_id on recent_releases
         app.migrations.add(UpdateRecentReleases7())
     }
+    do {  // Migration 040 - add platform_compatibility field
+        app.migrations.add(UpdatePackageAppPlatformCompatibility())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -91,7 +91,8 @@ final class PackageTests: AppTestCase {
             "score": 17,
             "status": "ok",
             "createdAt": 0,
-            "updatedAt": 1
+            "updatedAt": 1,
+            "platformCompatibility": ["macos","ios"]
         }
         """
         let decoder = JSONDecoder()
@@ -102,6 +103,7 @@ final class PackageTests: AppTestCase {
         XCTAssertEqual(p.status, .ok)
         XCTAssertEqual(p.createdAt, Date(timeIntervalSince1970: 0))
         XCTAssertEqual(p.updatedAt, Date(timeIntervalSince1970: 1))
+        XCTAssertEqual(p.platformCompatibility, [.ios, .macos])
     }
     
     func test_unique_url() throws {
@@ -356,7 +358,7 @@ final class PackageTests: AppTestCase {
     }
 
     func test_save_platformCompatibility_save() throws {
-        try Package(url: "1".url, platformCompatibility: [.ios, .ios, .macos])
+        try Package(url: "1".url, platformCompatibility: [.ios, .macos, .ios])
             .save(on: app.db).wait()
         let readBack = try XCTUnwrap(Package.query(on: app.db).first().wait())
         XCTAssertEqual(readBack.platformCompatibility, [.ios, .macos])

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -354,6 +354,14 @@ final class PackageTests: AppTestCase {
         XCTAssertTrue(pkg.isNew)
     }
 
+    func test_save_platformCompatibility() throws {
+        try Package(url: "1".url, platformCompatibility: [.ios])
+            .save(on: app.db).wait()
+        let readBack = try XCTUnwrap(Package.query(on: app.db).first().wait())
+        XCTAssertEqual(readBack.platformCompatibility, [.ios])
+
+    }
+
 }
 
 

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -388,26 +388,7 @@ final class PackageTests: AppTestCase {
         try savePackage(on: app.db, "2")
 
         // MUT
-        try (app.db as! SQLDatabase).raw(
-            #"""
-            UPDATE packages p SET platform_compatibility = ARRAY(
-                SELECT
-                    CASE
-                        WHEN b.platform LIKE 'macos-%' THEN 'macos'
-                        ELSE b.platform
-                    END
-                FROM versions v
-                JOIN builds b ON b.version_id = v.id
-                WHERE v.package_id = p.id
-                AND v.latest IS NOT NULL
-                AND b.status = 'ok'
-                GROUP BY b.platform
-                HAVING count(*) > 0
-            )
-            WHERE p.id = \#(bind: p.id)
-            """#
-        )
-            .run().wait()
+        try p.updatePlatformCompatibility(on: app.db).wait()
 
         // validate
         let p1 = try XCTUnwrap(


### PR DESCRIPTION
⚠️ Schema change ⚠️

This adds a new column `platform_compatibility` to `packages`. The field is updated whenever the server receives a build report from one of the builders by running an update query. This will handle keeping the field up-to-date going forwards.

We *must not* merge this until we've decided what to do about `macosArm` (see https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1432/files#r764835140). As the PR stands right now we're adding a case we're not actually ever using.

See #1429 for post-merge/deployment SQL to update the newly added column.

Implements #1429 