### PR TITLE
Accept and save runner id in build reports

### DIFF
--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -33,7 +33,9 @@ extension API {
                 }
                 .flatMapThrowing { ($0, try Build(dto, $0)) }
                 .flatMap { (version, build) -> EventLoopFuture<(App.Version, Build)> in
-                    AppMetrics.apiBuildReportTotal?.inc(1, .init(build.platform, build.swiftVersion))
+                    AppMetrics.apiBuildReportTotal?.inc(1, .init(build.platform,
+                                                                 build.runnerId ?? "",
+                                                                 build.swiftVersion))
                     if build.status == .infrastructureError {
                         req.logger.critical("build infrastructure error: \(build.jobUrl)")
                     }

--- a/Sources/App/Core/AppMetrics.swift
+++ b/Sources/App/Core/AppMetrics.swift
@@ -32,7 +32,21 @@ enum AppMetrics {
     // metrics
 
     enum Labels {
-        struct Build: MetricLabels {
+        struct BuildReport: MetricLabels {
+            var platform: String = ""
+            var runnerId: String = ""
+            var swiftVersion: String = ""
+
+            init() {}
+
+            init(_ platform: App.Build.Platform, _ runnerId: String, _ swiftVersion: SwiftVersion) {
+                self.platform = platform.rawValue
+                self.runnerId = runnerId
+                self.swiftVersion = "\(swiftVersion)"
+            }
+        }
+
+        struct BuildTrigger: MetricLabels {
             var platform: String = ""
             var swiftVersion: String = ""
 
@@ -98,8 +112,8 @@ enum AppMetrics {
         gauge("spi_analyze_versions_deleted_count", Labels.Version.self)
     }
 
-    static var apiBuildReportTotal: PromCounter<Int, Labels.Build>? {
-        counter("spi_api_build_report_total", Labels.Build.self)
+    static var apiBuildReportTotal: PromCounter<Int, Labels.BuildReport>? {
+        counter("spi_api_build_report_total", Labels.BuildReport.self)
     }
 
     static var apiPackageCollectionGetTotal: PromCounter<Int, EmptyLabels>? {
@@ -138,8 +152,8 @@ enum AppMetrics {
         gauge("spi_build_throttle_count", EmptyLabels.self)
     }
 
-    static var buildTriggerCount: PromGauge<Int, Labels.Build>? {
-        gauge("spi_build_trigger_count", Labels.Build.self)
+    static var buildTriggerCount: PromGauge<Int, Labels.BuildTrigger>? {
+        gauge("spi_build_trigger_count", Labels.BuildTrigger.self)
     }
 
     static var buildTriggerDurationSeconds: PromGauge<Double, EmptyLabels>? {

--- a/Sources/App/Migrations/043/UpdateBuildAddRunnerId.swift
+++ b/Sources/App/Migrations/043/UpdateBuildAddRunnerId.swift
@@ -12,23 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import DependencyResolution
+import Fluent
 
 
-extension API {
-    struct PostBuildTriggerDTO: Codable {
-        var platform: Build.Platform
-        var swiftVersion: SwiftVersion
+struct UpdateBuildAddRunnerId: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("builds")
+            .field("runner_id", .string)
+            .update()
     }
 
-    struct PostCreateBuildDTO: Codable {
-        var buildCommand: String?
-        var jobUrl: String?
-        var logUrl: String?
-        var platform: Build.Platform
-        var resolvedDependencies: [ResolvedDependency]?
-        var runnerId: String?
-        var status: Build.Status
-        var swiftVersion: SwiftVersion
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("builds")
+            .deleteField("runner_id")
+            .update()
     }
 }

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -51,6 +51,9 @@ final class Build: Model, Content {
 
     @Field(key: "platform")
     var platform: Platform
+
+    @Field(key: "runner_id")
+    var runnerId: String?
     
     @Field(key: "status")
     var status: Build.Status
@@ -66,6 +69,7 @@ final class Build: Model, Content {
          jobUrl: String? = nil,
          logUrl: String? = nil,
          platform: Platform,
+         runnerId: String? = nil,
          status: Status,
          swiftVersion: SwiftVersion) {
         self.id = id
@@ -74,24 +78,27 @@ final class Build: Model, Content {
         self.jobUrl = jobUrl
         self.logUrl = logUrl
         self.platform = platform
+        self.runnerId = runnerId
         self.status = status
         self.swiftVersion = swiftVersion
     }
 
     convenience init(id: Id? = nil,
-         version: Version,
-         buildCommand: String? = nil,
-         jobUrl: String? = nil,
-         logUrl: String? = nil,
-         platform: Platform,
-         status: Status,
-         swiftVersion: SwiftVersion) throws {
+                     version: Version,
+                     buildCommand: String? = nil,
+                     jobUrl: String? = nil,
+                     logUrl: String? = nil,
+                     platform: Platform,
+                     runnerId: String? = nil,
+                     status: Status,
+                     swiftVersion: SwiftVersion) throws {
         self.init(id: id,
                   versionId: try version.requireID(),
                   buildCommand: buildCommand,
                   jobUrl: jobUrl,
                   logUrl: logUrl,
                   platform: platform,
+                  runnerId: runnerId,
                   status: status,
                   swiftVersion: swiftVersion)
     }
@@ -102,6 +109,7 @@ final class Build: Model, Content {
                       jobUrl: dto.jobUrl,
                       logUrl: dto.logUrl,
                       platform: dto.platform,
+                      runnerId: dto.runnerId,
                       status: dto.status,
                       swiftVersion: dto.swiftVersion)
     }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -207,6 +207,9 @@ public func configure(_ app: Application) throws {
         app.migrations.add(UpdateRecentPackages4())
         app.migrations.add(UpdateRecentReleases8())
     }
+    do {  // Migration 043 - add runner_id to builds
+        app.migrations.add(UpdateBuildAddRunnerId())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -102,6 +102,7 @@ class ApiTests: AppTestCase {
                 logUrl: "log url",
                 platform: .macosXcodebuild,
                 resolvedDependencies: nil,
+                runnerId: "some-runner",
                 status: .failed,
                 swiftVersion: .init(5, 2, 0)
             )
@@ -123,6 +124,7 @@ class ApiTests: AppTestCase {
                     XCTAssertEqual(b.jobUrl, "https://example.com/jobs/1")
                     XCTAssertEqual(b.logUrl, "log url")
                     XCTAssertEqual(b.platform, .macosXcodebuild)
+                    XCTAssertEqual(b.runnerId, "some-runner")
                     XCTAssertEqual(b.status, .failed)
                     XCTAssertEqual(b.swiftVersion, .init(5, 2, 0))
                     XCTAssertEqual(try Build.query(on: app.db).count().wait(), 1)


### PR DESCRIPTION
Fixes #1482 

Runner id added to build reports via https://gitlab.com/finestructure/swiftpackageindex-builder/-/merge_requests/86

Both ends operate with `String?`, so the presence of the id is entirely optional and the merge/deploy order is irrelevant.