### PR TITLE
We should still allow blank issues to be opened

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Idea or Feature Request
     url: https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/discussions/new?category=ideas


### PR DESCRIPTION
As I was sorting out the issue template for the Package List, I saw we didn't have this enabled and I know that I would find it useful to still be able to open a blank issue.