### PR TITLE
Remove lodash

### DIFF
--- a/FrontEnd/scripts/copy_buttons.js
+++ b/FrontEnd/scripts/copy_buttons.js
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { delay } from 'lodash'
 import { measurePlausibleEvent } from './plausible_analytics.js'
 
 class SPICopyButton {
@@ -39,7 +38,7 @@ class SPICopyButton {
         button.textContent = 'Copied!'
 
         // Then change it back after a short delay.
-        delay(() => {
+        setTimeout(() => {
           button.textContent = oldButtonText
         }, 1000)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "@hotwired/turbo": "^7.1.0",
-    "lodash": "^4.17.21",
     "normalize.css": "^8.0.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -218,11 +218,6 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"


### PR DESCRIPTION
There was only one remaining function we were using in lodash and it could be easily replaced, so let's get rid of it!

Production JS size with this is ~147k -> ~73k!

