### PR TITLE
Migrate ErrorMiddleware to async/await

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ Public/main.css.map
 
 .nova/
 /.vscode/
+.env.staging


### PR DESCRIPTION
As part of the whole `pg_dump` investigation I wanted to make sure the rollbar item is sent in a fire and forget event and it turned out to be way easier in async/await.