### PR TITLE
Revert "Merge pull request #1537 from SwiftPackageIndex/updatePackage…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,9 @@ name: Continuous Integration
 on:
   workflow_dispatch:
   push:
-  pull_request_review:
-    types: [submitted]
 
 jobs:
   test-linux:
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event.ref == 'updatePackageDepedencies' && github.event.review.state == 'approved')
     name: Test
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
…Depedencies"

This reverts commit bddaca66efe7f8046200ceb10b966563c4de502a, reversing
changes made to 38560d188c3b634099e6356e0e86c3113cd0f39b.

Fixes #1595 

I'm simply reverting this now and will delete and push the "update" branch in the future. It's just once a week and not worth fiddling with a user account to make the bot trigger the CI, at least for now.

I suspect what happened was that this never worked and when I tested it it only looked like it did, because the tests _also_ triggered a CI run via a push. These are the actions from the original PR #1537:

<img width="583" alt="CleanShot 2022-02-28 at 13 06 07@2x" src="https://user-images.githubusercontent.com/65520/155980753-6320e0da-6d0a-4483-a2c3-a80ca842ba2a.png">

Notice how the PR action is actually cancelled. I suspect the cancellation is still happening when the bot opens the PR but there's no corresponding `push` action. At the same time for some reason the PR reads this as "all tests passed" and allows a PR to be merged. I'd say this is a GH actions bug but I'm not going to investigate this further for now.