### PR TITLE
Don't silence errors

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -55,10 +55,14 @@ struct AnalyzeCommand: Command {
 
         try Self.trimCheckouts()
 
-        try AppMetrics.push(client: client,
-                            logger: logger,
-                            jobName: "analyze")
-            .wait()
+        do {
+            try AppMetrics.push(client: client,
+                                logger: logger,
+                                jobName: "analyze")
+                .wait()
+        } catch {
+            logger.warning("\(error.localizedDescription)")
+        }
     }
 }
 

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -51,9 +51,14 @@ struct IngestCommand: CommandAsync {
             logger.error("\(error.localizedDescription)")
         }
 
-        try? await AppMetrics.push(client: client,
-                                   logger: logger,
-                                   jobName: "ingest")
+        do {
+            try await AppMetrics.push(client: client,
+                                      logger: logger,
+                                      jobName: "ingest")
+        } catch {
+            logger.error("\(error.localizedDescription)")
+        }
+
     }
 }
 

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -56,7 +56,7 @@ struct IngestCommand: CommandAsync {
                                       logger: logger,
                                       jobName: "ingest")
         } catch {
-            logger.error("\(error.localizedDescription)")
+            logger.warning("\(error.localizedDescription)")
         }
 
     }

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -58,7 +58,6 @@ struct IngestCommand: CommandAsync {
         } catch {
             logger.warning("\(error.localizedDescription)")
         }
-
     }
 }
 

--- a/Sources/App/Commands/ReAnalyzeVersions.swift
+++ b/Sources/App/Commands/ReAnalyzeVersions.swift
@@ -72,10 +72,14 @@ struct ReAnalyzeVersionsCommand: Command {
                 processed += currentBatchSize
             }
         }
-        try AppMetrics.push(client: client,
-                            logger: logger,
-                            jobName: "re-analyze-versions")
-            .wait()
+        do {
+            try AppMetrics.push(client: client,
+                                logger: logger,
+                                jobName: "re-analyze-versions")
+                .wait()
+        } catch {
+            logger.warning("\(error.localizedDescription)")
+        }
 
         logger.info("done.")
     }

--- a/Sources/App/Commands/Reconcile.swift
+++ b/Sources/App/Commands/Reconcile.swift
@@ -35,9 +35,13 @@ struct ReconcileCommand: CommandAsync {
 
         logger.info("done.")
 
-        try? await AppMetrics.push(client: context.application.client,
-                                   logger: context.application.logger,
-                                   jobName: "reconcile")
+        do {
+            try await AppMetrics.push(client: context.application.client,
+                                      logger: context.application.logger,
+                                      jobName: "reconcile")
+        } catch {
+            logger.warning("\(error.localizedDescription)")
+        }
     }
 }
 

--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -53,9 +53,13 @@ struct TriggerBuildsCommand: Command {
                           client: context.application.client,
                           logger: logger,
                           mode: mode).wait()
-        try AppMetrics.push(client: context.application.client,
-                            logger: context.application.logger,
-                            jobName: "trigger-builds").wait()
+        do {
+            try AppMetrics.push(client: context.application.client,
+                                logger: context.application.logger,
+                                jobName: "trigger-builds").wait()
+        } catch {
+            logger.warning("\(error.localizedDescription)")
+        }
     }
 }
 


### PR DESCRIPTION
```
❯ env swift run Run ingest --limit 1
[0/0] Build complete!
[ INFO ] Ingesting (limit: 1) ... [component: ingest]
[ WARNING ] Environment variable not set: METRICS_PUSHGATEWAY_URL [component: ingest]
~/P/S/spi-server on  log-metrics-push-errors
❯ echo $status
0
```

As mentioned in #1182