### PR TITLE
Send BUILD_ID when triggering builds

### DIFF
--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -198,13 +198,16 @@ func triggerBuildsUnchecked(on database: Database,
         logger.info("Triggering \(trigger.pairs.count) builds for package name: \(trigger.packageName), ref: \(trigger.reference)")
         return trigger.pairs.map { pair in
             AppMetrics.buildTriggerCount?.inc(1, .init(pair.platform, pair.swiftVersion))
+            let buildId: Build.Id = .init()
             return Build.trigger(database: database,
                           client: client,
+                          buildId: buildId,
                           platform: pair.platform,
                           swiftVersion: pair.swiftVersion,
                           versionId: trigger.versionId)
                 .flatMap { response in
-                    Build(versionId: trigger.versionId,
+                    Build(id: buildId,
+                          versionId: trigger.versionId,
                           jobUrl: response.webUrl,
                           platform: pair.platform,
                           status: .triggered,

--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -61,6 +61,7 @@ extension API {
             let dto = try req.content.decode(PostBuildTriggerDTO.self)
             return Build.trigger(database: req.db,
                                  client: req.client,
+                                 buildId: .init(),
                                  platform: dto.platform,
                                  swiftVersion: dto.swiftVersion,
                                  versionId: versionId)

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -62,6 +62,7 @@ extension API {
                 .flatMapEach(on: req.eventLoop) { versionId -> EventLoopFuture<HTTPStatus> in
                     Build.trigger(database: req.db,
                                   client: req.client,
+                                  buildId: .init(),
                                   platform: dto.platform,
                                   swiftVersion: dto.swiftVersion,
                                   versionId: versionId)

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -49,6 +49,7 @@ struct AppEnvironment {
     var shell: Shell
     var siteURL: () -> String
     var triggerBuild: (_ client: Client,
+                       _ buildId: Build.Id,
                        _ cloneURL: String,
                        _ platform: Build.Platform,
                        _ reference: Reference,

--- a/Sources/App/Core/Gitlab.swift
+++ b/Sources/App/Core/Gitlab.swift
@@ -64,6 +64,7 @@ extension Gitlab.Builder {
     }
 
     static func triggerBuild(client: Client,
+                             buildId: Build.Id,
                              cloneURL: String,
                              platform: Build.Platform,
                              reference: Reference,
@@ -81,6 +82,7 @@ extension Gitlab.Builder {
                     ref: branch,
                     variables: [
                         "API_BASEURL": SiteURL.apiBaseURL,
+                        "BUILD_ID": buildId.uuidString,
                         "BUILD_PLATFORM": platform.rawValue,
                         "BUILDER_TOKEN": builderToken,
                         "CLONE_URL": cloneURL,

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -166,6 +166,7 @@ extension Build {
 
     static func trigger(database: Database,
                         client: Client,
+                        buildId: Build.Id,
                         platform: Build.Platform,
                         swiftVersion: SwiftVersion,
                         versionId: Version.Id) -> EventLoopFuture<TriggerResponse> {
@@ -177,6 +178,7 @@ extension Build {
             .unwrap(or: Abort(.notFound))
         return version.flatMap {
             return Current.triggerBuild(client,
+                                        buildId,
                                         $0.package.url,
                                         platform,
                                         $0.reference,

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -560,7 +560,7 @@ class ApiTests: AppTestCase {
         // we're testing the exact Gitlab trigger post request in detail in
         // GitlabBuilderTests - so here we just ensure a request is being made
         var requestSent = false
-        Current.triggerBuild = { _, _, _, _, _, _ in
+        Current.triggerBuild = { _, _, _, _, _, _, _ in
             requestSent = true
             return self.app.eventLoopGroup.future(
                 .init(status: .ok, webUrl: "http://web_url")
@@ -671,7 +671,7 @@ class ApiTests: AppTestCase {
         // GitlabBuilderTests - so here we just ensure two requests are being
         // made (one for each version to build)
         var requestsSent = 0
-        Current.triggerBuild = { _, _, _, _, _, _ in
+        Current.triggerBuild = { _, _, _, _, _, _, _ in
             requestsSent += 1
             return self.app.eventLoopGroup.future(
                 .init(status: .ok, webUrl: "http://web_url")

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -123,6 +123,7 @@ class BuildTests: AppTestCase {
         let p = try savePackage(on: app.db, "1")
         let v = try Version(package: p, reference: .branch("main"))
         try v.save(on: app.db).wait()
+        let buildId = UUID()
         let versionID = try XCTUnwrap(v.id)
 
         // Use live dependency but replace actual client with a mock so we can
@@ -142,6 +143,7 @@ class BuildTests: AppTestCase {
                             ref: "main",
                             variables: [
                                 "API_BASEURL": "http://example.com/api",
+                                "BUILD_ID": buildId.uuidString,
                                 "BUILD_PLATFORM": "macos-xcodebuild",
                                 "BUILDER_TOKEN": "builder token",
                                 "CLONE_URL": "1",
@@ -154,6 +156,7 @@ class BuildTests: AppTestCase {
         // MUT
         let res = try Build.trigger(database: app.db,
                                     client: client,
+                                    buildId: buildId,
                                     platform: .macosXcodebuild,
                                     swiftVersion: .init(5, 2, 4),
                                     versionId: versionID).wait()

--- a/Tests/AppTests/GitlabBuilderTests.swift
+++ b/Tests/AppTests/GitlabBuilderTests.swift
@@ -42,6 +42,7 @@ class GitlabBuilderTests: XCTestCase {
         Current.builderToken = { "builder token" }
         Current.gitlabPipelineToken = { "pipeline token" }
         Current.siteURL = { "http://example.com" }
+        let buildId = UUID()
         let versionID = UUID()
         
         var called = false
@@ -57,6 +58,7 @@ class GitlabBuilderTests: XCTestCase {
                             ref: "main",
                             variables: [
                                 "API_BASEURL": "http://example.com/api",
+                                "BUILD_ID": buildId.uuidString,
                                 "BUILD_PLATFORM": "macos-spm",
                                 "BUILDER_TOKEN": "builder token",
                                 "CLONE_URL": "https://github.com/daveverwer/LeftPad.git",
@@ -68,6 +70,7 @@ class GitlabBuilderTests: XCTestCase {
         
         // MUT
         _ = try Gitlab.Builder.triggerBuild(client: client,
+                                            buildId: buildId,
                                             cloneURL: "https://github.com/daveverwer/LeftPad.git",
                                             platform: .macosSpm,
                                             reference: .tag(.init(1, 2, 3)),

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -69,7 +69,7 @@ extension AppEnvironment {
             setLogger: { _ in },
             shell: .mock,
             siteURL: { Environment.get("SITE_URL") ?? "http://localhost:8080" },
-            triggerBuild: { _, _, _, _, _, _ in
+            triggerBuild: { _, _, _, _, _, _, _ in
                 eventLoop.future(.init(status: .ok, webUrl: "http://web_url"))
             },
             twitterCredentials: { nil },


### PR DESCRIPTION
Step 2 of #1542 

Merge after #1543 and https://gitlab.com/finestructure/swiftpackageindex-builder/-/merge_requests/93

This will start sending `BUILD_ID` as a trigger variable, which in turn will make the builder (once updated via Gitlab MR 93) report back via the new build route added in step 1 (#1543)