### PR TITLE
Async ingest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,10 @@ jobs:
       - name: Install unzip
         run: apt-get update && apt-get install -y unzip
       - name: Run tests
-        run: cp .env.testing.template .env.testing && make test
+        # temporarily run without TSAN due to false positives on Linux
+        # https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1496
+        # Review with Swift 5.6
+        run: cp .env.testing.template .env.testing && make test-without-tsan
         env:
           COLLECTION_SIGNING_PRIVATE_KEY: ${{ secrets.COLLECTION_SIGNING_PRIVATE_KEY }}
           DATABASE_HOST: postgres

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,10 @@ test:
 	env RUN_IMAGE_SNAPSHOT_TESTS=true \
 	swift test --enable-code-coverage --disable-automatic-resolution --sanitize=thread
 
+test-without-tsan:
+	env RUN_IMAGE_SNAPSHOT_TESTS=true \
+	swift test --enable-code-coverage --disable-automatic-resolution
+
 test-fast:
 	@echo Skipping image snapshot tests
 	@echo Running without --sanitize=thread

--- a/Sources/App/Commands/CommandAsync.swift
+++ b/Sources/App/Commands/CommandAsync.swift
@@ -1,0 +1,25 @@
+import Vapor
+
+
+protocol CommandAsync: Command {
+    // Specifically avoid marking this function `throws` to ensure all
+    // errors are handled. Otherwise errors thrown would escape and
+    // leave the task dangling.
+    // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1493
+    func run(using context: CommandContext, signature: Signature) async
+}
+
+
+extension CommandAsync {
+    func run(using context: CommandContext, signature: Signature) throws {
+        let group = DispatchGroup()
+        group.enter()
+
+        Task {
+            defer { group.leave() }
+            await run(using: context, signature: signature)
+        }
+
+        group.wait()
+    }
+}

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -139,17 +139,20 @@ func ingest(client: Client,
 func fetchMetadata(
     client: Client, packages: [Joined<Package, Repository>]
 ) async -> [Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?), Error>] {
-    await packages.mapAsync { pkg -> Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?), Error> in
-        do {
-            // We could run these tasks concurrently via `async let`.
-            // Keeping pre-async/await behaviour of running them sequentially for now.
-            let metadata = try await Current.fetchMetadata(client, pkg.model.url).get()
-            let license = try await Current.fetchLicense(client, pkg.model.url).get()
-            let readme = try await Current.fetchReadme(client, pkg.model.url).get()
-            return .success((pkg, metadata, license, readme))
-        } catch {
-            return .failure(error)
+    await withThrowingTaskGroup(
+        of: (Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?).self,
+        returning: [Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?), Error>].self
+    ) { group in
+        for pkg in packages {
+            group.addTask {
+                async let metadata = try await Current.fetchMetadata(client, pkg.model.url).get()
+                async let license = try await Current.fetchLicense(client, pkg.model.url).get()
+                async let readme = try await Current.fetchReadme(client, pkg.model.url).get()
+                return try await (pkg, metadata, license, readme)
+            }
         }
+
+        return await group.results()
     }
 }
 
@@ -163,21 +166,29 @@ func updateRepositories(
     on database: Database,
     metadata: [Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?), Error>]
 ) async -> [Result<Joined<Package, Repository>, Error>] {
-    await metadata.mapAsync { result -> Result<Joined<Package, Repository>, Error> in
-        switch result {
-            case let .success((pkg, metadata, licenseInfo, readmeInfo)):
-                AppMetrics.ingestMetadataSuccessCount?.inc()
-                return await Result {
-                    try await insertOrUpdateRepository(on: database,
-                                                       for: pkg,
-                                                       metadata: metadata,
-                                                       licenseInfo: licenseInfo,
-                                                       readmeInfo: readmeInfo)
-                }.map { pkg }
-            case let .failure(error):
-                AppMetrics.ingestMetadataFailureCount?.inc()
-                return .failure(error)
+    await withThrowingTaskGroup(
+        of: Joined<Package, Repository>.self,
+        returning: [Result<Joined<Package, Repository>, Error>].self
+    ) { group in
+        for result in metadata {
+            group.addTask {
+                switch result {
+                    case let .success((pkg, metadata, licenseInfo, readmeInfo)):
+                        AppMetrics.ingestMetadataSuccessCount?.inc()
+                        try await insertOrUpdateRepository(on: database,
+                                                           for: pkg,
+                                                           metadata: metadata,
+                                                           licenseInfo: licenseInfo,
+                                                           readmeInfo: readmeInfo)
+                        return pkg
+                    case let .failure(error):
+                        AppMetrics.ingestMetadataFailureCount?.inc()
+                        throw error
+                }
+            }
         }
+
+        return await group.results()
     }
 }
 

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -16,7 +16,7 @@ import Vapor
 import Fluent
 
 
-struct IngestCommand: Command {
+struct IngestCommand: CommandAsync {
     let defaultLimit = 1
     
     struct Signature: CommandSignature {
@@ -34,7 +34,7 @@ struct IngestCommand: Command {
         case limit(Int)
     }
 
-    func run(using context: CommandContext, signature: Signature) throws {
+    func run(using context: CommandContext, signature: Signature) async {
         let limit = signature.limit ?? defaultLimit
 
         let client = context.application.client
@@ -44,11 +44,16 @@ struct IngestCommand: Command {
         Self.resetMetrics()
 
         let mode = signature.id.map(Mode.id) ?? .limit(limit)
-        try ingest(client: client, database: db, logger: logger, mode: mode)
-            .wait()
-        try AppMetrics.push(client: client,
-                            logger: logger,
-                            jobName: "ingest").wait()
+
+        do {
+            try await ingest(client: client, database: db, logger: logger, mode: mode)
+        } catch {
+            logger.error("\(error.localizedDescription)")
+        }
+
+        try? await AppMetrics.push(client: client,
+                                   logger: logger,
+                                   jobName: "ingest")
     }
 }
 
@@ -71,32 +76,25 @@ extension IngestCommand {
 func ingest(client: Client,
             database: Database,
             logger: Logger,
-            mode: IngestCommand.Mode) -> EventLoopFuture<Void> {
+            mode: IngestCommand.Mode) async throws {
     let start = DispatchTime.now().uptimeNanoseconds
+    defer { AppMetrics.ingestDurationSeconds?.time(since: start) }
+
     switch mode {
         case .id(let id):
             logger.info("Ingesting (id: \(id)) ...")
-            return Package.fetchCandidate(database, id: id)
-                .map { [$0] }
-                .flatMap { packages in
-                    ingest(client: client,
-                           database: database,
-                           logger: logger,
-                           packages: packages)
-                }
-                .map {
-                    AppMetrics.ingestDurationSeconds?.time(since: start)
-                }
+            let pkg = try await Package.fetchCandidate(database, id: id).get()
+            try await ingest(client: client,
+                             database: database,
+                             logger: logger,
+                             packages: [pkg])
         case .limit(let limit):
             logger.info("Ingesting (limit: \(limit)) ...")
-            return Package.fetchCandidates(database, for: .ingestion, limit: limit)
-                .flatMap { ingest(client: client,
-                                  database: database,
-                                  logger: logger,
-                                  packages: $0) }
-                .map {
-                    AppMetrics.ingestDurationSeconds?.time(since: start)
-                }
+            let packages = try await Package.fetchCandidates(database, for: .ingestion, limit: limit).get()
+            try await ingest(client: client,
+                             database: database,
+                             logger: logger,
+                             packages: packages)
     }
 }
 
@@ -111,16 +109,25 @@ func ingest(client: Client,
 func ingest(client: Client,
             database: Database,
             logger: Logger,
-            packages: [Joined<Package, Repository>]) -> EventLoopFuture<Void> {
+            packages: [Joined<Package, Repository>]) async throws {
     logger.debug("Ingesting \(packages.compactMap {$0.model.id})")
     AppMetrics.ingestCandidatesCount?.set(packages.count)
-    let metadata = fetchMetadata(client: client, packages: packages)
-    let updates = metadata.flatMap { updateRepositories(on: database, metadata: $0) }
-    return updates.flatMap { updatePackages(client: client,
-                                            database: database,
-                                            logger: logger,
-                                            results: $0,
-                                            stage: .ingestion) }
+    // TODO: simplify the types in this chain by running the batches "vertically" instead of "horizontally"
+    // i.e. instead of [package, data1, data2, ...] -> updatePackages(...)
+    // run
+    // let data1 = ...
+    // let data2 = ...
+    // updatePackage(...)
+    // i.e. loop through each package end-to-end instead of building a wide tuple.
+    // (I'm pretty sure none of the db queries are actually batch queries, so we wouldn't
+    // introduce any extra latency. Should check if we could make them batch, though.)
+    let metadata = await fetchMetadata(client: client, packages: packages)
+    let updates = await updateRepositories(on: database, metadata: metadata)
+    return try await updatePackages(client: client,
+                                    database: database,
+                                    logger: logger,
+                                    results: updates,
+                                    stage: .ingestion).get()
 }
 
 
@@ -131,14 +138,19 @@ func ingest(client: Client,
 /// - Returns: results future
 func fetchMetadata(
     client: Client, packages: [Joined<Package, Repository>]
-) -> EventLoopFuture<[Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?), Error>]> {
-    let ops = packages.map { pkg in
-        Current.fetchMetadata(client, pkg.model.url)
-            .and(Current.fetchLicense(client, pkg.model.url))
-            .and(Current.fetchReadme(client, pkg.model.url))
-            .map { (pkg, $0.0, $0.1, $1) }
+) async -> [Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?), Error>] {
+    await packages.mapAsync { pkg -> Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?), Error> in
+        do {
+            // We could run these tasks concurrently via `async let`.
+            // Keeping pre-async/await behaviour of running them sequentially for now.
+            let metadata = try await Current.fetchMetadata(client, pkg.model.url).get()
+            let license = try await Current.fetchLicense(client, pkg.model.url).get()
+            let readme = try await Current.fetchReadme(client, pkg.model.url).get()
+            return .success((pkg, metadata, license, readme))
+        } catch {
+            return .failure(error)
+        }
     }
-    return EventLoopFuture.whenAllComplete(ops, on: client.eventLoop)
 }
 
 
@@ -150,23 +162,23 @@ func fetchMetadata(
 func updateRepositories(
     on database: Database,
     metadata: [Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?), Error>]
-) -> EventLoopFuture<[Result<Joined<Package, Repository>, Error>]> {
-    let ops = metadata.map { result -> EventLoopFuture<Joined<Package, Repository>> in
+) async -> [Result<Joined<Package, Repository>, Error>] {
+    await metadata.mapAsync { result -> Result<Joined<Package, Repository>, Error> in
         switch result {
             case let .success((pkg, metadata, licenseInfo, readmeInfo)):
                 AppMetrics.ingestMetadataSuccessCount?.inc()
-                return insertOrUpdateRepository(on: database,
-                                                for: pkg,
-                                                metadata: metadata,
-                                                licenseInfo: licenseInfo,
-                                                readmeInfo: readmeInfo)
-                    .map { pkg }
+                return await Result {
+                    try await insertOrUpdateRepository(on: database,
+                                                       for: pkg,
+                                                       metadata: metadata,
+                                                       licenseInfo: licenseInfo,
+                                                       readmeInfo: readmeInfo)
+                }.map { pkg }
             case let .failure(error):
                 AppMetrics.ingestMetadataFailureCount?.inc()
-                return database.eventLoop.future(error: error)
+                return .failure(error)
         }
     }
-    return EventLoopFuture.whenAllComplete(ops, on: database.eventLoop)
 }
 
 
@@ -180,41 +192,39 @@ func insertOrUpdateRepository(on database: Database,
                               for package: Joined<Package, Repository>,
                               metadata: Github.Metadata,
                               licenseInfo: Github.License?,
-                              readmeInfo: Github.Readme?) -> EventLoopFuture<Void> {
+                              readmeInfo: Github.Readme?) async throws {
     guard let pkgId = try? package.model.requireID() else {
-        return database.eventLoop.future(error: AppError.genericError(nil, "package id not found"))
+        throw AppError.genericError(nil, "package id not found")
     }
 
-    return Repository.query(on: database)
+    guard let repository = metadata.repository else {
+        throw AppError.genericError(pkgId, "repository is nil for package \(package.model.url)")
+    }
+
+    let repo = try await Repository.query(on: database)
         .filter(\.$package.$id == pkgId)
-        .first()
-        .flatMap { repo -> EventLoopFuture<Void> in
-            guard let repository = metadata.repository else {
-                return database.eventLoop.future(
-                    error: AppError.genericError(pkgId, "repository is nil for package \(package.model.url)"))
-            }
-            let repo = repo ?? Repository(packageId: pkgId)
-            repo.defaultBranch = repository.defaultBranch
-            repo.forks = repository.forkCount
-            repo.isArchived = repository.isArchived
-            repo.isInOrganization = repository.isInOrganization
-            repo.keywords = Set(repository.topics.map { $0.lowercased() }).sorted()
-            repo.lastIssueClosedAt = repository.lastIssueClosedAt
-            repo.lastPullRequestClosedAt = repository.lastPullRequestClosedAt
-            repo.license = .init(from: repository.licenseInfo)
-            repo.licenseUrl = licenseInfo?.htmlUrl
-            repo.name = repository.name
-            repo.openIssues = repository.openIssues.totalCount
-            repo.openPullRequests = repository.openPullRequests.totalCount
-            repo.owner = repository.owner.login
-            repo.ownerName = repository.owner.name
-            repo.ownerAvatarUrl = repository.owner.avatarUrl
-            repo.readmeUrl = readmeInfo?.downloadUrl
-            repo.readmeHtmlUrl = readmeInfo?.htmlUrl
-            repo.releases = metadata.repository?.releases.nodes
-                .map(Release.init(from:)) ?? []
-            repo.stars = repository.stargazerCount
-            repo.summary = repository.description
-            return repo.save(on: database)
-        }
+        .first() ?? Repository(packageId: pkgId)
+    repo.defaultBranch = repository.defaultBranch
+    repo.forks = repository.forkCount
+    repo.isArchived = repository.isArchived
+    repo.isInOrganization = repository.isInOrganization
+    repo.keywords = Set(repository.topics.map { $0.lowercased() }).sorted()
+    repo.lastIssueClosedAt = repository.lastIssueClosedAt
+    repo.lastPullRequestClosedAt = repository.lastPullRequestClosedAt
+    repo.license = .init(from: repository.licenseInfo)
+    repo.licenseUrl = licenseInfo?.htmlUrl
+    repo.name = repository.name
+    repo.openIssues = repository.openIssues.totalCount
+    repo.openPullRequests = repository.openPullRequests.totalCount
+    repo.owner = repository.owner.login
+    repo.ownerName = repository.owner.name
+    repo.ownerAvatarUrl = repository.owner.avatarUrl
+    repo.readmeUrl = readmeInfo?.downloadUrl
+    repo.readmeHtmlUrl = readmeInfo?.htmlUrl
+    repo.releases = metadata.repository?.releases.nodes
+        .map(Release.init(from:)) ?? []
+    repo.stars = repository.stargazerCount
+    repo.summary = repository.description
+
+    try await repo.save(on: database)
 }

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -80,18 +80,14 @@ extension API {
             switch cmd {
                 case .reconcile:
                     try await reconcile(client: req.client, database: req.db)
-                    return try await Package.query(on: req.db).count()
-                        .map { Command.Response.init(status: "ok", rows: $0) }
-                        .get()
+                    let rowCount = try await Package.query(on: req.db).count()
+                    return .init(status: "ok", rows: rowCount)
                 case .ingest:
-                    return try await ingest(client: req.application.client,
-                                            database: req.application.db,
-                                            logger: req.application.logger,
-                                            mode: .limit(limit))
-                        .map {
-                            Command.Response(status: "ok", rows: limit)
-                        }
-                        .get()
+                    try await ingest(client: req.application.client,
+                                     database: req.application.db,
+                                     logger: req.application.logger,
+                                     mode: .limit(limit))
+                    return .init(status: "ok", rows: limit)
                 case .analyze:
                     return try await analyze(client: req.application.client,
                                              database: req.application.db,

--- a/Sources/App/Core/ErrorMiddleware.swift
+++ b/Sources/App/Core/ErrorMiddleware.swift
@@ -38,10 +38,9 @@ public final class ErrorMiddleware: AsyncMiddleware {
                 Current.logger()?.error("ErrorPage.View \(statusCode): \(error.localizedDescription)")
             }
 
-            return try await ErrorPage.View(path: req.url.path, error: abortError)
+            return ErrorPage.View(path: req.url.path, error: abortError)
                 .document()
                 .encodeResponse(for: req, status: abortError.status)
-                .get()
         }
     }
 

--- a/Sources/App/Core/Extensions/Model+ext.swift
+++ b/Sources/App/Core/Extensions/Model+ext.swift
@@ -21,7 +21,13 @@ extension Array where Element: FluentKit.Model {
             $0.save(on: database)
         }.flatten(on: database.eventLoop)
     }
-    
+
+    public func save(on database: Database) async throws -> Void {
+        for element in self {
+            try await element.save(on: database)
+        }
+    }
+
     public func update(on database: Database) -> EventLoopFuture<Void> {
         map {
             $0.update(on: database)

--- a/Sources/App/Core/Extensions/Optional+ext.swift
+++ b/Sources/App/Core/Extensions/Optional+ext.swift
@@ -12,27 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Plot
-import Vapor
 
-protocol Renderable {
-    func render() -> String
-}
-
-extension Renderable {
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
-        request.eventLoop.future(encodeResponse(for: request, status: .ok))
+extension Optional {
+    func unwrap(or error: @autoclosure @escaping () -> Error) throws -> WrappedType {
+        guard let unwrapped = self else {
+            throw error()
+        }
+        return unwrapped
     }
 
-    public func encodeResponse(for request: Request, status: HTTPResponseStatus) -> Response {
-        let res = Response(status: status, body: .init(string: self.render()))
-        res.headers.add(name: "Content-Type", value: "text/html; charset=utf-8")
-        return res
+    func unwrap() throws -> WrappedType {
+        try unwrap(or: OptionError.unexpectedNil)
     }
-}
 
-extension HTML: Renderable, ResponseEncodable  {
-}
-
-extension Node: Renderable, ResponseEncodable {
+    enum OptionError: Error {
+        case unexpectedNil
+    }
 }

--- a/Sources/App/Core/Extensions/Result+ext.swift
+++ b/Sources/App/Core/Extensions/Result+ext.swift
@@ -23,3 +23,14 @@ extension Result {
         }
     }
 }
+
+
+extension Result where Failure == Error {
+    init(catching body: () async throws -> Success) async {
+        do {
+            self = .success(try await body())
+        } catch {
+            self = .failure(error)
+        }
+    }
+}

--- a/Sources/App/Core/Extensions/Sequence+ext.swift
+++ b/Sources/App/Core/Extensions/Sequence+ext.swift
@@ -12,27 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Plot
-import Vapor
 
-protocol Renderable {
-    func render() -> String
-}
-
-extension Renderable {
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
-        request.eventLoop.future(encodeResponse(for: request, status: .ok))
+extension Sequence {
+    func mapAsync<T>(_ transform: (Element) async throws -> T) async rethrows -> [T] {
+        var results = [T]()
+        for element in self {
+            try await results.append(transform(element))
+        }
+        return results
     }
-
-    public func encodeResponse(for request: Request, status: HTTPResponseStatus) -> Response {
-        let res = Response(status: status, body: .init(string: self.render()))
-        res.headers.add(name: "Content-Type", value: "text/html; charset=utf-8")
-        return res
-    }
-}
-
-extension HTML: Renderable, ResponseEncodable  {
-}
-
-extension Node: Renderable, ResponseEncodable {
 }

--- a/Sources/App/Core/Extensions/ThrowingTaskGroup+ext.swift
+++ b/Sources/App/Core/Extensions/ThrowingTaskGroup+ext.swift
@@ -1,0 +1,29 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+extension ThrowingTaskGroup {
+    mutating func results() async -> [Result<ChildTaskResult, Error>] {
+        var results = [Result<ChildTaskResult, Error>]()
+        while !isEmpty {
+            do {
+                guard let res = try await next() else { break }
+                results.append(.success(res))
+            } catch {
+                results.append(.failure(error))
+            }
+        }
+        return results
+    }
+}

--- a/Tests/AppTests/ErrorMiddlewareTests.swift
+++ b/Tests/AppTests/ErrorMiddlewareTests.swift
@@ -84,7 +84,9 @@ class ErrorMiddlewareTests: AppTestCase {
         
         try app.test(.GET, "500", afterResponse: { response in
             XCTAssertEqual(reportedLevel, .critical)
-            XCTAssert(reportedError?.contains("Abort.500: Internal Server Error") ?? false)
+            let errorMessage = try reportedError.unwrap()
+            XCTAssert(errorMessage.contains("Abort.500: Internal Server Error"),
+                      "error was: \(errorMessage)")
         })
     }
     

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -37,7 +37,7 @@ class ErrorReportingTests: AppTestCase {
         try Rollbar.createItem(client: client, level: .critical, message: "Test critical").wait()
     }
     
-    func test_Ingestor_error_reporting() throws {
+    func test_Ingestor_error_reporting() async throws {
         // setup
         try savePackages(on: app.db, ["1", "2"], processingStage: .reconciliation)
         Current.fetchMetadata = { _, pkg in self.future(error: AppError.invalidPackageUrl(nil, "foo")) }
@@ -51,7 +51,7 @@ class ErrorReportingTests: AppTestCase {
         }
         
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         // validation
         XCTAssertEqual(reportedError, AppError.invalidPackageUrl(nil, "foo"))

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -21,20 +21,21 @@ import XCTest
 
 class IngestorTests: AppTestCase {
     
-    func test_ingest_basic() throws {
+    func test_ingest_basic() async throws {
         // setup
-        let urls = ["https://github.com/finestructure/Gala",
-                    "https://github.com/finestructure/Rester",
-                    "https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server"]
         Current.fetchMetadata = { _, pkg in self.future(.mock(for: pkg)) }
-        let packages = try savePackages(on: app.db, urls.asURLs, processingStage: .reconciliation)
+        let packages = ["https://github.com/finestructure/Gala",
+                        "https://github.com/finestructure/Rester",
+                        "https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server"]
+            .map { Package(url: $0, processingStage: .reconciliation) }
+        try await packages.save(on: app.db)
         let lastUpdate = Date()
         
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         // validate
-        let repos = try Repository.query(on: app.db).all().wait()
+        let repos = try await Repository.query(on: app.db).all()
         XCTAssertEqual(Set(repos.map(\.$package.id)), Set(packages.map(\.id)))
         repos.forEach {
             XCTAssertNotNil($0.id)
@@ -47,17 +48,18 @@ class IngestorTests: AppTestCase {
             XCTAssert($0.stars > 0)
         }
         // assert packages have been updated
-        (try Package.query(on: app.db).all().wait()).forEach {
+        (try await Package.query(on: app.db).all()).forEach {
             XCTAssert($0.updatedAt != nil && $0.updatedAt! > lastUpdate)
             XCTAssertEqual($0.status, .new)
             XCTAssertEqual($0.processingStage, .ingestion)
         }
     }
     
-    func test_fetchMetadata() throws {
+    func test_fetchMetadata() async throws {
+        // Test completion of all fetches despite early error
         // setup
-        let packages = try savePackages(on: app.db, ["https://github.com/foo/1",
-                                                     "https://github.com/foo/2"])
+        let packages = try await savePackagesAsync(on: app.db, ["https://github.com/foo/1",
+                                                                "https://github.com/foo/2"])
             .map(Joined<Package, Repository>.init(model:))
         Current.fetchMetadata = { _, pkg in
             if pkg.url == "https://github.com/foo/1" {
@@ -68,7 +70,7 @@ class IngestorTests: AppTestCase {
         Current.fetchLicense = { _, _ in self.future(Github.License(htmlUrl: "license")) }
 
         // MUT
-        let res = try fetchMetadata(client: app.client, packages: packages).wait()
+        let res = await fetchMetadata(client: app.client, packages: packages)
         
         // validate
         XCTAssertEqual(res.map(\.isSuccess), [false, true])
@@ -76,82 +78,83 @@ class IngestorTests: AppTestCase {
         XCTAssertEqual(license, .init(htmlUrl: "license"))
     }
     
-    func test_insertOrUpdateRepository() throws {
-        let pkg = try savePackage(on: app.db, "https://github.com/foo/bar")
-        let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
+    func test_insertOrUpdateRepository() async throws {
+        let pkg = try await savePackageAsync(on: app.db, "https://github.com/foo/bar")
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
         do {  // test insert
-            try insertOrUpdateRepository(on: app.db,
-                                         for: jpr,
-                                         metadata: .mock(for: pkg.url),
-                                         licenseInfo: .init(htmlUrl: ""),
-                                         readmeInfo: .init(downloadUrl: "", htmlUrl: "")).wait()
-            let repos = try Repository.query(on: app.db).all().wait()
+            try await insertOrUpdateRepository(on: app.db,
+                                               for: jpr,
+                                               metadata: .mock(for: pkg.url),
+                                               licenseInfo: .init(htmlUrl: ""),
+                                               readmeInfo: .init(downloadUrl: "", htmlUrl: ""))
+            let repos = try await Repository.query(on: app.db).all()
             XCTAssertEqual(repos.map(\.summary), [.some("This is package https://github.com/foo/bar")])
         }
         do {  // test update - run the same package again, with different metadata
             var md = Github.Metadata.mock(for: pkg.url)
             md.repository?.description = "New description"
-            try insertOrUpdateRepository(on: app.db,
-                                         for: jpr,
-                                         metadata: md,
-                                         licenseInfo: .init(htmlUrl: ""),
-                                         readmeInfo: .init(downloadUrl: "", htmlUrl: "")).wait()
-            let repos = try Repository.query(on: app.db).all().wait()
+            try await insertOrUpdateRepository(on: app.db,
+                                               for: jpr,
+                                               metadata: md,
+                                               licenseInfo: .init(htmlUrl: ""),
+                                               readmeInfo: .init(downloadUrl: "", htmlUrl: ""))
+            let repos = try await Repository.query(on: app.db).all().get()
             XCTAssertEqual(repos.map(\.summary), [.some("New description")])
         }
     }
     
-    func test_updateRepositories() throws {
+    func test_updateRepositories() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "2")
-        let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
-        let metadata: [Result<(Joined<Package, Repository>, Github.Metadata, Github.License?, Github.Readme?),
-                              Error>] = [
-            .failure(AppError.metadataRequestFailed(nil, .badRequest, "1")),
-            .success((jpr,
-                      .init(defaultBranch: "main",
-                            forks: 1,
-                            issuesClosedAtDates: [
-                                Date(timeIntervalSince1970: 0),
-                                Date(timeIntervalSince1970: 2),
-                                Date(timeIntervalSince1970: 1),
-                            ],
-                            license: .mit,
-                            openIssues: 1,
-                            openPullRequests: 2,
-                            owner: "foo",
-                            pullRequestsClosedAtDates: [
-                                Date(timeIntervalSince1970: 1),
-                                Date(timeIntervalSince1970: 3),
-                                Date(timeIntervalSince1970: 2),
-                            ],
-                            releases: [
-                                .init(description: "a release",
-                                      descriptionHTML: "<p>a release</p>",
-                                      isDraft: false,
-                                      publishedAt: Date(timeIntervalSince1970: 5),
-                                      tagName: "1.2.3",
-                                      url: "https://example.com/1.2.3")
-                            ],
-                            repositoryTopics: ["foo", "bar", "Bar", "baz"],
-                            name: "bar",
-                            stars: 2,
-                            summary: "package desc",
-                            isInOrganization: true),
-                      licenseInfo: .init(htmlUrl: "license url"),
-                      readmeInfo: .init(downloadUrl: "readme url", htmlUrl: "readme html url")))
-        ]
+        let pkg = try await savePackageAsync(on: app.db, "2")
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
+        let metadata: [Result<(Joined<Package, Repository>,
+                               Github.Metadata, Github.License?,
+                               Github.Readme?),
+                       Error>] = [
+                        .failure(AppError.metadataRequestFailed(nil, .badRequest, "1")),
+                        .success((jpr,
+                                  .init(defaultBranch: "main",
+                                        forks: 1,
+                                        issuesClosedAtDates: [
+                                            Date(timeIntervalSince1970: 0),
+                                            Date(timeIntervalSince1970: 2),
+                                            Date(timeIntervalSince1970: 1),
+                                        ],
+                                        license: .mit,
+                                        openIssues: 1,
+                                        openPullRequests: 2,
+                                        owner: "foo",
+                                        pullRequestsClosedAtDates: [
+                                            Date(timeIntervalSince1970: 1),
+                                            Date(timeIntervalSince1970: 3),
+                                            Date(timeIntervalSince1970: 2),
+                                        ],
+                                        releases: [
+                                            .init(description: "a release",
+                                                  descriptionHTML: "<p>a release</p>",
+                                                  isDraft: false,
+                                                  publishedAt: Date(timeIntervalSince1970: 5),
+                                                  tagName: "1.2.3",
+                                                  url: "https://example.com/1.2.3")
+                                        ],
+                                        repositoryTopics: ["foo", "bar", "Bar", "baz"],
+                                        name: "bar",
+                                        stars: 2,
+                                        summary: "package desc",
+                                        isInOrganization: true),
+                                  licenseInfo: .init(htmlUrl: "license url"),
+                                  readmeInfo: .init(downloadUrl: "readme url", htmlUrl: "readme html url")))
+                       ]
         
         // MUT
-        let res = try updateRepositories(on: app.db, metadata: metadata).wait()
+        let res = await updateRepositories(on: app.db, metadata: metadata)
         
         // validate
         XCTAssertEqual(res.map(\.isSuccess), [false, true])
-        let repo = try XCTUnwrap(
-            Repository.query(on: app.db)
-                .filter(\.$package.$id == pkg.requireID())
-                .first().wait()
-        )
+        let repo = try await Repository.query(on: app.db)
+            .filter(\.$package.$id == pkg.requireID())
+            .first()
+            .unwrap()
         XCTAssertEqual(repo.defaultBranch, "main")
         XCTAssertEqual(repo.forks, 1)
         XCTAssertEqual(repo.isInOrganization, true)
@@ -180,10 +183,10 @@ class IngestorTests: AppTestCase {
         XCTAssertEqual(repo.summary, "package desc")
     }
     
-    func test_updatePackage() throws {
+    func test_updatePackage() async throws {
         // setup
-        let pkgs = try savePackages(on: app.db, ["https://github.com/foo/1",
-                                                 "https://github.com/foo/2"])
+        let pkgs = try await savePackagesAsync(on: app.db, ["https://github.com/foo/1",
+                                                            "https://github.com/foo/2"])
             .map(Joined<Package, Repository>.init(model:))
         let results: [Result<Joined<Package, Repository>, Error>] = [
             .failure(AppError.metadataRequestFailed(try pkgs[0].model.requireID(), .badRequest, "1")),
@@ -191,89 +194,69 @@ class IngestorTests: AppTestCase {
         ]
         
         // MUT
-        try updatePackages(client: app.client,
-                           database: app.db,
-                           logger: app.logger,
-                           results: results,
-                           stage: .ingestion).wait()
+        try await updatePackages(client: app.client,
+                                 database: app.db,
+                                 logger: app.logger,
+                                 results: results,
+                                 stage: .ingestion).get()
         
         // validate
         do {
-            let pkgs = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let pkgs = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(pkgs.map(\.status), [.metadataRequestFailed, .new])
             XCTAssertEqual(pkgs.map(\.processingStage), [.ingestion, .ingestion])
         }
     }
     
-    func test_updatePackages_new() throws {
+    func test_updatePackages_new() async throws {
         // Ensure newly ingested packages are passed on with status = new to fast-track
         // them into analysis
         let pkgs = [
             Package(id: UUID(), url: "https://github.com/foo/1", status: .ok, processingStage: .reconciliation),
             Package(id: UUID(), url: "https://github.com/foo/2", status: .new, processingStage: .reconciliation)
         ]
-        try pkgs.save(on: app.db).wait()
+        try await pkgs.save(on: app.db).get()
         let results: [Result<Joined<Package, Repository>, Error>] = [ .success(.init(model: pkgs[0])),
-                                              .success(.init(model: pkgs[1]))]
+                                                                      .success(.init(model: pkgs[1]))]
         
         // MUT
-        try updatePackages(client: app.client,
-                           database: app.db,
-                           logger: app.logger,
-                           results: results,
-                           stage: .ingestion).wait()
+        try await updatePackages(client: app.client,
+                                 database: app.db,
+                                 logger: app.logger,
+                                 results: results,
+                                 stage: .ingestion).get()
         
         // validate
         do {
-            let pkgs = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let pkgs = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(pkgs.map(\.status), [.ok, .new])
             XCTAssertEqual(pkgs.map(\.processingStage), [.ingestion, .ingestion])
         }
     }
     
-    func test_partial_save_issue() throws {
+    func test_partial_save_issue() async throws {
         // Test to ensure futures are properly waited for and get flushed to the db in full
         // setup
         Current.fetchMetadata = { _, pkg in self.future(.mock(for: pkg)) }
-        let packages = try savePackages(on: app.db, testUrls, processingStage: .reconciliation)
-        
+        let packages = testUrls.map { Package(url: $0, processingStage: .reconciliation) }
+        try await packages.save(on: app.db)
+
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(testUrls.count)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(testUrls.count))
         
         // validate
-        let repos = try Repository.query(on: app.db).all().wait()
+        let repos = try await Repository.query(on: app.db).all()
         XCTAssertEqual(repos.count, testUrls.count)
         XCTAssertEqual(Set(repos.map(\.$package.id)), Set(packages.map(\.id)))
     }
     
-    func test_insertOrUpdateRepository_bulk() throws {
-        // test flattening of many updates
-        // Mainly a debug test for the issue described here:
-        // https://discordapp.com/channels/431917998102675485/444249946808647699/704335749637472327
-        let packages = try savePackages(on: app.db, testUrls100)
-        let req = packages
-            .map { ($0, Github.Metadata.mock(for: $0.url)) }
-            .map { insertOrUpdateRepository(on: self.app.db,
-                                            for: .init(model: $0.0),
-                                            metadata: $0.1,
-                                            licenseInfo: .init(htmlUrl: ""),
-                                            readmeInfo: .init(downloadUrl: "", htmlUrl: "")) }
-            .flatten(on: app.db.eventLoop)
-        
-        try req.wait()
-        
-        let repos = try Repository.query(on: app.db).all().wait()
-        XCTAssertEqual(repos.count, testUrls100.count)
-        XCTAssertEqual(repos.map(\.$package.id.uuidString).sorted(),
-                       packages.map(\.id).compactMap { $0?.uuidString }.sorted())
-    }
-    
-    func test_ingest_badMetadata() throws {
+    func test_ingest_badMetadata() async throws {
         // setup
         let urls = ["https://github.com/foo/1",
                     "https://github.com/foo/2",
                     "https://github.com/foo/3"]
-        let packages = try savePackages(on: app.db, urls.asURLs, processingStage: .reconciliation)
+        let packages = try await savePackagesAsync(on: app.db, urls.asURLs,
+                                                   processingStage: .reconciliation)
         Current.fetchMetadata = { _, pkg in
             if pkg.url == "https://github.com/foo/2" {
                 return self.future(error: AppError.metadataRequestFailed(packages[1].id, .badRequest, URI("2")))
@@ -283,47 +266,51 @@ class IngestorTests: AppTestCase {
         let lastUpdate = Date()
         
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         // validate
-        let repos = try Repository.query(on: app.db).all().wait()
+        let repos = try await Repository.query(on: app.db).all()
         XCTAssertEqual(repos.count, 2)
-        XCTAssertEqual(repos.map(\.summary),
-                       [.some("This is package https://github.com/foo/1"), .some("This is package https://github.com/foo/3")])
-        (try Package.query(on: app.db).all().wait()).forEach {
-            if $0.url == "https://github.com/foo/2" {
-                XCTAssertEqual($0.status, .metadataRequestFailed)
-            } else {
-                XCTAssertEqual($0.status, .new)
+        XCTAssertEqual(repos.compactMap(\.summary).sorted(),
+                       ["This is package https://github.com/foo/1",
+                        "This is package https://github.com/foo/3"])
+        (try await Package.query(on: app.db).all()).forEach { pkg in
+            switch pkg.url {
+                case "https://github.com/foo/2":
+                    XCTAssertEqual(pkg.status, .metadataRequestFailed)
+                default:
+                    XCTAssertEqual(pkg.status, .new)
             }
-            XCTAssert($0.updatedAt! > lastUpdate)
+            XCTAssert(pkg.updatedAt! > lastUpdate)
         }
     }
     
-    func test_ingest_unique_owner_name_violation() throws {
+    func test_ingest_unique_owner_name_violation() async throws {
         // Test error behaviour when two packages resolving to the same owner/name are ingested:
         //   - don't update package
         //   - don't create repository records
         //   - report critical error up to Rollbar
         // setup
-        let urls = ["https://github.com/foo/1", "https://github.com/foo/2"]
-        let packages = try savePackages(on: app.db, urls.asURLs, processingStage: .reconciliation)
+        for url in ["https://github.com/foo/1", "https://github.com/foo/2"].asURLs {
+            try await Package(url: url, processingStage: .reconciliation).save(on: app.db)
+        }
         // Return identical metadata for both packages, same as a for instance a redirected
         // package would after a rename / ownership change
-        Current.fetchMetadata = { _, _ in self.future(Github.Metadata.init(
-                                                    defaultBranch: "main",
-                                                    forks: 0,
-                                                    issuesClosedAtDates: [],
-                                                    license: .mit,
-                                                    openIssues: 0,
-                                                    openPullRequests: 0,
-                                                    owner: "owner",
-                                                    pullRequestsClosedAtDates: [],
-                                                    name: "name",
-                                                    stars: 0,
-                                                    summary: "desc",
-                                                    isInOrganization: false))
-        }
+        Current.fetchMetadata = { _, _ in self.future(
+            Github.Metadata.init(
+                defaultBranch: "main",
+                forks: 0,
+                issuesClosedAtDates: [],
+                license: .mit,
+                openIssues: 0,
+                openPullRequests: 0,
+                owner: "owner",
+                pullRequestsClosedAtDates: [],
+                name: "name",
+                stars: 0,
+                summary: "desc",
+                isInOrganization: false)
+        )}
         var reportedLevel: AppError.Level? = nil
         var reportedError: String? = nil
         Current.reportError = { _, level, error in
@@ -335,31 +322,38 @@ class IngestorTests: AppTestCase {
         let lastUpdate = Date()
         
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
-        // validate repositories (single element pointing to first package)
-        let repos = try Repository.query(on: app.db).all().wait()
-        XCTAssertEqual(repos.map(\.$package.id), [packages[0].id].compactMap{ $0 })
+        // validate repositories (single element pointing to the ingested package)
+        let repos = try await Repository.query(on: app.db).all()
+        let ingested = try await Package.query(on: app.db)
+            .filter(\.$processingStage == .ingestion)
+            .first()
+            .unwrap()
+        XCTAssertEqual(repos.map(\.$package.id), [try ingested.requireID()])
         
         // validate packages
-        let pkgs = try Package.query(on: app.db).sort(\.$url).all().wait()
-        // the first package gets the update ...
-        XCTAssertEqual(pkgs[0].status, .new)
-        XCTAssertEqual(pkgs[0].processingStage, .ingestion)
-        XCTAssert(pkgs[0].updatedAt! > lastUpdate)
-        // ... the second package remains unchanged ...
-        XCTAssertEqual(pkgs[1].status, .new)
-        XCTAssertEqual(pkgs[1].processingStage, .reconciliation)
-        XCTAssert(pkgs[1].updatedAt! < lastUpdate)
+        let reconciled = try await Package.query(on: app.db)
+            .filter(\.$processingStage == .reconciliation)
+            .first()
+            .unwrap()
+        // the ingested package has the update ...
+        XCTAssertEqual(ingested.status, .new)
+        XCTAssertEqual(ingested.processingStage, .ingestion)
+        XCTAssert(ingested.updatedAt! > lastUpdate)
+        // ... while the reconciled package remains unchanged ...
+        XCTAssertEqual(reconciled.status, .new)
+        XCTAssertEqual(reconciled.processingStage, .reconciliation)
+        XCTAssert(reconciled.updatedAt! < lastUpdate)
         // ... and an error report has been triggered
         XCTAssertEqual(reportedLevel, .critical)
         XCTAssert(reportedError?.contains("duplicate key value violates unique constraint") ?? false)
     }
     
-    func test_issue_761_no_license() throws {
+    func test_issue_761_no_license() async throws {
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/761
         // setup
-        let packages = try savePackages(on: app.db, ["https://github.com/foo/1"])
+        let packages = try await savePackagesAsync(on: app.db, ["https://github.com/foo/1"])
             .map(Joined<Package, Repository>.init(model:))
         // use mock for metadata request which we're not interested in ...
         Current.fetchMetadata = { _, _ in self.future(Github.Metadata()) }
@@ -370,7 +364,7 @@ class IngestorTests: AppTestCase {
         let client = MockClient { _, resp in resp.status = .notFound }
 
         // MUT
-        let res = try fetchMetadata(client: client, packages: packages).wait()
+        let res = await fetchMetadata(client: client, packages: packages)
 
         // validate
         XCTAssertEqual(res.map(\.isSuccess), [true], "future must be in success state")

--- a/Tests/AppTests/MetricsTests.swift
+++ b/Tests/AppTests/MetricsTests.swift
@@ -96,12 +96,12 @@ class MetricsTests: AppTestCase {
         XCTAssert((AppMetrics.reconcileDurationSeconds?.get()) ?? 0 > 0)
     }
 
-    func test_ingestDurationSeconds() throws {
+    func test_ingestDurationSeconds() async throws {
         // setup
         let pkg = try savePackage(on: app.db, "1")
 
         // MUT
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .id(pkg.id!)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .id(pkg.id!))
 
         // validation
         XCTAssert((AppMetrics.ingestDurationSeconds?.get()) ?? 0 > 0)

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -296,7 +296,7 @@ final class PackageTests: AppTestCase {
         }
 
         // run ingestion to progress package through pipeline
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT & validate
         do {
@@ -326,7 +326,7 @@ final class PackageTests: AppTestCase {
         }
 
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime) }
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         do {
             let pkg = try XCTUnwrap(Package.query(on: app.db).first().wait())
             XCTAssertFalse(pkg.isNew)

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -153,7 +153,7 @@ class PipelineTests: AppTestCase {
         try await reconcile(client: app.client, database: app.db)
         
         do {  // validate
-            let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let packages = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(packages.map(\.url), ["1", "2", "3"].asGithubUrls)
             XCTAssertEqual(packages.map(\.status), [.new, .new, .new])
             XCTAssertEqual(packages.map(\.processingStage), [.reconciliation, .reconciliation, .reconciliation])
@@ -161,10 +161,10 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - second stage
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         do { // validate
-            let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let packages = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(packages.map(\.url), ["1", "2", "3"].asGithubUrls)
             XCTAssertEqual(packages.map(\.status), [.new, .new, .new])
             XCTAssertEqual(packages.map(\.processingStage), [.ingestion, .ingestion, .ingestion])
@@ -172,14 +172,14 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - third stage
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try await analyze(client: app.client,
+                          database: app.db,
+                          logger: app.logger,
+                          threadPool: app.threadPool,
+                          mode: .limit(10)).get()
         
         do { // validate
-            let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let packages = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(packages.map(\.url), ["1", "2", "3"].asGithubUrls)
             XCTAssertEqual(packages.map(\.status), [.ok, .ok, .ok])
             XCTAssertEqual(packages.map(\.processingStage), [.analysis, .analysis, .analysis])
@@ -193,7 +193,7 @@ class PipelineTests: AppTestCase {
         try await reconcile(client: app.client, database: app.db)
         
         do {  // validate - only new package moves to .reconciliation stage
-            let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let packages = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(packages.map(\.url), ["1", "3", "4"].asGithubUrls)
             XCTAssertEqual(packages.map(\.status), [.ok, .ok, .new])
             XCTAssertEqual(packages.map(\.processingStage), [.analysis, .analysis, .reconciliation])
@@ -201,10 +201,10 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - ingest again
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         do {  // validate - only new package moves to .ingestion stage
-            let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let packages = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(packages.map(\.url), ["1", "3", "4"].asGithubUrls)
             XCTAssertEqual(packages.map(\.status), [.ok, .ok, .new])
             XCTAssertEqual(packages.map(\.processingStage), [.analysis, .analysis, .ingestion])
@@ -213,14 +213,14 @@ class PipelineTests: AppTestCase {
         
         // MUT - analyze again
         let lastAnalysis = Current.date()
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try await analyze(client: app.client,
+                          database: app.db,
+                          logger: app.logger,
+                          threadPool: app.threadPool,
+                          mode: .limit(10)).get()
         
         do {  // validate - only new package moves to .ingestion stage
-            let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let packages = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(packages.map(\.url), ["1", "3", "4"].asGithubUrls)
             XCTAssertEqual(packages.map(\.status), [.ok, .ok, .ok])
             XCTAssertEqual(packages.map(\.processingStage), [.analysis, .analysis, .analysis])
@@ -232,10 +232,10 @@ class PipelineTests: AppTestCase {
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime) }
         
         // MUT - ingest yet again
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
         
         do {  // validate - now all three packages should have been updated
-            let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let packages = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(packages.map(\.url), ["1", "3", "4"].asGithubUrls)
             XCTAssertEqual(packages.map(\.status), [.ok, .ok, .ok])
             XCTAssertEqual(packages.map(\.processingStage), [.ingestion, .ingestion, .ingestion])
@@ -243,14 +243,14 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - re-run analysis to complete the sequence
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try await analyze(client: app.client,
+                          database: app.db,
+                          logger: app.logger,
+                          threadPool: app.threadPool,
+                          mode: .limit(10)).get()
         
         do {  // validate - only new package moves to .ingestion stage
-            let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let packages = try await Package.query(on: app.db).sort(\.$url).all()
             XCTAssertEqual(packages.map(\.url), ["1", "3", "4"].asGithubUrls)
             XCTAssertEqual(packages.map(\.status), [.ok, .ok, .ok])
             XCTAssertEqual(packages.map(\.processingStage), [.analysis, .analysis, .analysis])

--- a/Tests/AppTests/ReconcilerTests.swift
+++ b/Tests/AppTests/ReconcilerTests.swift
@@ -39,7 +39,9 @@ class ReconcilerTests: AppTestCase {
     
     func test_adds_and_deletes() async throws {
         // save intial set of packages 1, 2, 3
-        try savePackages(on: app.db, ["1", "2", "3"].asURLs)
+        for url in ["1", "2", "3"].asURLs {
+            try await Package(url: url).save(on: app.db)
+        }
         
         // new package list drops 2, 3, adds 4, 5
         let urls = ["1", "4", "5"]
@@ -49,7 +51,7 @@ class ReconcilerTests: AppTestCase {
         try await reconcile(client: app.client, database: app.db)
         
         // validate
-        let packages = try Package.query(on: app.db).all().wait()
+        let packages = try await Package.query(on: app.db).all()
         XCTAssertEqual(packages.map(\.url).sorted(), urls.sorted())
     }
 }

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -272,7 +272,7 @@ class TwitterTests: AppTestCase {
         }
         // run first two processing steps
         try await reconcile(client: app.client, database: app.db)
-            try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT - analyze, triggering the tweet
         try analyze(client: app.client,
@@ -289,7 +289,7 @@ class TwitterTests: AppTestCase {
         message = nil
         try await reconcile(client: app.client, database: app.db)
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime) }
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT - analyze, triggering tweets if any
         try analyze(client: app.client,
@@ -305,7 +305,7 @@ class TwitterTests: AppTestCase {
         tag = .tag(2, 0, 0)
         // fast forward our clock by the deadtime interval again (*2) and re-ingest
         Current.date = { Date().addingTimeInterval(Constants.reIngestionDeadtime * 2) }
-        try ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10)).wait()
+        try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT - analyze again
         try analyze(client: app.client,

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -92,6 +92,7 @@ func fixturesDirectory(path: String = #file) -> URL {
 // MARK: - Package db helpers
 
 
+// TODO: deprecate in favour of savePackage[Async](...) async throws
 @discardableResult
 func savePackage(on db: Database, id: Package.Id = UUID(), _ url: URL,
                  processingStage: Package.ProcessingStage? = nil) throws -> Package {
@@ -101,10 +102,29 @@ func savePackage(on db: Database, id: Package.Id = UUID(), _ url: URL,
 }
 
 
+// TODO: deprecate in favour of savePackages[Async](...) async throws
 @discardableResult
 func savePackages(on db: Database, _ urls: [URL],
                   processingStage: Package.ProcessingStage? = nil) throws -> [Package] {
     try urls.map { try savePackage(on: db, $0, processingStage: processingStage) }
+}
+
+
+@discardableResult
+func savePackageAsync(on db: Database, id: Package.Id = UUID(), _ url: URL,
+                      processingStage: Package.ProcessingStage? = nil) async throws -> Package {
+    let p = Package(id: id, url: url, processingStage: processingStage)
+    try await p.save(on: db)
+    return p
+}
+
+
+@discardableResult
+func savePackagesAsync(on db: Database, _ urls: [URL],
+                       processingStage: Package.ProcessingStage? = nil) async throws -> [Package] {
+    try await urls.mapAsync {
+        try await savePackageAsync(on: db, $0, processingStage: processingStage)
+    }
 }
 
 


### PR DESCRIPTION
The `.and` conversions I made were [definitely supposed to be concurrent](https://forums.swift.org/t/vapor-update-concurrent/53274/8) and timings from real-world ingestion testing shows that the `mapAsync` loops should be concurrent as well:

Ingesting 50 packages timings:

release2.55.9: 4s
this branch: 3.2s
async ingest before these changes: 56s

I'll deploy to staging from this branch to confirm.