### PR TITLE
Async ingest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
       - name: Install unzip
         run: apt-get update && apt-get install -y unzip
       - name: Run tests
-        run: cp .env.testing.template .env.testing && make test
+        # temporarily run without TSAN due to false positives on Linux
+        # https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1496
+        # Review with Swift 5.6
+        run: cp .env.testing.template .env.testing && make test-without-tsan
         env:
           COLLECTION_SIGNING_PRIVATE_KEY: ${{ secrets.COLLECTION_SIGNING_PRIVATE_KEY }}
           DATABASE_HOST: postgres

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,7 @@ jobs:
       - name: Install unzip
         run: apt-get update && apt-get install -y unzip
       - name: Run tests
-        # temporarily run without TSAN due to false positives on Linux
-        # https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1496
-        # Review with Swift 5.6
-        run: cp .env.testing.template .env.testing && make test-without-tsan
+        run: cp .env.testing.template .env.testing && make test
         env:
           COLLECTION_SIGNING_PRIVATE_KEY: ${{ secrets.COLLECTION_SIGNING_PRIVATE_KEY }}
           DATABASE_HOST: postgres

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ test:
 	env RUN_IMAGE_SNAPSHOT_TESTS=true \
 	swift test --enable-code-coverage --disable-automatic-resolution --sanitize=thread
 
+test-without-tsan:
+	env RUN_IMAGE_SNAPSHOT_TESTS=true \
+	swift test --enable-code-coverage --disable-automatic-resolution
+
 test-fast:
 	@echo Skipping image snapshot tests
 	@echo Running without --sanitize=thread

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,6 @@ test:
 	env RUN_IMAGE_SNAPSHOT_TESTS=true \
 	swift test --enable-code-coverage --disable-automatic-resolution --sanitize=thread
 
-test-without-tsan:
-	env RUN_IMAGE_SNAPSHOT_TESTS=true \
-	swift test --enable-code-coverage --disable-automatic-resolution
-
 test-fast:
 	@echo Skipping image snapshot tests
 	@echo Running without --sanitize=thread

--- a/Sources/App/Commands/CommandAsync.swift
+++ b/Sources/App/Commands/CommandAsync.swift
@@ -1,0 +1,25 @@
+import Vapor
+
+
+protocol CommandAsync: Command {
+    // Specifically avoid marking this function `throws` to ensure all
+    // errors are handled. Otherwise errors thrown would escape and
+    // leave the task dangling.
+    // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1493
+    func run(using context: CommandContext, signature: Signature) async
+}
+
+
+extension CommandAsync {
+    func run(using context: CommandContext, signature: Signature) throws {
+        let group = DispatchGroup()
+        group.enter()
+
+        Task {
+            defer { group.leave() }
+            await run(using: context, signature: signature)
+        }
+
+        group.wait()
+    }
+}

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -112,7 +112,7 @@ func ingest(client: Client,
             packages: [Joined<Package, Repository>]) async throws {
     logger.debug("Ingesting \(packages.compactMap {$0.model.id})")
     AppMetrics.ingestCandidatesCount?.set(packages.count)
-    // TODO: simply the types in this chain by running the batches "vertically" instead of "horizontally"
+    // TODO: simplify the types in this chain by running the batches "vertically" instead of "horizontally"
     // i.e. instead of [package, data1, data2, ...] -> updatePackages(...)
     // run
     // let data1 = ...

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -225,5 +225,6 @@ func insertOrUpdateRepository(on database: Database,
         .map(Release.init(from:)) ?? []
     repo.stars = repository.stargazerCount
     repo.summary = repository.description
-    return try await repo.save(on: database)
+
+    try await repo.save(on: database)
 }

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -137,11 +137,12 @@ func fetchMetadata(
     ) { group in
         for pkg in packages {
             group.addTask {
-                // TODO: check if ELF.and was eager, i.e. if async let is the correct translation
-                async let metadata = try await Current.fetchMetadata(client, pkg.model.url).get()
-                async let license = try await Current.fetchLicense(client, pkg.model.url).get()
-                async let readme = try await Current.fetchReadme(client, pkg.model.url).get()
-                return try await (pkg, metadata, license, readme)
+                // We could run these tasks concurrently via `async let`.
+                // Keeping pre-async/await behaviour of running them sequentially for now.
+                let metadata = try await Current.fetchMetadata(client, pkg.model.url).get()
+                let license = try await Current.fetchLicense(client, pkg.model.url).get()
+                let readme = try await Current.fetchReadme(client, pkg.model.url).get()
+                return (pkg, metadata, license, readme)
             }
         }
 

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -112,7 +112,6 @@ func ingest(client: Client,
             packages: [Joined<Package, Repository>]) async throws {
     logger.debug("Ingesting \(packages.compactMap {$0.model.id})")
     AppMetrics.ingestCandidatesCount?.set(packages.count)
-    #warning("simplify metadata's type by dropping Joined<Package, Repository>")
     let metadata = await fetchMetadata(client: client, packages: packages)
     let updates = await updateRepositories(on: database, metadata: metadata)
     return try await updatePackages(client: client,

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -145,16 +145,7 @@ func fetchMetadata(
             }
         }
 
-        var results = [Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?), Error>]()
-        while !group.isEmpty {
-            do {
-                guard let res = try await group.next() else { continue }
-                results.append(.success(res))
-            } catch {
-                results.append(.failure(error))
-            }
-        }
-        return results
+        return await group.results()
     }
 }
 

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -112,6 +112,15 @@ func ingest(client: Client,
             packages: [Joined<Package, Repository>]) async throws {
     logger.debug("Ingesting \(packages.compactMap {$0.model.id})")
     AppMetrics.ingestCandidatesCount?.set(packages.count)
+    // TODO: simply the types in this chain by running the batches "vertically" instead of "horizontally"
+    // i.e. instead of [package, data1, data2, ...] -> updatePackages(...)
+    // run
+    // let data1 = ...
+    // let data2 = ...
+    // updatePackage(...)
+    // i.e. loop through each package end-to-end instead of building a wide tuple.
+    // (I'm pretty sure none of the db queries are actually batch queries, so we wouldn't
+    // introduce any extra latency. Should check if we could make them batch, though.)
     let metadata = await fetchMetadata(client: client, packages: packages)
     let updates = await updateRepositories(on: database, metadata: metadata)
     return try await updatePackages(client: client,

--- a/Sources/App/Commands/Reconcile.swift
+++ b/Sources/App/Commands/Reconcile.swift
@@ -24,18 +24,20 @@ struct ReconcileCommand: CommandAsync {
     func run(using context: CommandContext, signature: Signature) async {
         let logger = Logger(component: "reconcile")
 
-        do {
-            logger.info("Reconciling ...")
-            try? await reconcile(client: context.application.client,
-                                 database: context.application.db)
-            logger.info("done.")
+        logger.info("Reconciling ...")
 
-            try await AppMetrics.push(client: context.application.client,
-                                      logger: context.application.logger,
-                                      jobName: "reconcile")
+        do {
+            try await reconcile(client: context.application.client,
+                                database: context.application.db)
         } catch {
             logger.error("\(error.localizedDescription)")
         }
+
+        logger.info("done.")
+
+        try? await AppMetrics.push(client: context.application.client,
+                                   logger: context.application.logger,
+                                   jobName: "reconcile")
     }
 }
 

--- a/Sources/App/Commands/Reconcile.swift
+++ b/Sources/App/Commands/Reconcile.swift
@@ -16,33 +16,26 @@ import Fluent
 import Vapor
 
 
-struct ReconcileCommand: Command {
+struct ReconcileCommand: CommandAsync {
     struct Signature: CommandSignature { }
     
     var help: String { "Reconcile package list with server" }
 
-    func run(using context: CommandContext, signature: Signature) throws {
-        let group = DispatchGroup()
-        group.enter()
-        Task {
-            defer { group.leave() }
+    func run(using context: CommandContext, signature: Signature) async {
+        let logger = Logger(component: "reconcile")
 
-            let logger = Logger(component: "reconcile")
+        do {
+            logger.info("Reconciling ...")
+            try? await reconcile(client: context.application.client,
+                                 database: context.application.db)
+            logger.info("done.")
 
-            do {
-                logger.info("Reconciling ...")
-                try? await reconcile(client: context.application.client,
-                                     database: context.application.db)
-                logger.info("done.")
-
-                try await AppMetrics.push(client: context.application.client,
-                                          logger: context.application.logger,
-                                          jobName: "reconcile")
-            } catch {
-                logger.error("\(error.localizedDescription)")
-            }
+            try await AppMetrics.push(client: context.application.client,
+                                      logger: context.application.logger,
+                                      jobName: "reconcile")
+        } catch {
+            logger.error("\(error.localizedDescription)")
         }
-        group.wait()
     }
 }
 

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -80,18 +80,14 @@ extension API {
             switch cmd {
                 case .reconcile:
                     try await reconcile(client: req.client, database: req.db)
-                    return try await Package.query(on: req.db).count()
-                        .map { Command.Response.init(status: "ok", rows: $0) }
-                        .get()
+                    let rowCount = try await Package.query(on: req.db).count()
+                    return .init(status: "ok", rows: rowCount)
                 case .ingest:
-                    return try await ingest(client: req.application.client,
-                                            database: req.application.db,
-                                            logger: req.application.logger,
-                                            mode: .limit(limit))
-                        .map {
-                            Command.Response(status: "ok", rows: limit)
-                        }
-                        .get()
+                    try await ingest(client: req.application.client,
+                                     database: req.application.db,
+                                     logger: req.application.logger,
+                                     mode: .limit(limit))
+                    return .init(status: "ok", rows: limit)
                 case .analyze:
                     return try await analyze(client: req.application.client,
                                              database: req.application.db,

--- a/Sources/App/Core/ErrorMiddleware.swift
+++ b/Sources/App/Core/ErrorMiddleware.swift
@@ -38,10 +38,9 @@ public final class ErrorMiddleware: AsyncMiddleware {
                 Current.logger()?.error("ErrorPage.View \(statusCode): \(error.localizedDescription)")
             }
 
-            return try await ErrorPage.View(path: req.url.path, error: abortError)
+            return ErrorPage.View(path: req.url.path, error: abortError)
                 .document()
                 .encodeResponse(for: req, status: abortError.status)
-                .get()
         }
     }
 

--- a/Sources/App/Core/Extensions/HTML+ResponseEncodable.swift
+++ b/Sources/App/Core/Extensions/HTML+ResponseEncodable.swift
@@ -21,13 +21,13 @@ protocol Renderable {
 
 extension Renderable {
     public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
-        encodeResponse(for: request, status: .ok)
+        request.eventLoop.future(encodeResponse(for: request, status: .ok))
     }
 
-    public func encodeResponse(for request: Request, status: HTTPResponseStatus) -> EventLoopFuture<Response> {
+    public func encodeResponse(for request: Request, status: HTTPResponseStatus) -> Response {
         let res = Response(status: status, body: .init(string: self.render()))
         res.headers.add(name: "Content-Type", value: "text/html; charset=utf-8")
-        return request.eventLoop.makeSucceededFuture(res)
+        return res
     }
 }
 

--- a/Sources/App/Core/Extensions/Model+ext.swift
+++ b/Sources/App/Core/Extensions/Model+ext.swift
@@ -21,7 +21,13 @@ extension Array where Element: FluentKit.Model {
             $0.save(on: database)
         }.flatten(on: database.eventLoop)
     }
-    
+
+    public func save(on database: Database) async throws -> Void {
+        for element in self {
+            try await element.save(on: database)
+        }
+    }
+
     public func update(on database: Database) -> EventLoopFuture<Void> {
         map {
             $0.update(on: database)

--- a/Sources/App/Core/Extensions/Optional+ext.swift
+++ b/Sources/App/Core/Extensions/Optional+ext.swift
@@ -1,0 +1,31 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+extension Optional {
+    func unwrap(or error: @autoclosure @escaping () -> Error) throws -> WrappedType {
+        guard let unwrapped = self else {
+            throw error()
+        }
+        return unwrapped
+    }
+
+    func unwrap() throws -> WrappedType {
+        try unwrap(or: OptionError.unexpectedNil)
+    }
+
+    enum OptionError: Error {
+        case unexpectedNil
+    }
+}

--- a/Sources/App/Core/Extensions/Result+ext.swift
+++ b/Sources/App/Core/Extensions/Result+ext.swift
@@ -23,3 +23,14 @@ extension Result {
         }
     }
 }
+
+
+extension Result where Failure == Error {
+    init(catching body: () async throws -> Success) async {
+        do {
+            self = .success(try await body())
+        } catch {
+            self = .failure(error)
+        }
+    }
+}

--- a/Sources/App/Core/Extensions/Sequence+ext.swift
+++ b/Sources/App/Core/Extensions/Sequence+ext.swift
@@ -21,4 +21,10 @@ extension Sequence {
         }
         return results
     }
+
+    func forEachAsync(_ body: (Element) async throws -> Void) async rethrows {
+        for element in self {
+            try await body(element)
+        }
+    }
 }

--- a/Sources/App/Core/Extensions/Sequence+ext.swift
+++ b/Sources/App/Core/Extensions/Sequence+ext.swift
@@ -13,16 +13,11 @@
 // limitations under the License.
 
 
-extension ThrowingTaskGroup {
-    mutating func results() async -> [Result<ChildTaskResult, Error>] {
-        var results = [Result<ChildTaskResult, Error>]()
-        while !isEmpty {
-            do {
-                guard let res = try await next() else { break }
-                results.append(.success(res))
-            } catch {
-                results.append(.failure(error))
-            }
+extension Sequence {
+    func mapAsync<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
+        var results = [T]()
+        for element in self {
+            try await results.append(transform(element))
         }
         return results
     }

--- a/Sources/App/Core/Extensions/Sequence+ext.swift
+++ b/Sources/App/Core/Extensions/Sequence+ext.swift
@@ -21,10 +21,4 @@ extension Sequence {
         }
         return results
     }
-
-    func forEachAsync(_ body: (Element) async throws -> Void) async rethrows {
-        for element in self {
-            try await body(element)
-        }
-    }
 }

--- a/Sources/App/Core/Extensions/ThrowingTaskGroup+ext.swift
+++ b/Sources/App/Core/Extensions/ThrowingTaskGroup+ext.swift
@@ -1,0 +1,29 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+extension ThrowingTaskGroup {
+    mutating func results() async -> [Result<ChildTaskResult, Error>] {
+        var results = [Result<ChildTaskResult, Error>]()
+        while !isEmpty {
+            do {
+                guard let res = try await next() else { break }
+                results.append(.success(res))
+            } catch {
+                results.append(.failure(error))
+            }
+        }
+        return results
+    }
+}

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -37,7 +37,7 @@ class ErrorReportingTests: AppTestCase {
         try Rollbar.createItem(client: client, level: .critical, message: "Test critical").wait()
     }
     
-    func test_Ingestor_error_reporting() throws {
+    func test_Ingestor_error_reporting() async throws {
         // setup
         try savePackages(on: app.db, ["1", "2"], processingStage: .reconciliation)
         Current.fetchMetadata = { _, pkg in self.future(error: AppError.invalidPackageUrl(nil, "foo")) }
@@ -51,7 +51,7 @@ class ErrorReportingTests: AppTestCase {
         }
         
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         // validation
         XCTAssertEqual(reportedError, AppError.invalidPackageUrl(nil, "foo"))

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -54,7 +54,8 @@ class IngestorTests: AppTestCase {
         }
     }
     
-    func test_fetchMetadata() throws {
+    func test_fetchMetadata() async throws {
+        // Test completion of all fetches despite early error
         // setup
         let packages = try savePackages(on: app.db, ["https://github.com/foo/1",
                                                      "https://github.com/foo/2"])
@@ -68,7 +69,7 @@ class IngestorTests: AppTestCase {
         Current.fetchLicense = { _, _ in self.future(Github.License(htmlUrl: "license")) }
 
         // MUT
-        let res = try fetchMetadata(client: app.client, packages: packages).wait()
+        let res = await fetchMetadata(client: app.client, packages: packages)
         
         // validate
         XCTAssertEqual(res.map(\.isSuccess), [false, true])
@@ -356,7 +357,7 @@ class IngestorTests: AppTestCase {
         XCTAssert(reportedError?.contains("duplicate key value violates unique constraint") ?? false)
     }
     
-    func test_issue_761_no_license() throws {
+    func test_issue_761_no_license() async throws {
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/761
         // setup
         let packages = try savePackages(on: app.db, ["https://github.com/foo/1"])
@@ -370,7 +371,7 @@ class IngestorTests: AppTestCase {
         let client = MockClient { _, resp in resp.status = .notFound }
 
         // MUT
-        let res = try fetchMetadata(client: client, packages: packages).wait()
+        let res = await fetchMetadata(client: client, packages: packages)
 
         // validate
         XCTAssertEqual(res.map(\.isSuccess), [true], "future must be in success state")

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 class IngestorTests: AppTestCase {
     
-    func test_ingest_basic() throws {
+    func test_ingest_basic() async throws {
         // setup
         let urls = ["https://github.com/finestructure/Gala",
                     "https://github.com/finestructure/Rester",
@@ -31,7 +31,7 @@ class IngestorTests: AppTestCase {
         let lastUpdate = Date()
         
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         // validate
         let repos = try Repository.query(on: app.db).all().wait()
@@ -231,14 +231,14 @@ class IngestorTests: AppTestCase {
         }
     }
     
-    func test_partial_save_issue() throws {
+    func test_partial_save_issue() async throws {
         // Test to ensure futures are properly waited for and get flushed to the db in full
         // setup
         Current.fetchMetadata = { _, pkg in self.future(.mock(for: pkg)) }
         let packages = try savePackages(on: app.db, testUrls, processingStage: .reconciliation)
         
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(testUrls.count)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(testUrls.count))
         
         // validate
         let repos = try Repository.query(on: app.db).all().wait()
@@ -268,7 +268,7 @@ class IngestorTests: AppTestCase {
                        packages.map(\.id).compactMap { $0?.uuidString }.sorted())
     }
     
-    func test_ingest_badMetadata() throws {
+    func test_ingest_badMetadata() async throws {
         // setup
         let urls = ["https://github.com/foo/1",
                     "https://github.com/foo/2",
@@ -283,7 +283,7 @@ class IngestorTests: AppTestCase {
         let lastUpdate = Date()
         
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         // validate
         let repos = try Repository.query(on: app.db).all().wait()
@@ -300,7 +300,7 @@ class IngestorTests: AppTestCase {
         }
     }
     
-    func test_ingest_unique_owner_name_violation() throws {
+    func test_ingest_unique_owner_name_violation() async throws {
         // Test error behaviour when two packages resolving to the same owner/name are ingested:
         //   - don't update package
         //   - don't create repository records
@@ -335,7 +335,7 @@ class IngestorTests: AppTestCase {
         let lastUpdate = Date()
         
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         // validate repositories (single element pointing to first package)
         let repos = try Repository.query(on: app.db).all().wait()

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -247,26 +247,6 @@ class IngestorTests: AppTestCase {
         XCTAssertEqual(Set(repos.map(\.$package.id)), Set(packages.map(\.id)))
     }
     
-    func test_insertOrUpdateRepository_bulk() async throws {
-        // test flattening of many updates
-        // Mainly a debug test for the issue described here:
-        // https://discordapp.com/channels/431917998102675485/444249946808647699/704335749637472327
-        let packages = try savePackages(on: app.db, testUrls100)
-        for pkg in packages {
-            let metadata = Github.Metadata.mock(for: pkg.url)
-            try await insertOrUpdateRepository(on: self.app.db,
-                                               for: .init(model: pkg),
-                                               metadata: metadata,
-                                               licenseInfo: .init(htmlUrl: ""),
-                                               readmeInfo: .init(downloadUrl: "", htmlUrl: ""))
-        }
-
-        let repos = try await Repository.query(on: app.db).all().get()
-        XCTAssertEqual(repos.count, testUrls100.count)
-        XCTAssertEqual(repos.map(\.$package.id.uuidString).sorted(),
-                       packages.map(\.id).compactMap { $0?.uuidString }.sorted())
-    }
-    
     func test_ingest_badMetadata() async throws {
         // setup
         let urls = ["https://github.com/foo/1",

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -59,7 +59,7 @@ class IngestorTests: AppTestCase {
         // Test completion of all fetches despite early error
         // setup
         let packages = try await savePackagesAsync(on: app.db, ["https://github.com/foo/1",
-                                                                 "https://github.com/foo/2"])
+                                                                "https://github.com/foo/2"])
             .map(Joined<Package, Repository>.init(model:))
         Current.fetchMetadata = { _, pkg in
             if pkg.url == "https://github.com/foo/1" {
@@ -107,42 +107,44 @@ class IngestorTests: AppTestCase {
         // setup
         let pkg = try await savePackageAsync(on: app.db, "2")
         let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
-        let metadata: [Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?),
-                              Error>] = [
-            .failure(AppError.metadataRequestFailed(nil, .badRequest, "1")),
-            .success((jpr,
-                      .init(defaultBranch: "main",
-                            forks: 1,
-                            issuesClosedAtDates: [
-                                Date(timeIntervalSince1970: 0),
-                                Date(timeIntervalSince1970: 2),
-                                Date(timeIntervalSince1970: 1),
-                            ],
-                            license: .mit,
-                            openIssues: 1,
-                            openPullRequests: 2,
-                            owner: "foo",
-                            pullRequestsClosedAtDates: [
-                                Date(timeIntervalSince1970: 1),
-                                Date(timeIntervalSince1970: 3),
-                                Date(timeIntervalSince1970: 2),
-                            ],
-                            releases: [
-                                .init(description: "a release",
-                                      descriptionHTML: "<p>a release</p>",
-                                      isDraft: false,
-                                      publishedAt: Date(timeIntervalSince1970: 5),
-                                      tagName: "1.2.3",
-                                      url: "https://example.com/1.2.3")
-                            ],
-                            repositoryTopics: ["foo", "bar", "Bar", "baz"],
-                            name: "bar",
-                            stars: 2,
-                            summary: "package desc",
-                            isInOrganization: true),
-                      licenseInfo: .init(htmlUrl: "license url"),
-                      readmeInfo: .init(downloadUrl: "readme url", htmlUrl: "readme html url")))
-        ]
+        let metadata: [Result<(Joined<Package, Repository>,
+                               Github.Metadata, Github.License?,
+                               Github.Readme?),
+                       Error>] = [
+                        .failure(AppError.metadataRequestFailed(nil, .badRequest, "1")),
+                        .success((jpr,
+                                  .init(defaultBranch: "main",
+                                        forks: 1,
+                                        issuesClosedAtDates: [
+                                            Date(timeIntervalSince1970: 0),
+                                            Date(timeIntervalSince1970: 2),
+                                            Date(timeIntervalSince1970: 1),
+                                        ],
+                                        license: .mit,
+                                        openIssues: 1,
+                                        openPullRequests: 2,
+                                        owner: "foo",
+                                        pullRequestsClosedAtDates: [
+                                            Date(timeIntervalSince1970: 1),
+                                            Date(timeIntervalSince1970: 3),
+                                            Date(timeIntervalSince1970: 2),
+                                        ],
+                                        releases: [
+                                            .init(description: "a release",
+                                                  descriptionHTML: "<p>a release</p>",
+                                                  isDraft: false,
+                                                  publishedAt: Date(timeIntervalSince1970: 5),
+                                                  tagName: "1.2.3",
+                                                  url: "https://example.com/1.2.3")
+                                        ],
+                                        repositoryTopics: ["foo", "bar", "Bar", "baz"],
+                                        name: "bar",
+                                        stars: 2,
+                                        summary: "package desc",
+                                        isInOrganization: true),
+                                  licenseInfo: .init(htmlUrl: "license url"),
+                                  readmeInfo: .init(downloadUrl: "readme url", htmlUrl: "readme html url")))
+                       ]
         
         // MUT
         let res = await updateRepositories(on: app.db, metadata: metadata)
@@ -150,9 +152,9 @@ class IngestorTests: AppTestCase {
         // validate
         XCTAssertEqual(res.map(\.isSuccess), [false, true])
         let repo = try await Repository.query(on: app.db)
-                .filter(\.$package.$id == pkg.requireID())
-                .first()
-                .unwrap()
+            .filter(\.$package.$id == pkg.requireID())
+            .first()
+            .unwrap()
         XCTAssertEqual(repo.defaultBranch, "main")
         XCTAssertEqual(repo.forks, 1)
         XCTAssertEqual(repo.isInOrganization, true)
@@ -184,7 +186,7 @@ class IngestorTests: AppTestCase {
     func test_updatePackage() async throws {
         // setup
         let pkgs = try await savePackagesAsync(on: app.db, ["https://github.com/foo/1",
-                                                             "https://github.com/foo/2"])
+                                                            "https://github.com/foo/2"])
             .map(Joined<Package, Repository>.init(model:))
         let results: [Result<Joined<Package, Repository>, Error>] = [
             .failure(AppError.metadataRequestFailed(try pkgs[0].model.requireID(), .badRequest, "1")),
@@ -215,7 +217,7 @@ class IngestorTests: AppTestCase {
         ]
         try await pkgs.save(on: app.db).get()
         let results: [Result<Joined<Package, Repository>, Error>] = [ .success(.init(model: pkgs[0])),
-                                              .success(.init(model: pkgs[1]))]
+                                                                      .success(.init(model: pkgs[1]))]
         
         // MUT
         try await updatePackages(client: app.client,

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -235,8 +235,9 @@ class IngestorTests: AppTestCase {
         // Test to ensure futures are properly waited for and get flushed to the db in full
         // setup
         Current.fetchMetadata = { _, pkg in self.future(.mock(for: pkg)) }
-        let packages = try savePackages(on: app.db, testUrls, processingStage: .reconciliation)
-        
+        let packages = testUrls.map { Package(url: $0, processingStage: .reconciliation) }
+        try await packages.save(on: app.db)
+
         // MUT
         try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(testUrls.count))
         

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -23,11 +23,12 @@ class IngestorTests: AppTestCase {
     
     func test_ingest_basic() async throws {
         // setup
-        let urls = ["https://github.com/finestructure/Gala",
-                    "https://github.com/finestructure/Rester",
-                    "https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server"]
         Current.fetchMetadata = { _, pkg in self.future(.mock(for: pkg)) }
-        let packages = try savePackages(on: app.db, urls.asURLs, processingStage: .reconciliation)
+        let packages = ["https://github.com/finestructure/Gala",
+                        "https://github.com/finestructure/Rester",
+                        "https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server"]
+            .map { Package(url: $0, processingStage: .reconciliation) }
+        try await packages.save(on: app.db)
         let lastUpdate = Date()
         
         // MUT

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -251,7 +251,7 @@ class IngestorTests: AppTestCase {
         // test flattening of many updates
         // Mainly a debug test for the issue described here:
         // https://discordapp.com/channels/431917998102675485/444249946808647699/704335749637472327
-        let packages = try await savePackagesAsync(on: app.db, testUrls100)
+        let packages = try savePackages(on: app.db, testUrls100)
         for pkg in packages {
             let metadata = Github.Metadata.mock(for: pkg.url)
             try await insertOrUpdateRepository(on: self.app.db,

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -102,7 +102,7 @@ class IngestorTests: AppTestCase {
         }
     }
     
-    func test_updateRepositories() throws {
+    func test_updateRepositories() async throws {
         // setup
         let pkg = try savePackage(on: app.db, "2")
         let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
@@ -144,7 +144,7 @@ class IngestorTests: AppTestCase {
         ]
         
         // MUT
-        let res = try updateRepositories(on: app.db, metadata: metadata).wait()
+        let res = try await updateRepositories(on: app.db, metadata: metadata)
         
         // validate
         XCTAssertEqual(res.map(\.isSuccess), [false, true])

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -242,7 +242,7 @@ class IngestorTests: AppTestCase {
         try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(testUrls.count))
         
         // validate
-        let repos = try Repository.query(on: app.db).all().wait()
+        let repos = try await Repository.query(on: app.db).all()
         XCTAssertEqual(repos.count, testUrls.count)
         XCTAssertEqual(Set(repos.map(\.$package.id)), Set(packages.map(\.id)))
     }

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -144,7 +144,7 @@ class IngestorTests: AppTestCase {
         ]
         
         // MUT
-        let res = try await updateRepositories(on: app.db, metadata: metadata)
+        let res = await updateRepositories(on: app.db, metadata: metadata)
         
         // validate
         XCTAssertEqual(res.map(\.isSuccess), [false, true])

--- a/Tests/AppTests/MetricsTests.swift
+++ b/Tests/AppTests/MetricsTests.swift
@@ -96,12 +96,12 @@ class MetricsTests: AppTestCase {
         XCTAssert((AppMetrics.reconcileDurationSeconds?.get()) ?? 0 > 0)
     }
 
-    func test_ingestDurationSeconds() throws {
+    func test_ingestDurationSeconds() async throws {
         // setup
         let pkg = try savePackage(on: app.db, "1")
 
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .id(pkg.id!)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .id(pkg.id!))
 
         // validation
         XCTAssert((AppMetrics.ingestDurationSeconds?.get()) ?? 0 > 0)

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -296,7 +296,7 @@ final class PackageTests: AppTestCase {
         }
 
         // run ingestion to progress package through pipeline
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT & validate
         do {
@@ -326,7 +326,7 @@ final class PackageTests: AppTestCase {
         }
 
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime) }
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         do {
             let pkg = try XCTUnwrap(Package.query(on: app.db).first().wait())
             XCTAssertFalse(pkg.isNew)

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -161,7 +161,7 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - second stage
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         do { // validate
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
@@ -201,7 +201,7 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - ingest again
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         do {  // validate - only new package moves to .ingestion stage
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
@@ -232,7 +232,7 @@ class PipelineTests: AppTestCase {
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime) }
         
         // MUT - ingest yet again
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         do {  // validate - now all three packages should have been updated
             let packages = try Package.query(on: app.db).sort(\.$url).all().wait()

--- a/Tests/AppTests/ReconcilerTests.swift
+++ b/Tests/AppTests/ReconcilerTests.swift
@@ -39,7 +39,9 @@ class ReconcilerTests: AppTestCase {
     
     func test_adds_and_deletes() async throws {
         // save intial set of packages 1, 2, 3
-        try savePackages(on: app.db, ["1", "2", "3"].asURLs)
+        for url in ["1", "2", "3"].asURLs {
+            try await Package(url: url).save(on: app.db)
+        }
         
         // new package list drops 2, 3, adds 4, 5
         let urls = ["1", "4", "5"]
@@ -49,7 +51,7 @@ class ReconcilerTests: AppTestCase {
         try await reconcile(client: app.client, database: app.db)
         
         // validate
-        let packages = try Package.query(on: app.db).all().wait()
+        let packages = try await Package.query(on: app.db).all()
         XCTAssertEqual(packages.map(\.url).sorted(), urls.sorted())
     }
 }

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -272,7 +272,7 @@ class TwitterTests: AppTestCase {
         }
         // run first two processing steps
         try await reconcile(client: app.client, database: app.db)
-            try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT - analyze, triggering the tweet
         try analyze(client: app.client,
@@ -289,7 +289,7 @@ class TwitterTests: AppTestCase {
         message = nil
         try await reconcile(client: app.client, database: app.db)
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime) }
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT - analyze, triggering tweets if any
         try analyze(client: app.client,
@@ -305,7 +305,7 @@ class TwitterTests: AppTestCase {
         tag = .tag(2, 0, 0)
         // fast forward our clock by the deadtime interval again (*2) and re-ingest
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime * 2) }
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT - analyze again
         try analyze(client: app.client,

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -102,9 +102,25 @@ func savePackage(on db: Database, id: Package.Id = UUID(), _ url: URL,
 
 
 @discardableResult
+func savePackageAsync(on db: Database, id: Package.Id = UUID(), _ url: URL,
+                 processingStage: Package.ProcessingStage? = nil) async throws -> Package {
+    let p = Package(id: id, url: url, processingStage: processingStage)
+    try await p.save(on: db)
+    return p
+}
+
+
+@discardableResult
 func savePackages(on db: Database, _ urls: [URL],
                   processingStage: Package.ProcessingStage? = nil) throws -> [Package] {
     try urls.map { try savePackage(on: db, $0, processingStage: processingStage) }
+}
+
+
+@discardableResult
+func savePackagesAsync(on db: Database, _ urls: [URL],
+                  processingStage: Package.ProcessingStage? = nil) async throws -> [Package] {
+    try await urls.mapAsync { try await savePackageAsync(on: db, $0, processingStage: processingStage) }
 }
 
 

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -92,6 +92,7 @@ func fixturesDirectory(path: String = #file) -> URL {
 // MARK: - Package db helpers
 
 
+// TODO: deprecate in favour of savePackage[Async](...) async throws
 @discardableResult
 func savePackage(on db: Database, id: Package.Id = UUID(), _ url: URL,
                  processingStage: Package.ProcessingStage? = nil) throws -> Package {
@@ -101,10 +102,29 @@ func savePackage(on db: Database, id: Package.Id = UUID(), _ url: URL,
 }
 
 
+// TODO: deprecate in favour of savePackages[Async](...) async throws
 @discardableResult
 func savePackages(on db: Database, _ urls: [URL],
                   processingStage: Package.ProcessingStage? = nil) throws -> [Package] {
     try urls.map { try savePackage(on: db, $0, processingStage: processingStage) }
+}
+
+
+@discardableResult
+func savePackageAsync(on db: Database, id: Package.Id = UUID(), _ url: URL,
+                      processingStage: Package.ProcessingStage? = nil) async throws -> Package {
+    let p = Package(id: id, url: url, processingStage: processingStage)
+    try await p.save(on: db)
+    return p
+}
+
+
+@discardableResult
+func savePackagesAsync(on db: Database, _ urls: [URL],
+                       processingStage: Package.ProcessingStage? = nil) async throws -> [Package] {
+    try await urls.mapAsync {
+        try await savePackageAsync(on: db, $0, processingStage: processingStage)
+    }
 }
 
 

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -102,25 +102,9 @@ func savePackage(on db: Database, id: Package.Id = UUID(), _ url: URL,
 
 
 @discardableResult
-func savePackageAsync(on db: Database, id: Package.Id = UUID(), _ url: URL,
-                 processingStage: Package.ProcessingStage? = nil) async throws -> Package {
-    let p = Package(id: id, url: url, processingStage: processingStage)
-    try await p.save(on: db)
-    return p
-}
-
-
-@discardableResult
 func savePackages(on db: Database, _ urls: [URL],
                   processingStage: Package.ProcessingStage? = nil) throws -> [Package] {
     try urls.map { try savePackage(on: db, $0, processingStage: processingStage) }
-}
-
-
-@discardableResult
-func savePackagesAsync(on db: Database, _ urls: [URL],
-                  processingStage: Package.ProcessingStage? = nil) async throws -> [Package] {
-    try await urls.mapAsync { try await savePackageAsync(on: db, $0, processingStage: processingStage) }
 }
 
 


### PR DESCRIPTION
We're getting a reproducible TSAN related failure:

```
Test Case 'IngestorTests.test_insertOrUpdateRepository' started at 2022-01-18 13:15:25.568
ThreadSanitizer:DEADLYSIGNAL
==8776==ERROR: ThreadSanitizer: SEGV on unknown address 0x7b680003ae20 (pc 0x7b680003ae20 bp 0x7b6000012d80 sp 0x7f7ca279de08 T8778)
==8776==The signal is caused by a READ memory access.
ThreadSanitizer:DEADLYSIGNAL
==8776==Hint: PC is at a non-executable region. Maybe a wild jump?
    #0 <null> <null> (0x7b680003ae20)

ThreadSanitizer can not provide additional info.
SUMMARY: ThreadSanitizer: SEGV (<unknown module>) 
==8776==ABORTING
error: terminated(1): /usr/bin/llvm-profdata merge -sparse -o /__w/SwiftPackageIndex-Server/SwiftPackageIndex-Server/.build/x86_64-unknown-linux-gnu/debug/codecov/default.profdata output:
    error: No input files specified. See llvm-profdata merge -help

make: *** [Makefile:36: test] Error 1
```

I can't tell if it's TSAN crashing or TSAN finding an issue. FWIW, it's passing with TSAN on macOS.

I've tried running this in Docker on arm64 but _every_ test fails with the following error:

```
error: terminated(66): /workspaces/spi-server/.build/aarch64-unknown-linux-gnu/debug/SPI-ServerPackageTests.xctest --dump-tests-json output:
    FATAL: ThreadSanitizer CHECK failed: /home/build-user/llvm-project/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp:296 "((personality(old_personality | ADDR_NO_RANDOMIZE))) != ((-1))" (0xffffffffffffffff, 0xffffffffffffffff)
        #0 __tsan::TsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) /home/build-user/llvm-project/compiler-rt/lib/tsan/rtl/tsan_rtl_report.cpp:47 (SPI-ServerPackageTests.xctest+0x2fc3e0)
        #1 __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long) /home/build-user/llvm-project/compiler-rt/lib/sanitizer_common/sanitizer_termination.cpp:78 (SPI-ServerPackageTests.xctest+0x2767a0)
        #2 __tsan::InitializePlatform() /home/build-user/llvm-project/compiler-rt/lib/tsan/rtl/tsan_platform_linux.cpp:296 (SPI-ServerPackageTests.xctest+0x30328c)
        #3 __tsan::Initialize(__tsan::ThreadState*) /home/build-user/llvm-project/compiler-rt/lib/tsan/rtl/tsan_rtl.cpp:401 (SPI-ServerPackageTests.xctest+0x2ed508)
        #4 _dl_rtld_di_serinfo ??:? (ld-linux-aarch64.so.1+0xe9c0)
        #5 <null> <null> (ld-linux-aarch64.so.1+0x1140)
```

Need to try and repro this on an x86_64 machine.