### PR TITLE
Build reporting updates

### DIFF
--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -198,13 +198,16 @@ func triggerBuildsUnchecked(on database: Database,
         logger.info("Triggering \(trigger.pairs.count) builds for package name: \(trigger.packageName), ref: \(trigger.reference)")
         return trigger.pairs.map { pair in
             AppMetrics.buildTriggerCount?.inc(1, .init(pair.platform, pair.swiftVersion))
+            let buildId: Build.Id = .init()
             return Build.trigger(database: database,
                           client: client,
+                          buildId: buildId,
                           platform: pair.platform,
                           swiftVersion: pair.swiftVersion,
                           versionId: trigger.versionId)
                 .flatMap { response in
-                    Build(versionId: trigger.versionId,
+                    Build(id: buildId,
+                          versionId: trigger.versionId,
                           jobUrl: response.webUrl,
                           platform: pair.platform,
                           status: .triggered,

--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -304,6 +304,11 @@ struct BuildTriggerInfo: Equatable {
 }
 
 
+func missingPairs(existing: [BuildPair]) -> Set<BuildPair> {
+     Set(BuildPair.all).subtracting(Set(existing))
+ }
+
+
 func findMissingBuilds(_ database: Database,
                        packageId: Package.Id) -> EventLoopFuture<[BuildTriggerInfo]> {
     let versions = Version.query(on: database)
@@ -315,9 +320,8 @@ func findMissingBuilds(_ database: Database,
     return versions.mapEachCompact { v in
         guard let versionId = v.id else { return nil }
         let existing = v.builds.map { BuildPair($0.platform, $0.swiftVersion) }
-        let pairs = Set(BuildPair.all).subtracting(Set(existing))
         return BuildTriggerInfo(versionId: versionId,
-                                pairs: pairs,
+                                pairs: missingPairs(existing: existing),
                                 packageName: v.packageName,
                                 reference: v.reference)
     }

--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -27,9 +27,9 @@ extension API {
                 .unwrap(or: Abort(.notFound))
 
             do {  // update build
-                // Find or create build for updating.
-                // We look up by default, because the common case is that a build stub
-                // is present.
+                  // Find or create build for updating.
+                  // We look up by default, because the common case is that a build stub
+                  // is present.
                 let build = try await Build.query(on: req.db,
                                                   platform: dto.platform,
                                                   swiftVersion: dto.swiftVersion,
@@ -70,23 +70,23 @@ extension API {
 
             do {  // update version and package
                 if let dependencies = dto.resolvedDependencies {
-                     version.resolvedDependencies = dependencies
-                     try await version.save(on: req.db)
-                 }
+                    version.resolvedDependencies = dependencies
+                    try await version.save(on: req.db)
+                }
 
-                 // it's ok to reach through $package to get its id, because `$package.id`
-                 // is actually `versions.package_id` and therefore loaded
-                 try await Package
-                     .updatePlatformCompatibility(for: version.$package.id, on: req.db)
-             }
-
+                // it's ok to reach through $package to get its id, because `$package.id`
+                // is actually `versions.package_id` and therefore loaded
+                try await Package
+                    .updatePlatformCompatibility(for: version.$package.id, on: req.db)
+            }
 
             return .noContent
         }
 
         func trigger(req: Request) throws -> EventLoopFuture<Build.TriggerResponse> {
             guard let id = req.parameters.get("id"),
-                  let versionId = UUID(uuidString: id) else {
+                  let versionId = UUID(uuidString: id)
+            else {
                 return req.eventLoop.future(error: Abort(.badRequest))
             }
             let dto = try req.content.decode(PostBuildTriggerDTO.self)

--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -92,6 +92,7 @@ extension API {
             let dto = try req.content.decode(PostBuildTriggerDTO.self)
             return Build.trigger(database: req.db,
                                  client: req.client,
+                                 buildId: .init(),
                                  platform: dto.platform,
                                  swiftVersion: dto.swiftVersion,
                                  versionId: versionId)

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -62,6 +62,7 @@ extension API {
                 .flatMapEach(on: req.eventLoop) { versionId -> EventLoopFuture<HTTPStatus> in
                     Build.trigger(database: req.db,
                                   client: req.client,
+                                  buildId: .init(),
                                   platform: dto.platform,
                                   swiftVersion: dto.swiftVersion,
                                   versionId: versionId)

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -49,6 +49,7 @@ struct AppEnvironment {
     var shell: Shell
     var siteURL: () -> String
     var triggerBuild: (_ client: Client,
+                       _ buildId: Build.Id,
                        _ cloneURL: String,
                        _ platform: Build.Platform,
                        _ reference: Reference,

--- a/Sources/App/Core/Gitlab.swift
+++ b/Sources/App/Core/Gitlab.swift
@@ -64,6 +64,7 @@ extension Gitlab.Builder {
     }
 
     static func triggerBuild(client: Client,
+                             buildId: Build.Id,
                              cloneURL: String,
                              platform: Build.Platform,
                              reference: Reference,
@@ -81,6 +82,7 @@ extension Gitlab.Builder {
                     ref: branch,
                     variables: [
                         "API_BASEURL": SiteURL.apiBaseURL,
+                        "BUILD_ID": buildId.uuidString,
                         "BUILD_PLATFORM": platform.rawValue,
                         "BUILDER_TOKEN": builderToken,
                         "CLONE_URL": cloneURL,

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -154,6 +154,7 @@ extension Build {
 
     static func trigger(database: Database,
                         client: Client,
+                        buildId: Build.Id,
                         platform: Build.Platform,
                         swiftVersion: SwiftVersion,
                         versionId: Version.Id) -> EventLoopFuture<TriggerResponse> {
@@ -165,6 +166,7 @@ extension Build {
             .unwrap(or: Abort(.notFound))
         return version.flatMap {
             return Current.triggerBuild(client,
+                                        buildId,
                                         $0.package.url,
                                         platform,
                                         $0.reference,

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -103,17 +103,6 @@ final class Build: Model, Content {
                   swiftVersion: swiftVersion)
     }
 
-    convenience init(_ dto: API.PostCreateBuildDTO, _ version: Version) throws {
-        try self.init(version: version,
-                      buildCommand: dto.buildCommand,
-                      jobUrl: dto.jobUrl,
-                      logUrl: dto.logUrl,
-                      platform: dto.platform,
-                      runnerId: dto.runnerId,
-                      status: dto.status,
-                      swiftVersion: dto.swiftVersion)
-    }
-    
 }
 
 
@@ -188,32 +177,20 @@ extension Build {
 
 
 extension Build {
-    func upsert(on database: Database) -> EventLoopFuture<Void> {
-        save(on: database)
-            .flatMapError {
-                // if we run into a unique key violation ...
-                guard let error = $0 as? PostgresError,
-                      error.code == .uniqueViolation else {
-                    return database.eventLoop.future(error: $0)
-                }
-                // We can't avoid the "duplicate key" error message leaking out to the console
-                // so what we do is also log an explainer that it's not a real error.
-                // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/737
-                // Use print so it's not affected by log levels (just like the underlying Postgres
-                // error isn't)
-                print(#"DISREGARD the above error message about duplicate key violation of constraint "uq:builds.version_id+builds.platform+builds.swift_version+v2" - it is being handled and the error is logged over-eagerly by a subsystem"#)
-                // ... find the existing build
-                return Build.query(on: database)
-                    .filter(\.$platform == self.platform)
-                    .filter(.sql(raw: "(swift_version->'major')::int = \(self.swiftVersion.major)"))
-                    .filter(.sql(raw: "(swift_version->'minor')::int = \(self.swiftVersion.minor)"))
-                    .filter(\.$version.$id == self.$version.id)
-                    .all()
-                    // ... delete it
-                    .flatMap { $0.delete(on: database) }
-                    // ... and insert the new build instead
-                    .flatMap { self.save(on: database) }
-            }
+    static func query(on database: Database,
+                      platform: Platform,
+                      swiftVersion: SwiftVersion,
+                      versionId: Version.Id) async throws -> Build? {
+        let builds = try await Build.query(on: database)
+            .filter(\.$platform == platform)
+            .filter(.sql(raw: "(swift_version->'major')::int = \(swiftVersion.major)"))
+            .filter(.sql(raw: "(swift_version->'minor')::int = \(swiftVersion.minor)"))
+            .filter(\.$version.$id == versionId)
+            .all()
+        guard builds.count <= 1 else {
+            throw AppError.genericError(nil, "More than one build record per (platform/swiftVersion/versionId) found")
+        }
+        return builds.first
     }
 }
 

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -232,31 +232,31 @@ extension Package {
 
 extension Package {
     static func updatePlatformCompatibility(for packageId: Package.Id,
-                                             on database: Database) async throws {
-         guard let db = database as? SQLDatabase else {
-             throw AppError.genericError(packageId, "Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
-         }
-         return try await db.raw(
-             #"""
-             UPDATE packages p SET platform_compatibility = ARRAY(
-                 SELECT
-                     CASE
-                         WHEN b.platform LIKE 'macos-%' THEN 'macos'
-                         ELSE b.platform
-                     END
-                 FROM versions v
-                 JOIN builds b ON b.version_id = v.id
-                 WHERE v.package_id = p.id
-                 AND v.latest IS NOT NULL
-                 AND b.status = 'ok'
-                 GROUP BY b.platform
-                 HAVING count(*) > 0
-             ),
-             updated_at = NOW()
-             WHERE p.id = \#(bind: packageId)
-             """#
-         ).run()
-     }
+                                            on database: Database) async throws {
+        guard let db = database as? SQLDatabase else {
+            throw AppError.genericError(packageId, "Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+        return try await db.raw(
+            #"""
+            UPDATE packages p SET platform_compatibility = ARRAY(
+                SELECT
+                    CASE
+                        WHEN b.platform LIKE 'macos-%' THEN 'macos'
+                        ELSE b.platform
+                    END
+                FROM versions v
+                JOIN builds b ON b.version_id = v.id
+                WHERE v.package_id = p.id
+                AND v.latest IS NOT NULL
+                AND b.status = 'ok'
+                GROUP BY b.platform
+                HAVING count(*) > 0
+            ),
+            updated_at = NOW()
+            WHERE p.id = \#(bind: packageId)
+            """#
+        ).run()
+    }
 }
 
 

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -231,31 +231,32 @@ extension Package {
 
 
 extension Package {
-    func updatePlatformCompatibility(on database: Database) -> EventLoopFuture<Void> {
-        guard let db = database as? SQLDatabase else {
-            return database.eventLoop.future(error: AppError.genericError(id, "Database must be an SQLDatabase ('as? SQLDatabase' must succeed)"))
-        }
-        return db.raw(
-            #"""
-            UPDATE packages p SET platform_compatibility = ARRAY(
-                SELECT
-                    CASE
-                        WHEN b.platform LIKE 'macos-%' THEN 'macos'
-                        ELSE b.platform
-                    END
-                FROM versions v
-                JOIN builds b ON b.version_id = v.id
-                WHERE v.package_id = p.id
-                AND v.latest IS NOT NULL
-                AND b.status = 'ok'
-                GROUP BY b.platform
-                HAVING count(*) > 0
-            ),
-            updated_at = NOW()
-            WHERE p.id = \#(bind: id)
-            """#
-        ).run()
-    }
+    static func updatePlatformCompatibility(for packageId: Package.Id,
+                                             on database: Database) async throws {
+         guard let db = database as? SQLDatabase else {
+             throw AppError.genericError(packageId, "Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+         }
+         return try await db.raw(
+             #"""
+             UPDATE packages p SET platform_compatibility = ARRAY(
+                 SELECT
+                     CASE
+                         WHEN b.platform LIKE 'macos-%' THEN 'macos'
+                         ELSE b.platform
+                     END
+                 FROM versions v
+                 JOIN builds b ON b.version_id = v.id
+                 WHERE v.package_id = p.id
+                 AND v.latest IS NOT NULL
+                 AND b.status = 'ok'
+                 GROUP BY b.platform
+                 HAVING count(*) > 0
+             ),
+             updated_at = NOW()
+             WHERE p.id = \#(bind: packageId)
+             """#
+         ).run()
+     }
 }
 
 

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -315,7 +315,7 @@ class ApiTests: AppTestCase {
         // we're testing the exact Gitlab trigger post request in detail in
         // GitlabBuilderTests - so here we just ensure a request is being made
         var requestSent = false
-        Current.triggerBuild = { _, _, _, _, _, _ in
+        Current.triggerBuild = { _, _, _, _, _, _, _ in
             requestSent = true
             return self.app.eventLoopGroup.future(
                 .init(status: .ok, webUrl: "http://web_url")
@@ -426,7 +426,7 @@ class ApiTests: AppTestCase {
         // GitlabBuilderTests - so here we just ensure two requests are being
         // made (one for each version to build)
         var requestsSent = 0
-        Current.triggerBuild = { _, _, _, _, _, _ in
+        Current.triggerBuild = { _, _, _, _, _, _, _ in
             requestsSent += 1
             return self.app.eventLoopGroup.future(
                 .init(status: .ok, webUrl: "http://web_url")

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -110,7 +110,7 @@ class ApiTests: AppTestCase {
             try app.test(
                 .POST,
                 "api/versions/\(versionId)/builds",
-                headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+                headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
                     // validation
@@ -148,7 +148,7 @@ class ApiTests: AppTestCase {
             try app.test(
                 .POST,
                 "api/versions/\(versionId)/builds",
-                headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+                headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
                     // validation
@@ -184,7 +184,7 @@ class ApiTests: AppTestCase {
             try app.test(
                 .POST,
                 "api/versions/\(versionId)/builds",
-                headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+                headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
                     // validation
@@ -214,7 +214,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+            headers: .bearerApplicationJSON("secr3t"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -245,7 +245,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json")]),
+            headers: .applicationJSON,
             body: body,
             afterResponse: { res in
                 // validation
@@ -257,7 +257,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer wrong")]),
+            headers: .bearerApplicationJSON("wrong"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -283,7 +283,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json")]),
+            headers: .applicationJSON,
             body: body,
             afterResponse: { res in
                 // validation
@@ -295,7 +295,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/builds",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer token")]),
+            headers: .bearerApplicationJSON("token"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -330,7 +330,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/trigger-build",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+            headers: .bearerApplicationJSON("secr3t"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -353,7 +353,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/trigger-build",
-            headers: .init([("Content-Type", "application/json")]),
+            headers: .applicationJSON,
             body: body,
             afterResponse: { res in
                 // validation
@@ -364,7 +364,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/versions/\(versionId)/trigger-build",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer wrong")]),
+            headers: .bearerApplicationJSON("wrong"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -441,7 +441,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/packages/\(owner)/\(repo)/trigger-builds",
-            headers: .init([("Content-Type", "application/json"), ("Authorization", "Bearer secr3t")]),
+            headers: .bearerApplicationJSON("secr3t"),
             body: body,
             afterResponse: { res in
                 // validation
@@ -472,7 +472,7 @@ class ApiTests: AppTestCase {
         try app.test(
             .POST,
             "api/packages/\(owner)/\(repo)/trigger-builds",
-            headers: .init([("Content-Type", "application/json")]),
+            headers: .applicationJSON,
             body: body,
             afterResponse: { res in
                 // validation
@@ -622,7 +622,7 @@ class ApiTests: AppTestCase {
 
             try app.test(.POST,
                          "api/package-collections",
-                         headers: .init([("Content-Type", "application/json")]),
+                         headers: .applicationJSON,
                          body: body,
                          afterResponse: { res in
                 // validation
@@ -696,7 +696,7 @@ class ApiTests: AppTestCase {
 
             try app.test(.POST,
                          "api/package-collections",
-                         headers: .init([("Content-Type", "application/json")]),
+                         headers: .applicationJSON,
                          body: body,
                          afterResponse: { res in
                             // validation
@@ -716,7 +716,7 @@ class ApiTests: AppTestCase {
 
         try app.test(.POST,
                      "api/package-collections",
-                     headers: .init([("Content-Type", "application/json")]),
+                     headers: .applicationJSON,
                      body: body,
                      afterResponse: { res in
                         // validation
@@ -724,4 +724,15 @@ class ApiTests: AppTestCase {
                      })
     }
 
+}
+
+
+private extension HTTPHeaders {
+    static var applicationJSON: Self {
+        .init([("Content-Type", "application/json")])
+    }
+
+    static func bearerApplicationJSON(_ token: String) -> Self {
+        .init([("Content-Type", "application/json"), ("Authorization", "Bearer \(token)")])
+    }
 }

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -123,6 +123,7 @@ class BuildTests: AppTestCase {
         let p = try savePackage(on: app.db, "1")
         let v = try Version(package: p, reference: .branch("main"))
         try v.save(on: app.db).wait()
+        let buildId = UUID()
         let versionID = try XCTUnwrap(v.id)
 
         // Use live dependency but replace actual client with a mock so we can
@@ -142,6 +143,7 @@ class BuildTests: AppTestCase {
                             ref: "main",
                             variables: [
                                 "API_BASEURL": "http://example.com/api",
+                                "BUILD_ID": buildId.uuidString,
                                 "BUILD_PLATFORM": "macos-xcodebuild",
                                 "BUILDER_TOKEN": "builder token",
                                 "CLONE_URL": "1",
@@ -154,6 +156,7 @@ class BuildTests: AppTestCase {
         // MUT
         let res = try Build.trigger(database: app.db,
                                     client: client,
+                                    buildId: buildId,
                                     platform: .macosXcodebuild,
                                     swiftVersion: .init(5, 2, 4),
                                     versionId: versionID).wait()

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -102,6 +102,19 @@ class BuildTriggerTests: AppTestCase {
         XCTAssertEqual(ids, [pkgId])
     }
 
+    func test_missingPairs() throws {
+         // Ensure we find missing builds purely via x.y Swift version,
+         // i.e. ignoring patch version
+         let allExceptFirst = Array(BuildPair.all.dropFirst())
+         // just assert what the first one actually is so we test the right thing
+         XCTAssertEqual(BuildPair.all.first, .init(.ios, .init(5, 1, 5)))
+         // substitute in a 5.1 build with a different patch version
+         let existing = allExceptFirst + [.init(.ios, .init(5, 1, 4))]
+
+         // MUT & validate 5.1.4 is matched as an existing 5.1 build
+         XCTAssertEqual(missingPairs(existing: existing), Set())
+     }
+
     func test_findMissingBuilds() throws {
         // setup
         let pkgId = UUID()

--- a/Tests/AppTests/GitlabBuilderTests.swift
+++ b/Tests/AppTests/GitlabBuilderTests.swift
@@ -42,6 +42,7 @@ class GitlabBuilderTests: XCTestCase {
         Current.builderToken = { "builder token" }
         Current.gitlabPipelineToken = { "pipeline token" }
         Current.siteURL = { "http://example.com" }
+        let buildId = UUID()
         let versionID = UUID()
         
         var called = false
@@ -57,6 +58,7 @@ class GitlabBuilderTests: XCTestCase {
                             ref: "main",
                             variables: [
                                 "API_BASEURL": "http://example.com/api",
+                                "BUILD_ID": buildId.uuidString,
                                 "BUILD_PLATFORM": "macos-spm",
                                 "BUILDER_TOKEN": "builder token",
                                 "CLONE_URL": "https://github.com/daveverwer/LeftPad.git",
@@ -68,6 +70,7 @@ class GitlabBuilderTests: XCTestCase {
         
         // MUT
         _ = try Gitlab.Builder.triggerBuild(client: client,
+                                            buildId: buildId,
                                             cloneURL: "https://github.com/daveverwer/LeftPad.git",
                                             platform: .macosSpm,
                                             reference: .tag(.init(1, 2, 3)),

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -69,7 +69,7 @@ extension AppEnvironment {
             setLogger: { _ in },
             shell: .mock,
             siteURL: { Environment.get("SITE_URL") ?? "http://localhost:8080" },
-            triggerBuild: { _, _, _, _, _, _ in
+            triggerBuild: { _, _, _, _, _, _, _ in
                 eventLoop.future(.init(status: .ok, webUrl: "http://web_url"))
             },
             twitterCredentials: { nil },


### PR DESCRIPTION
This brings across the useful bits of the three "build id trigger PRs" here on GH:

* `TriggerBuilds.missingPairs` + `BuildTriggerTests.test_BuildPair_matching`
* change version id build reporting to do a fetch + update or insert instead of a create + catch exception + delete + insert, i.e. recreate `updateBuild` (the `PUT` route handler) for the `POST` build handler
* keep new `static func updatePlatformCompatibility(for packageId: Package.Id ...)`
* send `BUILD_ID`

The MRs on the Gitlab side aren't urgent and it's only test infra that I'd want to keep. I'll follow up on that later this week.