### PR TITLE
Login in again in case the previous steps were slow

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,6 +44,9 @@ build:
 
     docker run --rm -v $PWD:/host -w /host --user $(id -u):$(id -g) node:16-alpine yarn
     docker run --rm -v $PWD:/host -w /host --user $(id -u):$(id -g) node:16-alpine yarn build
+
+    # Login in again in case the previous steps were slow and made the token time out
+    docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
     docker build -t $REGISTRY_IMAGE:$VERSION .
 
     retries=3


### PR DESCRIPTION
Should fix these build errors in Gitlab:

```
Done in 1.61s.
Step 1/15 : FROM registry.gitlab.com/finestructure/spi-base:0.7.0 as build
Head "https://registry.gitlab.com/v2/finestructure/spi-base/manifests/0.7.0": unauthorized: HTTP Basic: Access denied
```