### PR TITLE
Enable GZIP compression for all responses

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -21,6 +21,10 @@ public func configure(_ app: Application) throws -> String {
     app.logger.component = "server"
     Current.setLogger(app.logger)
 
+    // Enable GZIP (de-)compression on all requests and responses
+    app.http.server.configuration.responseCompression = .enabled
+    app.http.server.configuration.requestDecompression = .enabled
+    
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(ErrorMiddleware())
 


### PR DESCRIPTION
As per the documentation (https://docs.vapor.codes/4.0/server/#response-compression) this is turned off by default, but does provide (in testing) a decrease in response times and data sizes. Hopefully this will help reduce our bandwidth, reducing costs, as well as making the experience better for our users.

We will want to closely monitor these changes, it may be hard to evaluate perfectly in staging due to the low usage.