### PR TITLE
Use tagged SPM revision as a dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "83b23d940471b313427da226196661856f6ba3e0",
-          "version": "0.4.4"
+          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
+          "version": "1.0.3"
         }
       },
       {
@@ -176,8 +176,8 @@
         "package": "swift-driver",
         "repositoryURL": "https://github.com/apple/swift-driver.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "86c54dacd270e0c43374c0cb9b2ceb2924c9ea72",
+          "branch": "release/5.6",
+          "revision": "9982f32f96a2e0e597d1b4a0af4a7e997dc471be",
           "version": null
         }
       },
@@ -185,8 +185,8 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "83c4bcb8dfca48cc065325287b55d08ff7b26428",
+          "branch": "release/5.6",
+          "revision": "acd686530e56122d916acd49a166beb9198e9b87",
           "version": null
         }
       },
@@ -257,8 +257,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "swift-5.5.3-RELEASE",
-          "revision": "a29154a4137747bdbfe83ca26db4b24f8c4fcd31",
+          "branch": "release/5.6",
+          "revision": "6647fa09d6042b29cbb115eecf6f292beb7f6837",
           "version": null
         }
       },
@@ -284,8 +284,8 @@
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "release/5.5",
-          "revision": "3b586ce12865db205081acdcea79fe5509b28152",
+          "branch": "release/5.6",
+          "revision": "107e570e3565920174d5a25bc3a0340b32d16042",
           "version": null
         }
       },

--- a/Package.resolved
+++ b/Package.resolved
@@ -150,8 +150,8 @@
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {
           "branch": null,
-          "revision": "e394bf350e38cb100b6bc4172834770ede1b7232",
-          "version": "1.0.3"
+          "revision": "83b23d940471b313427da226196661856f6ba3e0",
+          "version": "0.4.4"
         }
       },
       {
@@ -161,15 +161,6 @@
           "branch": null,
           "revision": "d3e04a9d4b3833363fb6192065b763310b156d54",
           "version": "1.3.1"
-        }
-      },
-      {
-        "package": "swift-collections",
-        "repositoryURL": "https://github.com/apple/swift-collections.git",
-        "state": {
-          "branch": null,
-          "revision": "48254824bb4248676bf7ce56014ff57b142b77eb",
-          "version": "1.0.2"
         }
       },
       {
@@ -185,8 +176,8 @@
         "package": "swift-driver",
         "repositoryURL": "https://github.com/apple/swift-driver.git",
         "state": {
-          "branch": "main",
-          "revision": "30ade40aca629ce40714aebd97966763f783aeb7",
+          "branch": "release/5.5",
+          "revision": "86c54dacd270e0c43374c0cb9b2ceb2924c9ea72",
           "version": null
         }
       },
@@ -194,8 +185,8 @@
         "package": "llbuild",
         "repositoryURL": "https://github.com/apple/swift-llbuild.git",
         "state": {
-          "branch": "main",
-          "revision": "5d1b2863d18a8a2ef19363fc9bd803fc94bfd8cd",
+          "branch": "release/5.5",
+          "revision": "83c4bcb8dfca48cc065325287b55d08ff7b26428",
           "version": null
         }
       },
@@ -266,8 +257,8 @@
         "package": "SwiftPM",
         "repositoryURL": "https://github.com/apple/swift-package-manager.git",
         "state": {
-          "branch": "main",
-          "revision": "a783689cd4b09cd5983c6e9901b308b86a6d32fc",
+          "branch": "swift-5.5.3-RELEASE",
+          "revision": "a29154a4137747bdbfe83ca26db4b24f8c4fcd31",
           "version": null
         }
       },
@@ -290,20 +281,11 @@
         }
       },
       {
-        "package": "swift-system",
-        "repositoryURL": "https://github.com/apple/swift-system.git",
-        "state": {
-          "branch": null,
-          "revision": "836bc4557b74fe6d2660218d56e3ce96aff76574",
-          "version": "1.1.1"
-        }
-      },
-      {
         "package": "swift-tools-support-core",
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
-          "branch": "main",
-          "revision": "9a23d5caf7164f2bb2cc2d9c0a3d1bb9b4c6ffae",
+          "branch": "release/5.5",
+          "revision": "3b586ce12865db205081acdcea79fe5509b28152",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/handya/OhhAuth.git", from: "1.4.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
         .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git",
-                 .branch("swift-5.5.3-RELEASE"))
+                 .branch("release/5.6"))
     ],
     targets: [
         .target(name: "App", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -39,8 +39,8 @@ let package = Package(
         .package(url: "https://github.com/SwiftPackageIndex/SemanticVersion", from: "0.3.0"),
         .package(url: "https://github.com/handya/OhhAuth.git", from: "1.4.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
-        .package(name: "SwiftPM",
-                 url: "https://github.com/apple/swift-package-manager.git", .branch("main"))
+        .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git",
+                 .branch("swift-5.5.3-RELEASE"))
     ],
     targets: [
         .target(name: "App", dependencies: [


### PR DESCRIPTION
Fixes #1589 

Ideally, SPM had SemVer we could track but it doesn't. We'll need to move this whenever we need incorporate upstream changes, which is only the package collections module at the moment:

```swift
            .product(name: "SwiftPMPackageCollections", package: "SwiftPM")
```