### PR TITLE
Fix async error handling

### DIFF
--- a/Sources/App/Commands/Reconcile.swift
+++ b/Sources/App/Commands/Reconcile.swift
@@ -24,7 +24,7 @@ struct ReconcileCommand: Command {
     func run(using context: CommandContext, signature: Signature) throws {
         let group = DispatchGroup()
         group.enter()
-        Task.detached {
+        Task {
             defer { group.leave() }
 
             let logger = Logger(component: "reconcile")


### PR DESCRIPTION
Recent work on async/await CLI tools highlighted a gap in our error handling: when using `Task { ... }`, it's important to wrap the body in `do` - `catch` in order to handle any error that might be thrown.

If they are not caught, the task will dangle and never call `group.leave()`. I _think_ this makes sense - where would `Task { ... }` throw an error that bubbles up?

NB: once `Command` supports `func run(...) async throws` this workaround with `Task { ... }` and the `DispatchGroup` will go away and everything will be handed automatically.