### PR TITLE
Added joining clauses for the remaining cases now that they may be seen publicly

### DIFF
--- a/Sources/App/Views/PackageController/Builds/BuildShow+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+View.swift
@@ -101,13 +101,12 @@ enum BuildShow {
 
 private extension Build.Status {
 
-    // There should only be "ok" or "failed" builds visible on this page (others don't have any details to display) so these other cases are only covered for completeness.
-
     var joiningClause: String {
         switch self {
             case .ok: return " build of "
             case .failed: return " to build "
-            case .infrastructureError, .triggered, .timeout: return ""
+            case .triggered: return " a build of "
+            case .infrastructureError, .timeout: return " while building "
         }
     }
 


### PR DESCRIPTION
Fixes #1529

It didn't feel worth adding two (or even three) entire new snapshot tests to test this, but I will if you think it's worthwhile @finestructure.

<img width="585" alt="Screenshot 2022-02-15 at 14 03 59@2x" src="https://user-images.githubusercontent.com/5180/154077616-9402bb77-2787-42c3-9b54-84041a0ac261.png">

Will need rebasing before merging.