### PR TITLE
Change the name of the `id` column on `recent_releases`

### DIFF
--- a/Sources/App/Core/RecentRelease.swift
+++ b/Sources/App/Core/RecentRelease.swift
@@ -21,7 +21,7 @@ import SQLKit
 struct RecentRelease: Decodable, Equatable {
     static let schema = "recent_releases"
     
-    var id: UUID
+    var packageId: UUID
     var repositoryOwner: String
     var repositoryName: String
     var packageName: String
@@ -32,7 +32,7 @@ struct RecentRelease: Decodable, Equatable {
     var releaseNotesHTML: String?
     
     enum CodingKeys: String, CodingKey {
-        case id
+        case packageId = "package_id"
         case repositoryOwner = "repository_owner"
         case repositoryName = "repository_name"
         case packageName = "package_name"

--- a/Sources/App/Migrations/039/UpdateRecentReleases7.swift
+++ b/Sources/App/Migrations/039/UpdateRecentReleases7.swift
@@ -1,0 +1,88 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateRecentReleases7: Migration {
+    let dropSQL: SQLQueryString = "DROP MATERIALIZED VIEW recent_releases"
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        let updatedViewSQL: SQLQueryString =
+            """
+            -- v7
+            CREATE MATERIALIZED VIEW recent_releases AS
+            SELECT * FROM (SELECT DISTINCT ON (v.package_id)
+                    v.package_id AS package_id,
+                    r.owner AS repository_owner,
+                    r.name AS repository_name,
+                    r.summary AS package_summary,
+                    package_name,
+                    reference -> 'tag' ->> 'tagName' AS version,
+                    commit_date AS released_at,
+                    v.url AS release_url,
+                    v.release_notes_html AS release_notes_html
+                FROM
+                    versions v
+                    JOIN repositories r ON v.package_id = r.package_id
+                WHERE
+                    commit_date IS NOT NULL
+                    AND package_name IS NOT NULL
+                    AND reference ->> 'tag' IS NOT NULL
+                ORDER BY
+                    v.package_id,
+                    v.commit_date DESC) t
+            ORDER BY released_at DESC
+            LIMIT 100;
+            """
+        return db.raw(dropSQL).run()
+            .flatMap { db.raw(updatedViewSQL).run() }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        let oldViewSQL: SQLQueryString =
+            """
+            -- v6
+            CREATE MATERIALIZED VIEW recent_releases AS
+            SELECT * from (
+              SELECT DISTINCT ON (v.package_id)
+                v.package_id AS id,
+                r.owner AS repository_owner,
+                r.name AS repository_name,
+                r.summary AS package_summary,
+                package_name,
+                reference->'tag'->>'tagName' AS version,
+                commit_date AS released_at,
+                v.url AS release_url,
+                v.release_notes_html as release_notes_html
+              FROM versions v
+              JOIN repositories r ON v.package_id = r.package_id
+              WHERE commit_date IS NOT NULL
+                AND package_name IS NOT NULL
+                AND reference->>'tag' IS NOT NULL
+              ORDER BY v.package_id, v.commit_date desc
+            ) t
+            order by released_at desc
+            limit 100
+            """
+        return db.raw(dropSQL).run()
+            .flatMap { db.raw(oldViewSQL).run() }
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -194,6 +194,9 @@ public func configure(_ app: Application) throws {
         app.migrations.add(AddLastActivityAtToRepositories())
         app.migrations.add(UpdateSearch3())
     }
+    do {  // Migration 039 - rename id to package_id on recent_releases
+        app.migrations.add(UpdateRecentReleases7())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/RecentViewsTests.swift
+++ b/Tests/AppTests/RecentViewsTests.swift
@@ -158,7 +158,7 @@ class RecentViewsTests: AppTestCase {
             let minor = $0 % 3  // 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0
             let patch = $0 % 2  // 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0
             let pre = $0 <= 10 ? "" : "-b1"
-            return RecentRelease(id: UUID(),
+            return RecentRelease(packageId: UUID(),
                                  repositoryOwner: "",
                                  repositoryName: "",
                                  packageName: "",


### PR DESCRIPTION
⚠️ SCHEMA CHANGE ⚠️

Given the name of this view includes the word `releases`, it seemed strange that the `id` column was a package identifier. This PR renames that `id` field to be `package_id` to be a little more verbose about it.