### PR TITLE
Fix layout on iPad mini 6th gen

### DIFF
--- a/FrontEnd/main.scss
+++ b/FrontEnd/main.scss
@@ -15,7 +15,7 @@
 
 @use 'normalize.css/normalize.css';
 
-$mobile-breakpoint: 767px;
+$mobile-breakpoint: 740px;
 
 @import 'styles/base.scss';
 @import 'styles/build_logs.scss';


### PR DESCRIPTION
Fixes #1644 

Since its launch, the iPad mini has had the same logical screen size as the original iPad 768x1024, until the 6th gen when it changed to 744x1133.

TIL