### PR TITLE
Make BuildMonitorController.index async

### DIFF
--- a/Sources/App/Core/Extensions/HTML+ResponseEncodable.swift
+++ b/Sources/App/Core/Extensions/HTML+ResponseEncodable.swift
@@ -20,6 +20,10 @@ protocol Renderable {
 }
 
 extension Renderable {
+    public func encodeResponse(for request: Request) async throws -> Response {
+        encodeResponse(for: request, status: .ok)
+    }
+
     public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
         request.eventLoop.future(encodeResponse(for: request, status: .ok))
     }
@@ -31,8 +35,8 @@ extension Renderable {
     }
 }
 
-extension HTML: Renderable, ResponseEncodable  {
+extension HTML: Renderable, ResponseEncodable, AsyncResponseEncodable  {
 }
 
-extension Node: Renderable, ResponseEncodable {
+extension Node: Renderable, ResponseEncodable, AsyncResponseEncodable {
 }

--- a/Sources/App/Core/Query+Support/JoinedQueryBuilder.swift
+++ b/Sources/App/Core/Query+Support/JoinedQueryBuilder.swift
@@ -113,6 +113,11 @@ struct JoinedQueryBuilder<J: ModelInitializable> {
         queryBuilder.limit(count)
         return self
     }
+    
+    func all() async throws -> [J] {
+        try await queryBuilder.all()
+            .map(J.init(model:))
+    }
 
     func all() -> EventLoopFuture<[J]> {
         queryBuilder.all()


### PR DESCRIPTION
As discussed, here's the async variant!

Vapor packages protocol conformances of async variants in new protocols with an `Async` suffix. I.e. whenever we need to adapt something that conforms to a Vapor protocol (migrations was another recent case) we need to look for those and add them.