### PR TITLE
Tweak gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,9 @@
 
 name: Continuous Integration
 
-on: [push]
+on:
+  workflow_dispatch:
+  push:
 
 jobs:
   test-linux:

--- a/.github/workflows/package-update.yml
+++ b/.github/workflows/package-update.yml
@@ -17,7 +17,7 @@ name: Package Update
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 8 * * 1' # Monday at 08:00
+    - cron: '0 6 * * 1' # Monday at 06:00 UTC
 
 jobs:
   dependencies:


### PR DESCRIPTION
Closing and re-opening the dependency update PRs doesn't trigger CI like it does in the package list repo for some reason.

Instead, once we add `workflow_dispatch` as a trigger, we can manually kick it off on the Actions tab:

<img width="717" alt="CleanShot 2022-01-31 at 11 35 49@2x" src="https://user-images.githubusercontent.com/65520/151779000-b465f227-2f16-4d4d-890c-a74247aef768.png">

