### PR TITLE
Increase the number of items in RSS feeds

### DIFF
--- a/Sources/App/Core/Constants.swift
+++ b/Sources/App/Core/Constants.swift
@@ -33,7 +33,7 @@ enum Constants {
     
     static let reIngestionDeadtime: TimeInterval = .minutes(90)
     
-    static let rssFeedMaxItemCount = 100
+    static let rssFeedMaxItemCount = 500
     static let rssTTL: TimeInterval = .minutes(60)
     
     static let resultsPageSize = 20

--- a/Sources/App/Migrations/042/UpdateRecentPackages4.swift
+++ b/Sources/App/Migrations/042/UpdateRecentPackages4.swift
@@ -1,0 +1,86 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+
+struct UpdateRecentPackages4: Migration {
+    let dropSQL: SQLQueryString = "DROP MATERIALIZED VIEW recent_packages"
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        let updatedViewSQL: SQLQueryString =
+            """
+            -- v4
+            CREATE MATERIALIZED VIEW recent_packages AS
+            SELECT * FROM ( SELECT DISTINCT ON (p.id)
+                    p.id,
+                    r.owner AS repository_owner,
+                    r.name AS repository_name,
+                    r.summary AS package_summary,
+                    v.package_name,
+                    p.created_at
+                FROM
+                    packages p
+                    JOIN versions v ON v.package_id = p.id
+                    JOIN repositories r ON r.package_id = p.id
+                WHERE
+                    v.package_name IS NOT NULL
+                    AND r.owner IS NOT NULL
+                    AND r.name IS NOT NULL
+                ORDER BY
+                    p.id,
+                    v.commit_date DESC) t
+            ORDER BY
+                created_at DESC
+            LIMIT 500;
+            """
+        return db.raw(dropSQL).run()
+            .flatMap { db.raw(updatedViewSQL).run() }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        let oldViewSQL: SQLQueryString =
+            """
+            -- v3
+            CREATE MATERIALIZED VIEW recent_packages AS
+            SELECT * FROM (
+              SELECT DISTINCT ON (p.id)
+                  p.id,
+                  r.owner AS repository_owner,
+                  r.name AS repository_name,
+                  r.summary AS package_summary,
+                  v.package_name,
+                  p.created_at
+              FROM packages p
+              JOIN versions v ON v.package_id = p.id
+              JOIN repositories r ON r.package_id = p.id
+              WHERE v.package_name IS NOT NULL
+                AND r.owner IS NOT NULL
+                AND r.name IS NOT NULL
+              order by p.id, v.commit_date desc
+            ) t
+            order by created_at desc
+            limit 100
+            """
+        return db.raw(dropSQL).run()
+            .flatMap { db.raw(oldViewSQL).run() }
+    }
+}

--- a/Sources/App/Migrations/042/UpdateRecentReleases8.swift
+++ b/Sources/App/Migrations/042/UpdateRecentReleases8.swift
@@ -1,0 +1,91 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+struct UpdateRecentReleases8: Migration {
+    let dropSQL: SQLQueryString = "DROP MATERIALIZED VIEW recent_releases"
+
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        let updatedViewSQL: SQLQueryString =
+            """
+            -- v8
+            CREATE MATERIALIZED VIEW recent_releases AS
+            SELECT * FROM ( SELECT DISTINCT ON (v.package_id)
+                    v.package_id AS package_id,
+                    r.owner AS repository_owner,
+                    r.name AS repository_name,
+                    r.summary AS package_summary,
+                    package_name,
+                    reference -> 'tag' ->> 'tagName' AS version,
+                    commit_date AS released_at,
+                    v.url AS release_url,
+                    v.release_notes_html AS release_notes_html
+                FROM
+                    versions v
+                    JOIN repositories r ON v.package_id = r.package_id
+                WHERE
+                    commit_date IS NOT NULL
+                    AND package_name IS NOT NULL
+                    AND reference ->> 'tag' IS NOT NULL
+                ORDER BY
+                    v.package_id,
+                    v.commit_date DESC) t
+            ORDER BY
+                released_at DESC
+            LIMIT 500;
+            """
+        return db.raw(dropSQL).run()
+            .flatMap { db.raw(updatedViewSQL).run() }
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        let oldViewSQL: SQLQueryString =
+            """
+            -- v7
+            CREATE MATERIALIZED VIEW recent_releases AS
+            SELECT * FROM (SELECT DISTINCT ON (v.package_id)
+                    v.package_id AS package_id,
+                    r.owner AS repository_owner,
+                    r.name AS repository_name,
+                    r.summary AS package_summary,
+                    package_name,
+                    reference -> 'tag' ->> 'tagName' AS version,
+                    commit_date AS released_at,
+                    v.url AS release_url,
+                    v.release_notes_html AS release_notes_html
+                FROM
+                    versions v
+                    JOIN repositories r ON v.package_id = r.package_id
+                WHERE
+                    commit_date IS NOT NULL
+                    AND package_name IS NOT NULL
+                    AND reference ->> 'tag' IS NOT NULL
+                ORDER BY
+                    v.package_id,
+                    v.commit_date DESC) t
+            ORDER BY released_at DESC
+            LIMIT 100;
+            """
+        return db.raw(dropSQL).run()
+            .flatMap { db.raw(oldViewSQL).run() }
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -203,6 +203,10 @@ public func configure(_ app: Application) throws {
     do {  // Migration 041 - add platform_compatibility to search
         app.migrations.add(UpdateSearch4())
     }
+    do {  // Migration 042 - increase number of rows in recent_releases and recent_packages
+        app.migrations.add(UpdateRecentPackages4())
+        app.migrations.add(UpdateRecentReleases8())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")


### PR DESCRIPTION
Fixes #1443 

⚠️ SCHEMA CHANGE ⚠️ 

I went to 500 instead of 400 because of round numbers!

Performance shouldn't be an issue because these are materialised. File size has obviously increased (releases is now ~750Kb) but the amount of traffic we get to the RSS feeds mean it should be inconsequential. If we need to reduce this, we should cache it with CloudFlare, but I think that would be overkill at this time.