### PR TITLE
Make the overflowing keyword list generic so it can be used elsewhere

### DIFF
--- a/FrontEnd/main.js
+++ b/FrontEnd/main.js
@@ -36,11 +36,11 @@ new SPIBuildLogNavigation()
 new SPICopyableInput()
 new SPIAutofocus()
 new SPIPlaygroundsAppLinkFallback()
-new SPIShowMoreKeywords()
 new SPISearchFilterSuggestions()
 new SPIPanel()
 
 customElements.define('spi-readme', SPIReadmeElement)
 customElements.define('tab-bar', SPITabBarElement)
+customElements.define('spi-overflowing-list', SPIOverflowingList)
 
 //# sourceMappingURL=main.js.map

--- a/FrontEnd/main.js
+++ b/FrontEnd/main.js
@@ -25,7 +25,7 @@ import { SPIAutofocus } from './scripts/autofocus.js'
 import { SPIPlaygroundsAppLinkFallback } from './scripts/playgrounds_app_link.js'
 import { SPIReadmeElement } from './scripts/readme_element.js'
 import { SPITabBarElement } from './scripts/tab_bar_element.js'
-import { SPIShowMoreKeywords } from './scripts/show_more_keywords.js'
+import { SPIOverflowingList } from './scripts/overflowing_list.js'
 import { SPISearchFilterSuggestions } from './scripts/search_filter_suggestions.js'
 import { SPIPanel } from './scripts/panel.js'
 

--- a/FrontEnd/main.js
+++ b/FrontEnd/main.js
@@ -39,8 +39,15 @@ new SPIPlaygroundsAppLinkFallback()
 new SPISearchFilterSuggestions()
 new SPIPanel()
 
-customElements.define('spi-readme', SPIReadmeElement)
-customElements.define('tab-bar', SPITabBarElement)
-customElements.define('spi-overflowing-list', SPIOverflowingList)
+document.addEventListener('turbo:load', () => {
+  defineCustomElement('spi-readme', SPIReadmeElement)
+  defineCustomElement('tab-bar', SPITabBarElement)
+  defineCustomElement('spi-overflowing-list', SPIOverflowingList)
+})
+
+function defineCustomElement(elementName, klass) {
+  if (customElements.get(elementName)) return
+  customElements.define(elementName, klass)
+}
 
 //# sourceMappingURL=main.js.map

--- a/FrontEnd/scripts/overflowing_list.js
+++ b/FrontEnd/scripts/overflowing_list.js
@@ -26,7 +26,7 @@ export class SPIOverflowingList extends HTMLElement {
     // If the collapsing hid any content, add a "show more" that expands it.
     if (this.isOverflowing(listElement)) {
       const showMoreElement = document.createElement('a')
-      showMoreElement.innerHTML = `Show all ${listElement.children.length} tags&hellip;`
+      showMoreElement.innerText = this.dataset.overflowMessage
       showMoreElement.href = '#' // Needed to turn the cursor into a hand.
       showMoreElement.classList.add('show_more')
 

--- a/FrontEnd/scripts/overflowing_list.js
+++ b/FrontEnd/scripts/overflowing_list.js
@@ -21,7 +21,7 @@ export class SPIOverflowingList extends HTMLElement {
     if (!listElement) return
 
     // Immediately collapse a potentially overflowing keyword list.
-    listElement.classList.add('collapsed')
+    listElement.style.setProperty('max-height', this.dataset.overflowHeight)
 
     // If the collapsing hid any content, add a "show more" that expands it.
     if (this.isOverflowing(listElement)) {
@@ -31,15 +31,13 @@ export class SPIOverflowingList extends HTMLElement {
       showMoreElement.classList.add('show_more')
 
       showMoreElement.addEventListener('click', (event) => {
-        listElement.classList.remove('collapsed')
+        listElement.style.removeProperty('max-height')
         showMoreElement.remove()
         event.preventDefault()
       })
 
       // Insert the new link adjacent to the list.
-      // console.log(this)
       this.appendChild(showMoreElement)
-      // console.log(this.children)
     }
   }
 

--- a/FrontEnd/scripts/overflowing_list.js
+++ b/FrontEnd/scripts/overflowing_list.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export class SPIShowMoreKeywords {
+export class SPIOverflowingList {
   constructor() {
     document.addEventListener('turbo:load', () => {
       const keywordsListElement = document.querySelector('article.details ul.keywords')

--- a/FrontEnd/scripts/overflowing_list.js
+++ b/FrontEnd/scripts/overflowing_list.js
@@ -12,33 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export class SPIOverflowingList {
+export class SPIOverflowingList extends HTMLElement {
   constructor() {
-    document.addEventListener('turbo:load', () => {
-      const keywordsListElement = document.querySelector('article.details ul.keywords')
-      if (keywordsListElement) {
-        // Immediately collapse a potentially overflowing keyword list.
-        keywordsListElement.classList.add('collapsed')
+    super()
 
-        // If the collapsing hid any content, add a "show more" that expands it.
-        if (this.isOverflowing(keywordsListElement)) {
-          const totalKeywords = keywordsListElement.children.length
-          const showMoreElement = document.createElement('a')
-          showMoreElement.innerHTML = `Show all ${totalKeywords} tags&hellip;`
-          showMoreElement.href = '#' // Needed to turn the cursor into a hand.
-          showMoreElement.classList.add('show_more')
+    // The list should be the immediate child of the custom element.
+    const listElement = this.querySelector(':scope > ul')
+    if (!listElement) return
 
-          showMoreElement.addEventListener('click', (event) => {
-            keywordsListElement.classList.remove('collapsed')
-            showMoreElement.remove()
-            event.preventDefault()
-          })
+    // Immediately collapse a potentially overflowing keyword list.
+    listElement.classList.add('collapsed')
 
-          const keywordsListParentElement = keywordsListElement.parentElement
-          keywordsListParentElement.appendChild(showMoreElement)
-        }
-      }
-    })
+    // If the collapsing hid any content, add a "show more" that expands it.
+    if (this.isOverflowing(listElement)) {
+      const showMoreElement = document.createElement('a')
+      showMoreElement.innerHTML = `Show all ${listElement.children.length} tags&hellip;`
+      showMoreElement.href = '#' // Needed to turn the cursor into a hand.
+      showMoreElement.classList.add('show_more')
+
+      showMoreElement.addEventListener('click', (event) => {
+        listElement.classList.remove('collapsed')
+        showMoreElement.remove()
+        event.preventDefault()
+      })
+
+      // Insert the new link adjacent to the list.
+      // console.log(this)
+      this.appendChild(showMoreElement)
+      // console.log(this.children)
+    }
   }
 
   // Adapted from https://stackoverflow.com/a/143889

--- a/FrontEnd/styles/base.scss
+++ b/FrontEnd/styles/base.scss
@@ -212,3 +212,15 @@ a.download {
   overflow: hidden;
   text-overflow: ellipsis;
 }
+
+spi-overflowing-list {
+  ul {
+    // This CSS is augmented with a `max-height` declaration defined via
+    // the custom element in overflowing_list.js.
+    overflow: hidden;
+  }
+
+  .show_more {
+    font-size: 13px;
+  }
+}

--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -106,18 +106,6 @@
       li.keywords {
         grid-column-start: span 2;
         background-image: var(--image-tag);
-
-        ul.collapsed {
-          // This magic number is *very* important! It's the exact size of two rows of tags
-          // and if incorrect, the "show more" button will show up unnecessarily as it may
-          // overflow by just a single pixel.
-          max-height: 52px;
-          overflow: hidden;
-        }
-
-        .show_more {
-          font-size: 13px;
-        }
       }
     }
 

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -371,7 +371,7 @@ extension PackageShow.Model {
         if let keywords = keywords {
             return .li(
                 .class("keywords"),
-                .spiOverflowingList(
+                .spiOverflowingList(overflowMessage: "Show all \(keywords.count) tags…",
                     .class("keywords"),
                     .forEach(keywords, { keyword in
                         .li(

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -372,6 +372,7 @@ extension PackageShow.Model {
             return .li(
                 .class("keywords"),
                 .spiOverflowingList(overflowMessage: "Show all \(keywords.count) tags…",
+                                    overflowHeight: 52,
                     .class("keywords"),
                     .forEach(keywords, { keyword in
                         .li(

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -371,7 +371,7 @@ extension PackageShow.Model {
         if let keywords = keywords {
             return .li(
                 .class("keywords"),
-                .ul(
+                .spiOverflowingList(
                     .class("keywords"),
                     .forEach(keywords, { keyword in
                         .li(

--- a/Sources/App/Views/Plot+Extensions.swift
+++ b/Sources/App/Views/Plot+Extensions.swift
@@ -52,7 +52,7 @@ extension Node where Context: HTML.BodyContext {
     }
 
     static func spiOverflowingList(_ nodes: Node<HTML.ListContext>...) -> Self {
-        .element(named: "spi-overflowing-ul", nodes:[ .ul(.group(nodes)) ])
+        .element(named: "spi-overflowing-list", nodes:[ .ul(.group(nodes)) ])
     }
 
     static func spinner() -> Self {

--- a/Sources/App/Views/Plot+Extensions.swift
+++ b/Sources/App/Views/Plot+Extensions.swift
@@ -51,6 +51,10 @@ extension Node where Context: HTML.BodyContext {
         .element(named: "tab-bar", nodes: nodes)
     }
 
+    static func spiOverflowingList(_ nodes: Node<HTML.ListContext>...) -> Self {
+        .element(named: "spi-overflowing-ul", nodes: nodes)
+    }
+
     static func spinner() -> Self {
         .div(
             .class("spinner"),

--- a/Sources/App/Views/Plot+Extensions.swift
+++ b/Sources/App/Views/Plot+Extensions.swift
@@ -52,7 +52,7 @@ extension Node where Context: HTML.BodyContext {
     }
 
     static func spiOverflowingList(_ nodes: Node<HTML.ListContext>...) -> Self {
-        .element(named: "spi-overflowing-ul", nodes: nodes)
+        .element(named: "spi-overflowing-ul", nodes:[ .ul(.group(nodes)) ])
     }
 
     static func spinner() -> Self {

--- a/Sources/App/Views/Plot+Extensions.swift
+++ b/Sources/App/Views/Plot+Extensions.swift
@@ -51,8 +51,13 @@ extension Node where Context: HTML.BodyContext {
         .element(named: "tab-bar", nodes: nodes)
     }
 
-    static func spiOverflowingList(_ nodes: Node<HTML.ListContext>...) -> Self {
-        .element(named: "spi-overflowing-list", nodes:[ .ul(.group(nodes)) ])
+    static func spiOverflowingList(overflowMessage: String, _ nodes: Node<HTML.ListContext>...) -> Self {
+        .element(named: "spi-overflowing-list", nodes:[
+            .data(named: "overflow-message", value: overflowMessage),
+            .ul(
+                .group(nodes)
+            )
+        ])
     }
 
     static func spinner() -> Self {

--- a/Sources/App/Views/Plot+Extensions.swift
+++ b/Sources/App/Views/Plot+Extensions.swift
@@ -51,9 +51,16 @@ extension Node where Context: HTML.BodyContext {
         .element(named: "tab-bar", nodes: nodes)
     }
 
-    static func spiOverflowingList(overflowMessage: String, _ nodes: Node<HTML.ListContext>...) -> Self {
+    static func spiOverflowingList(overflowMessage: String,
+                                   overflowHeight: Int,
+                                   _ nodes: Node<HTML.ListContext>...) -> Self {
+        // Note: The `overflowHeight` is a magic number that needs some experimentation each
+        // time this tag is used. It's the exact size in pixels of the collapsed element. If
+        // incorrect, the "show more" button will show up unnecessarily as it may overflow by
+        // just a single invisible pixel.
         .element(named: "spi-overflowing-list", nodes:[
             .data(named: "overflow-message", value: overflowMessage),
+            .data(named: "overflow-height", value: "\(overflowHeight)px"),
             .ul(
                 .group(nodes)
             )

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.txt
@@ -122,38 +122,40 @@
                 <li class="libraries">3 libraries</li>
                 <li class="executables">1 executable</li>
                 <li class="keywords">
-                  <ul class="keywords">
-                    <li>
-                      <a href="/keywords/tag1">tag1</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag2">tag2</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag3">tag3</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag4">tag4</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag5">tag5</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag6">tag6</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag7">tag7</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag8">tag8</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag9">tag9</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag10">tag10</a>
-                    </li>
-                  </ul>
+                  <spi-overflowing-list data-overflow-message="Show all 10 tags…" data-overflow-height="52px">
+                    <ul class="keywords">
+                      <li>
+                        <a href="/keywords/tag1">tag1</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag2">tag2</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag3">tag3</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag4">tag4</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag5">tag5</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag6">tag6</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag7">tag7</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag8">tag8</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag9">tag9</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag10">tag10</a>
+                      </li>
+                    </ul>
+                  </spi-overflowing-list>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.txt
@@ -122,128 +122,130 @@
                 <li class="libraries">3 libraries</li>
                 <li class="executables">1 executable</li>
                 <li class="keywords">
-                  <ul class="keywords">
-                    <li>
-                      <a href="/keywords/tag1">tag1</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag2">tag2</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag3">tag3</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag4">tag4</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag5">tag5</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag6">tag6</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag7">tag7</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag8">tag8</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag9">tag9</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag10">tag10</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag11">tag11</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag12">tag12</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag13">tag13</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag14">tag14</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag15">tag15</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag16">tag16</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag17">tag17</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag18">tag18</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag19">tag19</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag20">tag20</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag21">tag21</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag22">tag22</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag23">tag23</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag24">tag24</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag25">tag25</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag26">tag26</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag27">tag27</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag28">tag28</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag29">tag29</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag30">tag30</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag31">tag31</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag32">tag32</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag33">tag33</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag34">tag34</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag35">tag35</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag36">tag36</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag37">tag37</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag38">tag38</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag39">tag39</a>
-                    </li>
-                    <li>
-                      <a href="/keywords/tag40">tag40</a>
-                    </li>
-                  </ul>
+                  <spi-overflowing-list data-overflow-message="Show all 40 tags…" data-overflow-height="52px">
+                    <ul class="keywords">
+                      <li>
+                        <a href="/keywords/tag1">tag1</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag2">tag2</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag3">tag3</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag4">tag4</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag5">tag5</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag6">tag6</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag7">tag7</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag8">tag8</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag9">tag9</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag10">tag10</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag11">tag11</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag12">tag12</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag13">tag13</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag14">tag14</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag15">tag15</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag16">tag16</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag17">tag17</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag18">tag18</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag19">tag19</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag20">tag20</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag21">tag21</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag22">tag22</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag23">tag23</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag24">tag24</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag25">tag25</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag26">tag26</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag27">tag27</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag28">tag28</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag29">tag29</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag30">tag30</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag31">tag31</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag32">tag32</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag33">tag33</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag34">tag34</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag35">tag35</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag36">tag36</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag37">tag37</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag38">tag38</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag39">tag39</a>
+                      </li>
+                      <li>
+                        <a href="/keywords/tag40">tag40</a>
+                      </li>
+                    </ul>
+                  </spi-overflowing-list>
                 </li>
               </ul>
             </section>


### PR DESCRIPTION
No functional changes here, but it will allow us to make any list of anything collapsable

<img width="513" alt="Screenshot 2022-02-22 at 16 14 42@2x" src="https://user-images.githubusercontent.com/5180/155173063-f72a073b-756d-4e13-87e3-014d99eeef9b.png">
.