### PR TITLE
Deal better with errors rendering README files

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -46,12 +46,13 @@ struct PackageController {
             .query(on: req.db, owner: owner, repository: repository)
             .flatMap { result in
                 guard let url = result.repository?.readmeHtmlUrl
-                else { return req.eventLoop.future(nil) }
+                else { return req.eventLoop.future((url: nil, readme: nil)) }
                 return req.client.get(URI(string: url))
-                    .map { $0.body?.asString() }
+                    .map { (url: url, readme: $0.body?.asString()) }
             }
-            .map(PackageReadme.Model.init(readme:))
-            .map { PackageReadme.View(model: $0).document() }
+            .map(PackageReadme.Model.init(url:readme:))
+            .map(PackageReadme.View.init(model:))
+            .map { $0.document() }
     }
     
     func releases(req: Request) throws -> EventLoopFuture<Node<HTML.BodyContext>> {

--- a/Sources/App/Views/PackageController/PackageReadme+Model.swift
+++ b/Sources/App/Views/PackageController/PackageReadme+Model.swift
@@ -19,9 +19,11 @@ import SwiftSoup
 extension PackageReadme {
     
     struct Model: Equatable {
+        var url: String?
         private var readmeElement: Element?
 
         internal init(url: String?, readme: String?) {
+            self.url = url
             self.readmeElement = processReadme(readme)
         }
 

--- a/Sources/App/Views/PackageController/PackageReadme+Model.swift
+++ b/Sources/App/Views/PackageController/PackageReadme+Model.swift
@@ -21,7 +21,7 @@ extension PackageReadme {
     struct Model: Equatable {
         private var readmeElement: Element?
 
-        internal init(readme: String?) {
+        internal init(url: String?, readme: String?) {
             self.readmeElement = processReadme(readme)
         }
 

--- a/Sources/App/Views/PackageController/PackageReadme+View.swift
+++ b/Sources/App/Views/PackageController/PackageReadme+View.swift
@@ -32,12 +32,26 @@ enum PackageReadme {
 
         override func frameContent() -> Node<HTML.BodyContext> {
             guard let readme = model.readme
-            else { return .empty }
+            else { return blankReadmePlaceholder() }
 
             return .group(
                 .spiReadme(
                     .raw(readme)
                 )
+            )
+        }
+
+        func blankReadmePlaceholder() -> Node<HTML.BodyContext> {
+            guard let url = model.url
+            else { return .p("This package does not have a README file.") }
+
+            return .p(
+                .text("This package's README file couldn't be loaded. Try "),
+                .a(
+                    .href(url),
+                    .text("viewing it on GitHub")
+                ),
+                .text(".")
             )
         }
     }

--- a/Tests/AppTests/Mocks/PackageReadmeModel+mock.swift
+++ b/Tests/AppTests/Mocks/PackageReadmeModel+mock.swift
@@ -19,7 +19,9 @@ import Foundation
 
 extension PackageReadme.Model {
     static var mock: PackageReadme.Model {
-        .init(readme: """
+        .init(
+            url: "https://example.com/owner/repo/README",
+            readme: """
             <div id="readme">
                 <article>
                     <p>This is README content.</p>

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -21,7 +21,9 @@ import SnapshotTesting
 class PackageReadmeModelTests: SnapshotTestCase {
 
     func test_processReadme_extractReadmeElement() throws {
-        let model = PackageReadme.Model(readme: """
+        let model = PackageReadme.Model(
+            url: "https://example.com/owner/repo/README",
+            readme: """
             <html>
                 <head>
                     <title>README file</title>
@@ -42,7 +44,9 @@ class PackageReadmeModelTests: SnapshotTestCase {
     }
 
     func test_processReadme_processRelativeImages() throws {
-        let model = PackageReadme.Model(readme: """
+        let model = PackageReadme.Model(
+            url: "https://example.com/owner/repo/README",
+            readme: """
             <html>
                 <head>
                     <title>README file</title>
@@ -67,7 +71,9 @@ class PackageReadmeModelTests: SnapshotTestCase {
     }
 
     func test_processReadme_processRelativeLinks() throws {
-        let model = PackageReadme.Model(readme: """
+        let model = PackageReadme.Model(
+            url: "https://example.com/owner/repo/README",
+            readme: """
             <html>
                 <head>
                     <title>README file</title>

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -332,6 +332,24 @@ class WebpageSnapshotTests: WebpageSnapshotTestCase {
         #endif
     }
 
+    func test_PackageReadmeView_unparseableReadme() throws {
+        let model = PackageReadme.Model(url: "https://example.com/owner/repo/README", readme: nil)
+        let page = { PackageReadme.View(model: model).document() }
+
+        assertSnapshot(matching: page, as: .html)
+
+        // Note: This snapshot test deliberately omits an image snapshot as the HTML being tested has no explicit styling.
+    }
+
+    func test_PackageReadmeView_noReadme() throws {
+        let model = PackageReadme.Model(url: nil, readme: nil)
+        let page = { PackageReadme.View(model: model).document() }
+
+        assertSnapshot(matching: page, as: .html)
+
+        // Note: This snapshot test deliberately omits an image snapshot as the HTML being tested has no explicit styling.
+    }
+
     func test_PackageReleasesView() throws {
         let model = PackageReleases.Model.mock
         let page = { PackageReleases.View(model: model).document() }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageReadmeView_noReadme.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageReadmeView_noReadme.1.txt
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <turbo-frame id="readme_page">
+      <p>This package does not have a README file.</p>
+    </turbo-frame>
+  </body>
+</html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageReadmeView_unparseableReadme.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageReadmeView_unparseableReadme.1.txt
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <turbo-frame id="readme_page">
+      <p>This package's README file couldn't be loaded. Try 
+        <a href="https://example.com/owner/repo/README">viewing it on GitHub</a>.
+      </p>
+    </turbo-frame>
+  </body>
+</html>


### PR DESCRIPTION
Progress towards: #1628 

For packages with a README that fails to parse:

<img width="862" alt="Screenshot 2022-03-21 at 19 19 55@2x" src="https://user-images.githubusercontent.com/5180/159348355-fb734272-8f35-41ad-8a76-8bf0b457fcfd.png">

For packages without a README at all:

<img width="861" alt="Screenshot 2022-03-21 at 19 20 07@2x" src="https://user-images.githubusercontent.com/5180/159348361-28a215a8-6d65-41ed-887d-c196654a7ddc.png">

