### PR TITLE
Add put build route

### DIFF
--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -67,9 +67,8 @@ extension API {
         }
 
         func updateBuild(req: Request) async throws -> HTTPStatus {
-            let dto = try req.content.decode(PostCreateBuildDTO.self)
-            guard let buildId = req.parameters.get("id").map(UUID.init(uuidString:)),
-                  let versionId = dto.versionId else {
+            let dto = try req.content.decode(PutBuildDTO.self)
+            guard let buildId = req.parameters.get("id").map(UUID.init(uuidString:)) else {
                       throw Abort(.badRequest)
                   }
 
@@ -78,7 +77,7 @@ extension API {
                 // is present.
                 let build = try await Build.find(buildId, on: req.db)
                 ?? Build(id: buildId,
-                         versionId: versionId,
+                         versionId: dto.versionId,
                          platform: dto.platform,
                          status: dto.status,
                          swiftVersion: dto.swiftVersion)

--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -71,6 +71,9 @@ extension API {
             guard let buildId = req.parameters.get("id").map(UUID.init(uuidString:)) else {
                       throw Abort(.badRequest)
                   }
+            let version = try await App.Version
+                .find(dto.versionId, on: req.db)
+                .unwrap(or: Abort(.notFound))
 
             do {  // update build
                 // We look up by default, because the common case is that a build stub
@@ -92,9 +95,6 @@ extension API {
             }
 
             do {  // update version and package
-                let version = try await App.Version
-                    .find(dto.versionId, on: req.db)
-                    .unwrap(or: Abort(.notFound))
                 if let dependencies = dto.resolvedDependencies {
                     version.resolvedDependencies = dependencies
                     try await version.save(on: req.db)

--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -74,6 +74,8 @@ extension API {
                   }
 
             do {  // update build
+                // We look up by default, because the common case is that a build stub
+                // is present.
                 let build = try await Build.find(buildId, on: req.db)
                 ?? Build(id: buildId,
                          versionId: versionId,
@@ -99,6 +101,8 @@ extension API {
                     try await version.save(on: req.db)
                 }
 
+                // it's ok to reach through $package to get its id, because `$package.id`
+                // is actually `versions.package_id` and therefore loaded
                 try await Package
                     .updatePlatformCompatibility(for: version.$package.id, on: req.db)
             }

--- a/Sources/App/Controllers/API/API+DTOs.swift
+++ b/Sources/App/Controllers/API/API+DTOs.swift
@@ -30,5 +30,7 @@ extension API {
         var runnerId: String?
         var status: Build.Status
         var swiftVersion: SwiftVersion
+        #warning("make non-optional")
+        var versionId: App.Version.Id?
     }
 }

--- a/Sources/App/Controllers/API/API+DTOs.swift
+++ b/Sources/App/Controllers/API/API+DTOs.swift
@@ -21,6 +21,7 @@ extension API {
         var swiftVersion: SwiftVersion
     }
 
+    @available(*, deprecated)
     struct PostCreateBuildDTO: Codable {
         var buildCommand: String?
         var jobUrl: String?
@@ -30,7 +31,17 @@ extension API {
         var runnerId: String?
         var status: Build.Status
         var swiftVersion: SwiftVersion
-        #warning("make non-optional")
-        var versionId: App.Version.Id?
+    }
+
+    struct PutBuildDTO: Codable {
+        var buildCommand: String?
+        var jobUrl: String?
+        var logUrl: String?
+        var platform: Build.Platform
+        var resolvedDependencies: [ResolvedDependency]?
+        var runnerId: String?
+        var status: Build.Status
+        var swiftVersion: SwiftVersion
+        var versionId: App.Version.Id
     }
 }

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -29,6 +29,7 @@ import Vapor
 
 
 enum Api: Resourceable {
+    case builds(_ id: Parameter<UUID>)
     case packages(_ owner: Parameter<String>, _ repository: Parameter<String>, PackagesPathComponents)
     case packageCollections
     case search
@@ -37,10 +38,14 @@ enum Api: Resourceable {
     
     var path: String {
         switch self {
+            case let .builds(.value(id)):
+                return "builds/\(id)"
+            case .builds(.key):
+                fatalError("path must be called with a value parameter")
             case let .packages(.value(owner), .value(repo), next):
                 return "packages/\(owner)/\(repo)/\(next.path)"
             case .packages:
-                fatalError("path must not be called with a name parameter")
+                fatalError("path must be called with a value parameter")
             case .packageCollections:
                 return "package-collections"
             case .version:
@@ -48,7 +53,7 @@ enum Api: Resourceable {
             case let .versions(.value(id), next):
                 return "versions/\(id.uuidString)/\(next.path)"
             case .versions(.key, _):
-                fatalError("path must not be called with a name parameter")
+                fatalError("path must be called with a value parameter")
             case .search:
                 return "search"
         }
@@ -56,10 +61,14 @@ enum Api: Resourceable {
     
     var pathComponents: [PathComponent] {
         switch self {
+            case .builds(.key):
+                return ["builds", ":id"]
+            case .builds(.value):
+                fatalError("pathComponents must be called with a key parameter")
             case let .packages(.key, .key, remainder):
                 return ["packages", ":owner", ":repository"] + remainder.pathComponents
             case .packages:
-                fatalError("pathComponents must not be called with a value parameter")
+                fatalError("pathComponents must be called with a key parameter")
             case .packageCollections:
                 return ["package-collections"]
             case .search, .version:
@@ -67,7 +76,7 @@ enum Api: Resourceable {
             case let .versions(.key, remainder):
                 return ["versions", ":id"] + remainder.pathComponents
             case .versions(.value, _):
-                fatalError("pathComponents must not be called with a value parameter")
+                fatalError("pathComponents must be called with a key parameter")
         }
     }
     

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -103,6 +103,7 @@ final class Build: Model, Content {
                   swiftVersion: swiftVersion)
     }
 
+    @available(*, deprecated)
     convenience init(_ dto: API.PostCreateBuildDTO, _ version: Version) throws {
         try self.init(version: version,
                       buildCommand: dto.buildCommand,
@@ -188,6 +189,7 @@ extension Build {
 
 
 extension Build {
+    @available(*, deprecated)
     func upsert(on database: Database) -> EventLoopFuture<Void> {
         save(on: database)
             .flatMapError {

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -231,6 +231,34 @@ extension Package {
 
 
 extension Package {
+    static func updatePlatformCompatibility(for packageId: Package.Id,
+                                            on database: Database) async throws {
+        guard let db = database as? SQLDatabase else {
+            throw AppError.genericError(packageId, "Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        return try await db.raw(
+            #"""
+            UPDATE packages p SET platform_compatibility = ARRAY(
+                SELECT
+                    CASE
+                        WHEN b.platform LIKE 'macos-%' THEN 'macos'
+                        ELSE b.platform
+                    END
+                FROM versions v
+                JOIN builds b ON b.version_id = v.id
+                WHERE v.package_id = p.id
+                AND v.latest IS NOT NULL
+                AND b.status = 'ok'
+                GROUP BY b.platform
+                HAVING count(*) > 0
+            ),
+            updated_at = NOW()
+            WHERE p.id = \#(bind: packageId)
+            """#
+        ).run()
+    }
+
+    @available(*, deprecated)
     func updatePlatformCompatibility(on database: Database) -> EventLoopFuture<Void> {
         guard let db = database as? SQLDatabase else {
             return database.eventLoop.future(error: AppError.genericError(id, "Database must be an SQLDatabase ('as? SQLDatabase' must succeed)"))

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -120,6 +120,8 @@ func routes(_ app: Application) throws {
                          use: buildController.create)
             protected.post(SiteURL.api(.versions(.key, .triggerBuild)).pathComponents,
                            use: buildController.trigger)
+            protected.put(SiteURL.api(.builds(.key)).pathComponents,
+                          use: buildController.updateBuild)
             let packageController = API.PackageController()
             protected.post(SiteURL.api(.packages(.key, .key, .triggerBuilds)).pathComponents,
                            use: packageController.triggerBuilds)

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -404,7 +404,6 @@ class ApiTests: AppTestCase {
         }
 
     }
-
     func test_post_build_infrastructureError() throws {
         // setup
         Current.builderToken = { "secr3t" }
@@ -450,7 +449,7 @@ class ApiTests: AppTestCase {
                                                 status: .ok,
                                                 swiftVersion: .init(5, 2, 0))
         let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
-
+        
         // MUT - no auth header
         try app.test(
             .POST,
@@ -475,7 +474,7 @@ class ApiTests: AppTestCase {
                 XCTAssertEqual(try Build.query(on: app.db).count().wait(), 0)
             })
     }
-
+    
     func test_post_build_unauthenticated_without_server_token() throws {
         // Ensure we don't allow API requests when no token is configured server-side
         // setup

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -296,6 +296,224 @@ class ApiTests: AppTestCase {
             })
     }
 
+    func test_post_build() throws {
+        // setup
+        Current.builderToken = { "secr3t" }
+        let p = try savePackage(on: app.db, "1")
+        let v = try Version(package: p, latest: .defaultBranch)
+        try v.save(on: app.db).wait()
+        let versionId = try XCTUnwrap(v.id)
+
+        do {  // MUT - initial insert
+            let dto: API.PostCreateBuildDTO = .init(
+                buildCommand: "xcodebuild -scheme Foo",
+                jobUrl: "https://example.com/jobs/1",
+                logUrl: "log url",
+                platform: .macosXcodebuild,
+                resolvedDependencies: nil,
+                runnerId: "some-runner",
+                status: .failed,
+                swiftVersion: .init(5, 2, 0)
+            )
+            let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
+            try app.test(
+                .POST,
+                "api/versions/\(versionId)/builds",
+                headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+                body: body,
+                afterResponse: { res in
+                    // validation
+                    XCTAssertEqual(res.status, .ok)
+                    struct DTO: Decodable {
+                        var id: Build.Id?
+                    }
+                    let dto = try JSONDecoder().decode(DTO.self, from: res.body)
+                    let b = try XCTUnwrap(Build.find(dto.id, on: app.db).wait())
+                    XCTAssertEqual(b.buildCommand, "xcodebuild -scheme Foo")
+                    XCTAssertEqual(b.jobUrl, "https://example.com/jobs/1")
+                    XCTAssertEqual(b.logUrl, "log url")
+                    XCTAssertEqual(b.platform, .macosXcodebuild)
+                    XCTAssertEqual(b.runnerId, "some-runner")
+                    XCTAssertEqual(b.status, .failed)
+                    XCTAssertEqual(b.swiftVersion, .init(5, 2, 0))
+                    XCTAssertEqual(try Build.query(on: app.db).count().wait(), 1)
+                    let v = try Version.find(versionId, on: app.db).unwrap(or: Abort(.notFound)).wait()
+                    XCTAssertEqual(v.resolvedDependencies, [])
+                    // build failed, hence no package platform compatibility yet
+                    let p = try XCTUnwrap(Package.find(p.id, on: app.db).wait())
+                    XCTAssertEqual(p.platformCompatibility, [])
+                })
+        }
+
+        do {  // MUT - update (upsert)
+            let dto: API.PostCreateBuildDTO = .init(
+                platform: .macosXcodebuild,
+                resolvedDependencies: [.init(packageName: "foo",
+                                             repositoryURL: "http://foo/bar")],
+                status: .ok,
+                swiftVersion: .init(5, 2, 0)
+            )
+            let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
+            try app.test(
+                .POST,
+                "api/versions/\(versionId)/builds",
+                headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+                body: body,
+                afterResponse: { res in
+                    // validation
+                    XCTAssertEqual(res.status, .ok)
+                    struct DTO: Decodable {
+                        var id: Build.Id?
+                    }
+                    let dto = try JSONDecoder().decode(DTO.self, from: res.body)
+                    let b = try XCTUnwrap(Build.find(dto.id, on: app.db).wait())
+                    XCTAssertEqual(b.platform, .macosXcodebuild)
+                    XCTAssertEqual(b.status, .ok)
+                    XCTAssertEqual(b.swiftVersion, .init(5, 2, 0))
+                    XCTAssertEqual(try Build.query(on: app.db).count().wait(), 1)
+                    let v = try Version.find(versionId, on: app.db).unwrap(or: Abort(.notFound)).wait()
+                    XCTAssertEqual(v.resolvedDependencies,
+                                   [.init(packageName: "foo",
+                                          repositoryURL: "http://foo/bar")])
+                    // build ok now -> package is macos compatible
+                    let p = try XCTUnwrap(Package.find(p.id, on: app.db).wait())
+                    XCTAssertEqual(p.platformCompatibility, [.macos])
+                })
+        }
+
+        do {  // MUT - add another build to test Package.platformCompatibility
+            let dto: API.PostCreateBuildDTO = .init(
+                platform: .ios,
+                resolvedDependencies: [.init(packageName: "foo",
+                                             repositoryURL: "http://foo/bar")],
+                status: .ok,
+                swiftVersion: .init(5, 2, 0)
+            )
+            let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
+            try app.test(
+                .POST,
+                "api/versions/\(versionId)/builds",
+                headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+                body: body,
+                afterResponse: { res in
+                    // validation
+                    // additional ios build ok -> package is also ios compatible
+                    let p = try XCTUnwrap(Package.find(p.id, on: app.db).wait())
+                    XCTAssertEqual(p.platformCompatibility, [.ios, .macos])
+                })
+        }
+
+    }
+
+    func test_post_build_infrastructureError() throws {
+        // setup
+        Current.builderToken = { "secr3t" }
+        let p = try savePackage(on: app.db, "1")
+        let v = try Version(package: p)
+        try v.save(on: app.db).wait()
+        let versionId = try XCTUnwrap(v.id)
+
+        let dto: API.PostCreateBuildDTO = .init(
+            buildCommand: "xcodebuild -scheme Foo",
+            jobUrl: "https://example.com/jobs/1",
+            logUrl: "log url",
+            platform: .macosXcodebuild,
+            status: .infrastructureError,
+            swiftVersion: .init(5, 2, 0))
+        let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
+        try app.test(
+            .POST,
+            "api/versions/\(versionId)/builds",
+            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+            body: body,
+            afterResponse: { res in
+                // validation
+                XCTAssertEqual(res.status, .ok)
+                struct DTO: Decodable {
+                    var id: Build.Id?
+                }
+                let dto = try JSONDecoder().decode(DTO.self, from: res.body)
+                let b = try XCTUnwrap(Build.find(dto.id, on: app.db).wait())
+                XCTAssertEqual(b.status, .infrastructureError)
+            })
+    }
+
+    func test_post_build_unauthenticated() throws {
+        // Ensure unauthenticated access raises a 401
+        // setup
+        Current.builderToken = { "secr3t" }
+        let p = try savePackage(on: app.db, "1")
+        let v = try Version(package: p)
+        try v.save(on: app.db).wait()
+        let versionId = try XCTUnwrap(v.id)
+        let dto: API.PostCreateBuildDTO = .init(platform: .macosXcodebuild,
+                                                status: .ok,
+                                                swiftVersion: .init(5, 2, 0))
+        let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
+
+        // MUT - no auth header
+        try app.test(
+            .POST,
+            "api/versions/\(versionId)/builds",
+            headers: .init([("Content-Type", "application/json")]),
+            body: body,
+            afterResponse: { res in
+                // validation
+                XCTAssertEqual(res.status, .unauthorized)
+                XCTAssertEqual(try Build.query(on: app.db).count().wait(), 0)
+            })
+
+        // MUT - wrong token
+        try app.test(
+            .POST,
+            "api/versions/\(versionId)/builds",
+            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer wrong")]),
+            body: body,
+            afterResponse: { res in
+                // validation
+                XCTAssertEqual(res.status, .unauthorized)
+                XCTAssertEqual(try Build.query(on: app.db).count().wait(), 0)
+            })
+    }
+
+    func test_post_build_unauthenticated_without_server_token() throws {
+        // Ensure we don't allow API requests when no token is configured server-side
+        // setup
+        Current.builderToken = { nil }
+        let p = try savePackage(on: app.db, "1")
+        let v = try Version(package: p)
+        try v.save(on: app.db).wait()
+        let versionId = try XCTUnwrap(v.id)
+        let dto: API.PostCreateBuildDTO = .init(platform: .macosXcodebuild,
+                                                status: .ok,
+                                                swiftVersion: .init(5, 2, 0))
+        let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
+
+        // MUT - no auth header
+        try app.test(
+            .POST,
+            "api/versions/\(versionId)/builds",
+            headers: .init([("Content-Type", "application/json")]),
+            body: body,
+            afterResponse: { res in
+                // validation
+                XCTAssertEqual(res.status, .unauthorized)
+                XCTAssertEqual(try Build.query(on: app.db).count().wait(), 0)
+            })
+
+        // MUT - with auth header
+        try app.test(
+            .POST,
+            "api/versions/\(versionId)/builds",
+            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer token")]),
+            body: body,
+            afterResponse: { res in
+                // validation
+                XCTAssertEqual(res.status, .unauthorized)
+                XCTAssertEqual(try Build.query(on: app.db).count().wait(), 0)
+            })
+    }
+
     func test_post_build_trigger() throws {
         // Test basic build trigger (high level API, details tested in GitlabBuilderTests)
         // setup

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -110,7 +110,7 @@ class ApiTests: AppTestCase {
             try app.test(
                 .POST,
                 "api/versions/\(versionId)/builds",
-                headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+                headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
                     // validation
@@ -148,7 +148,7 @@ class ApiTests: AppTestCase {
             try app.test(
                 .POST,
                 "api/versions/\(versionId)/builds",
-                headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+                headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
                     // validation
@@ -184,7 +184,7 @@ class ApiTests: AppTestCase {
             try app.test(
                 .POST,
                 "api/versions/\(versionId)/builds",
-                headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+                headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
                     // validation
@@ -214,7 +214,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+            headers: .bearerApplicationJSON("secr3t"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -245,7 +245,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json")]),
+            headers: .applicationJSON,
             body: body,
             afterResponse: { res in
                 // validation
@@ -257,7 +257,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer wrong")]),
+            headers: .bearerApplicationJSON("wrong"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -283,7 +283,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json")]),
+            headers: .applicationJSON,
             body: body,
             afterResponse: { res in
                 // validation
@@ -295,7 +295,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer token")]),
+            headers: .bearerApplicationJSON("token"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -330,7 +330,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/trigger-build",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+            headers: .bearerApplicationJSON("secr3t"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -353,7 +353,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/trigger-build",
-            headers: .init([("Content-Type", "application/json")]),
+            headers: .applicationJSON,
             body: body,
             afterResponse: { res in
                 // validation
@@ -364,7 +364,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/trigger-build",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer wrong")]),
+            headers: .bearerApplicationJSON("wrong"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -441,7 +441,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/packages/\(owner)/\(repo)/trigger-builds",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+            headers: .bearerApplicationJSON("secr3t"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -472,7 +472,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/packages/\(owner)/\(repo)/trigger-builds",
-            headers: .init([("Content-Type", "application/json")]),
+            headers: .applicationJSON,
             body: body,
             afterResponse: { res in
                 // validation
@@ -622,7 +622,7 @@ class ApiTests: AppTestCase {
 
             try app.test(.POST,
                          "api/package-collections",
-                         headers: .init([("Content-Type", "application/json")]),
+                         headers: .applicationJSON,
                          body: body,
                          afterResponse: { res in
                 // validation
@@ -696,7 +696,7 @@ class ApiTests: AppTestCase {
 
             try app.test(.POST,
                          "api/package-collections",
-                         headers: .init([("Content-Type", "application/json")]),
+                         headers: .applicationJSON,
                          body: body,
                          afterResponse: { res in
                             // validation
@@ -716,7 +716,7 @@ class ApiTests: AppTestCase {
 
         try app.test(.POST,
                      "api/package-collections",
-                     headers: .init([("Content-Type", "application/json")]),
+                     headers: .applicationJSON,
                      body: body,
                      afterResponse: { res in
                         // validation
@@ -724,4 +724,15 @@ class ApiTests: AppTestCase {
                      })
     }
 
+}
+
+
+private extension HTTPHeaders {
+    static var applicationJSON: Self {
+        .init([("Content-Type", "application/json")])
+    }
+
+    static func bearerApplicationJSON(_ token: String) -> Self {
+        .init([("Content-Type", "application/json"), ("Authorization", "Bearer \(token)")])
+    }
 }

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -109,7 +109,7 @@ class ApiTests: AppTestCase {
         let buildId1 = try b.id.unwrap()
 
         do  {  // MUT
-            let dto: API.PostCreateBuildDTO = .init(
+            let dto: API.PutBuildDTO = .init(
                 buildCommand: "xcodebuild -scheme Foo",
                 jobUrl: "https://example.com/jobs/1",
                 logUrl: "log url",
@@ -150,7 +150,7 @@ class ApiTests: AppTestCase {
         let buildId2: Build.Id = UUID()
 
         do {  // MUT - second build report for different platform
-            let dto: API.PostCreateBuildDTO = .init(
+            let dto: API.PutBuildDTO = .init(
                 buildCommand: "xcodebuild -scheme Foo",
                 jobUrl: "https://example.com/jobs/1",
                 logUrl: "log url",
@@ -194,7 +194,7 @@ class ApiTests: AppTestCase {
         let versionId = try XCTUnwrap(v.id)
         let buildId: Build.Id = UUID()
 
-        let dto: API.PostCreateBuildDTO = .init(
+        let dto: API.PutBuildDTO = .init(
             buildCommand: "xcodebuild -scheme Foo",
             jobUrl: "https://example.com/jobs/1",
             logUrl: "log url",
@@ -225,7 +225,7 @@ class ApiTests: AppTestCase {
         try v.save(on: app.db).wait()
         let versionId = try v.id.unwrap()
         let buildId: Build.Id = UUID()
-        let dto: API.PostCreateBuildDTO = .init(platform: .macosXcodebuild,
+        let dto: API.PutBuildDTO = .init(platform: .macosXcodebuild,
                                                 status: .ok,
                                                 swiftVersion: .v5_5,
                                                 versionId: versionId)
@@ -265,7 +265,7 @@ class ApiTests: AppTestCase {
         try v.save(on: app.db).wait()
         let versionId = try v.id.unwrap()
         let buildId: Build.Id = UUID()
-        let dto: API.PostCreateBuildDTO = .init(platform: .macosXcodebuild,
+        let dto: API.PutBuildDTO = .init(platform: .macosXcodebuild,
                                                 status: .ok,
                                                 swiftVersion: .v5_5,
                                                 versionId: versionId)

--- a/Tests/AppTests/SiteURLTests.swift
+++ b/Tests/AppTests/SiteURLTests.swift
@@ -111,6 +111,7 @@ class SiteURLTests: XCTestCase {
     }
     
     func test_api_pathComponents() throws {
+        XCTAssertEqual(SiteURL.api(.builds(.key)).pathComponents.map(\.description), ["api", "builds", ":id"])
         XCTAssertEqual(SiteURL.api(.search).pathComponents.map(\.description), ["api", "search"])
         XCTAssertEqual(SiteURL.api(.version).pathComponents.map(\.description), ["api", "version"])
         XCTAssertEqual(SiteURL.api(.versions(.key, .builds)).pathComponents.map(\.description),


### PR DESCRIPTION
Part 1 of #1542 

This adds a new `PUT /api/builds/{id}` route, a purely additive change. I've marked a number of functions as deprecated as a reminder for later clean up. That's the only downside of this, we'll have 8 warnings until they are removed.

Keeping this in draft for the moment while I do the builder changes, in the unlikely event that I need to tweak anything.