### PR TITLE
Issue 1072 decouple trigger

### DIFF
--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -50,7 +50,7 @@ extension API {
                 .transform(to: .ok)
         }
         
-        func trigger(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+        func triggerBuilds(req: Request) throws -> EventLoopFuture<HTTPStatus> {
             guard
                 let owner = req.parameters.get("owner"),
                 let repository = req.parameters.get("repository")

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -171,7 +171,6 @@ extension API.PackageController {
 
 extension API.PackageController {
     enum TriggerBuildRoute {
-        #warning("add test")
         static func query(on database: Database, owner: String, repository: String) -> EventLoopFuture<[Version.Id]> {
             Joined3<Package, Repository, Version>
                 .query(on: database)

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -58,24 +58,19 @@ extension API {
                 return req.eventLoop.future(error: Abort(.notFound))
             }
             let dto = try req.content.decode(PostBuildTriggerDTO.self)
-            return PackageResult
+            return TriggerBuildRoute
                 .query(on: req.db, owner: owner, repository: repository)
-                .flatMap { package -> EventLoopFuture<HTTPStatus> in
-                    [App.Version.Kind.release, .preRelease, .defaultBranch]
-                        .compactMap { package.versions.latest(for: $0)?.id }
-                        .map {
-                            Build.trigger(database: req.db,
-                                          client: req.client,
-                                          platform: dto.platform,
-                                          swiftVersion: dto.swiftVersion,
-                                          versionId: $0)
-                        }
-                        .flatten(on: req.eventLoop)
-                        .mapEach(\.status)
-                        .map { statuses in
-                            statuses.allSatisfy { $0 == .created || $0 == .ok }
-                                ? .ok : .badRequest
-                        }
+                .flatMapEach(on: req.eventLoop) { versionId -> EventLoopFuture<HTTPStatus> in
+                    Build.trigger(database: req.db,
+                                  client: req.client,
+                                  platform: dto.platform,
+                                  swiftVersion: dto.swiftVersion,
+                                  versionId: versionId)
+                        .map(\.status)
+                }
+                .map { statuses -> HTTPStatus in
+                    statuses.allSatisfy { $0 == .created || $0 == .ok }
+                    ? .ok : .badRequest
                 }
         }
         
@@ -169,6 +164,23 @@ extension API.PackageController {
                     ($0.build.swiftVersion, $0.build.platform, $0.build.status)
                 }
                 .map(SignificantBuilds.init(buildInfo:))
+        }
+    }
+}
+
+
+extension API.PackageController {
+    enum TriggerBuildRoute {
+        #warning("add test")
+        static func query(on database: Database, owner: String, repository: String) -> EventLoopFuture<[Version.Id]> {
+            Joined3<Package, Repository, Version>
+                .query(on: database)
+                .filter(Version.self, \.$latest != nil)
+                .filter(Repository.self, \.$owner, .custom("ilike"), owner)
+                .filter(Repository.self, \.$name, .custom("ilike"), repository)
+                .field(Version.self, \.$id)
+                .all()
+                .flatMapEachThrowing { try $0.version.requireID() }
         }
     }
 }

--- a/Sources/App/Core/Query+Support/Joined3+Package.swift
+++ b/Sources/App/Core/Query+Support/Joined3+Package.swift
@@ -21,18 +21,21 @@ extension Joined3 where M == Package, R1 == Repository, R2 == Version {
     var repository: Repository { relation1! }
     var version: Version { relation2! }
 
-    static func query(on database: Database,
-                      version latest: Version.Kind = .defaultBranch) -> JoinedQueryBuilder<Joined3> {
+    static func query(on database: Database) -> JoinedQueryBuilder<Joined3> {
         query(on: database,
               join: \Repository.$package.$id == \Package.$id, method: .inner,
               join: \Version.$package.$id == \Package.$id, method: .inner)
+    }
+
+    static func query(on database: Database, version latest: Version.Kind) -> JoinedQueryBuilder<Joined3> {
+        query(on: database)
             .filter(Version.self, \.$latest == latest)
     }
 
     static func query(on database: Database,
                       owner: String,
                       repository: String,
-                      version latest: Version.Kind = .defaultBranch) -> JoinedQueryBuilder<Joined3> {
+                      version latest: Version.Kind) -> JoinedQueryBuilder<Joined3> {
         query(on: database, version: latest)
             .filter(Repository.self, \.$owner, .custom("ilike"), owner)
             .filter(Repository.self, \.$name, .custom("ilike"), repository)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -110,14 +110,14 @@ func routes(_ app: Application) throws {
 
         // protected routes
         app.group(User.TokenAuthenticator(), User.guardMiddleware()) { protected in
-            let builds = API.BuildController()
+            let buildController = API.BuildController()
             protected.on(.POST, SiteURL.api(.versions(.key, .builds)).pathComponents,
-                         use: builds.create)
+                         use: buildController.create)
             protected.post(SiteURL.api(.versions(.key, .triggerBuild)).pathComponents,
-                           use: builds.trigger)
-            let packages = API.PackageController()
+                           use: buildController.trigger)
+            let packageController = API.PackageController()
             protected.post(SiteURL.api(.packages(.key, .key, .triggerBuilds)).pathComponents,
-                           use: packages.trigger)
+                           use: packageController.triggerBuilds)
         }
         
         // sas: 2020-05-19: shut down public API until we have an auth mechanism

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -302,38 +302,6 @@ class ApiTests: AppTestCase {
             })
     }
 
-    func test_TriggerBuildRoute_query() throws {
-        // setup
-        let p = try savePackage(on: app.db, "1")
-        let v = try Version(id: .id0, package: p, latest: .release, reference: .tag(.init(1, 2, 3)))
-        try v.save(on: app.db).wait()
-        try Repository(package: p,
-                       defaultBranch: "main",
-                       license: .mit,
-                       name: "repo",
-                       owner: "owner").save(on: app.db).wait()
-        // save decoy version
-        try Version(id: .id1, package: p, latest: nil, reference: .tag(2, 0, 0))
-            .save(on: app.db).wait()
-        do { // save decoy package
-            let p = try savePackage(on: app.db, "2")
-            let v = try Version(package: p, latest: .release, reference: .tag(.init(2, 0, 0)))
-            try v.save(on: app.db).wait()
-            try Repository(package: p,
-                           defaultBranch: "main",
-                           license: .mit,
-                           name: "decoy",
-                           owner: "owner").save(on: app.db).wait()
-        }
-
-        // MUT
-        let versionIds = try API.PackageController.TriggerBuildRoute
-            .query(on: app.db, owner: "owner", repository: "repo").wait()
-
-        // validate
-        XCTAssertEqual(Set(versionIds), [.id0])
-    }
-
     func test_post_build_trigger() throws {
         // Test basic build trigger (high level API, details tested in GitlabBuilderTests)
         // setup
@@ -401,7 +369,39 @@ class ApiTests: AppTestCase {
                 XCTAssertEqual(res.status, .unauthorized)
             })
     }
-    
+
+    func test_TriggerBuildRoute_query() throws {
+        // setup
+        let p = try savePackage(on: app.db, "1")
+        let v = try Version(id: .id0, package: p, latest: .release, reference: .tag(.init(1, 2, 3)))
+        try v.save(on: app.db).wait()
+        try Repository(package: p,
+                       defaultBranch: "main",
+                       license: .mit,
+                       name: "repo",
+                       owner: "owner").save(on: app.db).wait()
+        // save decoy version
+        try Version(id: .id1, package: p, latest: nil, reference: .tag(2, 0, 0))
+            .save(on: app.db).wait()
+        do { // save decoy package
+            let p = try savePackage(on: app.db, "2")
+            let v = try Version(package: p, latest: .release, reference: .tag(.init(2, 0, 0)))
+            try v.save(on: app.db).wait()
+            try Repository(package: p,
+                           defaultBranch: "main",
+                           license: .mit,
+                           name: "decoy",
+                           owner: "owner").save(on: app.db).wait()
+        }
+
+        // MUT
+        let versionIds = try API.PackageController.TriggerBuildRoute
+            .query(on: app.db, owner: "owner", repository: "repo").wait()
+
+        // validate
+        XCTAssertEqual(Set(versionIds), [.id0])
+    }
+
     func test_post_build_trigger_package_name() throws {
         // Test POST /packages/{owner}/{repo}/trigger-builds
         // setup

--- a/Tests/AppTests/Joined3Tests.swift
+++ b/Tests/AppTests/Joined3Tests.swift
@@ -42,7 +42,8 @@ class Joined3Tests: AppTestCase {
         try Version(package: p, latest: .release).save(on: app.db).wait()
 
         // MUT
-        let res = try Joined3<Package, Repository, Version>.query(on: app.db)
+        let res = try Joined3<Package, Repository, Version>
+            .query(on: app.db, version: .defaultBranch)
             .all()
             .wait()
 
@@ -61,7 +62,8 @@ class Joined3Tests: AppTestCase {
                     packageName: "package name").save(on: app.db).wait()
 
         // MUT
-        let res = try Joined3<Package, Repository, Version>.query(on: app.db)
+        let res = try Joined3<Package, Repository, Version>
+            .query(on: app.db, version: .defaultBranch)
             .all().wait()
 
         // validate
@@ -80,7 +82,8 @@ class Joined3Tests: AppTestCase {
                         packageName: "package name").save(on: app.db).wait()
 
             // MUT
-            let res = try Joined3<Package, Repository, Version>.query(on: app.db)
+            let res = try Joined3<Package, Repository, Version>
+                .query(on: app.db, version: .defaultBranch)
                 .all().wait()
 
             // validate - result is empty, `res[0].repository` cannot be called
@@ -91,7 +94,8 @@ class Joined3Tests: AppTestCase {
             try Repository(package: p, owner: "owner").save(on: app.db).wait()
 
             // MUT
-            let res = try Joined3<Package, Repository, Version>.query(on: app.db)
+            let res = try Joined3<Package, Repository, Version>
+                .query(on: app.db, version: .defaultBranch)
                 .all().wait()
 
             // validate - result is empty, `res[0].repository` cannot be called

--- a/Tests/AppTests/PackageInfoTests.swift
+++ b/Tests/AppTests/PackageInfoTests.swift
@@ -28,7 +28,7 @@ class PackageInfoTests: AppTestCase {
         try Version(package: p, latest: .defaultBranch, packageName: "package name")
             .save(on: app.db).wait()
         let joined = try XCTUnwrap(Joined3<Package, Repository, Version>
-                                    .query(on: app.db)
+                                    .query(on: app.db, version: .defaultBranch)
                                     .first()
                                     .wait())
 
@@ -48,7 +48,7 @@ class PackageInfoTests: AppTestCase {
         try Version(package: p, latest: .defaultBranch, packageName: nil)
             .save(on: app.db).wait()
         let joined = try XCTUnwrap(Joined3<Package, Repository, Version>
-                                    .query(on: app.db)
+                                    .query(on: app.db, version: .defaultBranch)
                                     .first()
                                     .wait())
 


### PR DESCRIPTION
This replaces the re-use of the "package show" query in the "trigger builds" route with a faster custom query.

This one should also improve considerably in performance but it's not possible to test this side by side in Rester because the endpoint would need to fire off Gitlab requests in order to complete and return a status code.

Part of #1072