### PR TITLE
Redirect into the new issue flow from the app

### DIFF
--- a/Sources/App/Views/Error/ErrorPage+Model.swift
+++ b/Sources/App/Views/Error/ErrorPage+Model.swift
@@ -41,7 +41,7 @@ extension ErrorPage {
                         return .p(
                             .text("If you were expecting to find a page here, please "),
                             .a(
-                                .href("https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new"),
+                                .href("https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new/choose"),
                                 "raise an issue"
                             ),
                             .text(".")

--- a/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
@@ -54,7 +54,7 @@ enum BuildIndex {
                     ),
                     " to see how we derive build parameters. If you still see surprising results, please ",
                     .a(
-                        .href("https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new"),
+                        .href("https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new/choose"),
                         "raise an issue"
                     ),
                     "."

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.txt
@@ -78,7 +78,7 @@
           </p>
           <p>If you are the author of this package and see unexpected build failures, please check the 
             <a href="/docs/builds">build system documentation</a> to see how we derive build parameters. If you still see surprising results, please 
-            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new">raise an issue</a>.
+            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new/choose">raise an issue</a>.
           </p>
           <hr/>
           <h3>Swift 5.5</h3>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ErrorPageView.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ErrorPageView.1.txt
@@ -73,7 +73,7 @@
         <section class="error_message">
           <h4>404 - Not Found</h4>
           <p>If you were expecting to find a page here, please 
-            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new">raise an issue</a>.
+            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new/choose">raise an issue</a>.
           </p>
           <p>From here, you'll want to 
             <a href="/">go to the home page</a> or 


### PR DESCRIPTION
The old links still just opened a completely blank issue.