### PR TITLE
Fix import warnings during local database restore

### DIFF
--- a/scripts/load-db.sh
+++ b/scripts/load-db.sh
@@ -20,5 +20,7 @@ docker rm -f spi_dev
 docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 -d postgres:13.5-alpine
 echo "Giving Postgres a moment to launch ..."
 sleep 5
+echo "Creating Azure roles"
+PGPASSWORD=xxx psql -h "${HOST:-localhost}" -p 6432 -U spi_dev -d spi_dev -c 'CREATE ROLE azure_pg_admin; CREATE ROLE azuresu;'
 echo "Importing"
 PGPASSWORD=xxx pg_restore --no-owner -h "${HOST:-localhost}" -p 6432 -U spi_dev -d spi_dev < "$IMPORT_FILE"


### PR DESCRIPTION
The warnings were already annoying me! This creates two dummy roles to quiet them.

```
$ ./scripts/load-db.sh spi_prod-2021-12-06.dump
spi_dev
282c88ef907f38f3cbf4e08b698feb55d10d12e5755bf5112d6285125ef3ec7f
Giving Postgres a moment to launch ...
Creating Azure roles
CREATE ROLE
Importing
```