### PR TITLE
Fix flickering snapshot test

### DIFF
--- a/FrontEnd/scripts/controllers/overflowing_list_controller.js
+++ b/FrontEnd/scripts/controllers/overflowing_list_controller.js
@@ -26,21 +26,23 @@ export class OverflowingListController extends Controller {
     if (this.collapsedValue) {
       // Immediately adjust the height of the potentially overflowing keyword list.
       this.listTarget.style.setProperty('max-height', `${this.overflowHeightValue}px`)
-
-      // If the collapsing hid any content, add a "show more" that expands it.
-      if (this.isOverflowing(this.listTarget)) {
-        const showMoreElement = document.createElement('a')
-        showMoreElement.dataset.overflowingListTarget = 'showMore'
-        showMoreElement.dataset.action = 'click->overflowing-list#expand'
-        showMoreElement.innerText = this.overflowMessageValue
-        showMoreElement.href = '#' // Needed to turn the cursor into a hand.
-        this.element.appendChild(showMoreElement)
-      }
     }
   }
 
   disconnect() {
     if (this.hasShowMoreTarget) this.showMoreTarget.remove()
+  }
+
+  addShowMoreLinkIfNeeded() {
+    // If the collapsing hid any content, add a "show more" that expands it.
+    if (this.isOverflowing(this.listTarget) && this.hasShowMoreTarget === false) {
+      const showMoreElement = document.createElement('a')
+      showMoreElement.dataset.overflowingListTarget = 'showMore'
+      showMoreElement.dataset.action = 'click->overflowing-list#expand'
+      showMoreElement.innerText = this.overflowMessageValue
+      showMoreElement.href = '#' // Needed to turn the cursor into a hand.
+      this.element.appendChild(showMoreElement)
+    }
   }
 
   expand(event) {

--- a/Sources/App/Views/Plot+Extensions.swift
+++ b/Sources/App/Views/Plot+Extensions.swift
@@ -64,6 +64,7 @@ extension Node where Context: HTML.BodyContext {
             .data(named: "overflowing-list-overflow-message-value", value: overflowMessage),
             .data(named: "overflowing-list-overflow-height-value", value: String(overflowHeight)),
             .data(named: "overflowing-list-collapsed-value", value: String(true)),
+            .data(named: "action", value: "turbo:load@document->overflowing-list#addShowMoreLinkIfNeeded"),
             .ul(
                 .data(named: "overflowing-list-target", value: "list"),
                 .unwrap(listClass) { .class($0) },

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.txt
@@ -143,7 +143,7 @@
                 <li class="libraries">3 libraries</li>
                 <li class="executables">1 executable</li>
                 <li class="keywords">
-                  <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show all 9 tags…" data-overflowing-list-overflow-height-value="52" data-overflowing-list-collapsed-value="true">
+                  <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show all 9 tags…" data-overflowing-list-overflow-height-value="52" data-overflowing-list-collapsed-value="true" data-action="turbo:load@document->overflowing-list#addShowMoreLinkIfNeeded">
                     <ul data-overflowing-list-target="list" class="keywords">
                       <li>
                         <a href="/keywords/tag1">tag1</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.txt
@@ -143,7 +143,7 @@
                 <li class="libraries">3 libraries</li>
                 <li class="executables">1 executable</li>
                 <li class="keywords">
-                  <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show all 40 tags…" data-overflowing-list-overflow-height-value="52" data-overflowing-list-collapsed-value="true">
+                  <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show all 40 tags…" data-overflowing-list-overflow-height-value="52" data-overflowing-list-collapsed-value="true" data-action="turbo:load@document->overflowing-list#addShowMoreLinkIfNeeded">
                     <ul data-overflowing-list-target="list" class="keywords">
                       <li>
                         <a href="/keywords/tag1">tag1</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow.1.txt
@@ -181,7 +181,7 @@
             <div>
               <section class="author_results">
                 <h4>Matching authors</h4>
-                <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show more authors…" data-overflowing-list-overflow-height-value="129" data-overflowing-list-collapsed-value="true">
+                <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show more authors…" data-overflowing-list-overflow-height-value="129" data-overflowing-list-collapsed-value="true" data-action="turbo:load@document->overflowing-list#addShowMoreLinkIfNeeded">
                   <ul data-overflowing-list-target="list">
                     <li>
                       <a href="/Apple">Apple</a>
@@ -197,7 +197,7 @@
               </section>
               <section class="keyword_results">
                 <h4>Matching keywords</h4>
-                <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show more keywords…" data-overflowing-list-overflow-height-value="260" data-overflowing-list-collapsed-value="true">
+                <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show more keywords…" data-overflowing-list-overflow-height-value="260" data-overflowing-list-collapsed-value="true" data-action="turbo:load@document->overflowing-list#addShowMoreLinkIfNeeded">
                   <ul data-overflowing-list-target="list" class="keywords">
                     <li>
                       <a href="/keywords/keyword1">keyword1</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow_withFilters.1.txt
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow_withFilters.1.txt
@@ -163,7 +163,7 @@
             <div>
               <section class="author_results">
                 <h4>Matching authors</h4>
-                <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show more authors…" data-overflowing-list-overflow-height-value="129" data-overflowing-list-collapsed-value="true">
+                <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show more authors…" data-overflowing-list-overflow-height-value="129" data-overflowing-list-collapsed-value="true" data-action="turbo:load@document->overflowing-list#addShowMoreLinkIfNeeded">
                   <ul data-overflowing-list-target="list">
                     <li>
                       <a href="/Apple">Apple</a>
@@ -179,7 +179,7 @@
               </section>
               <section class="keyword_results">
                 <h4>Matching keywords</h4>
-                <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show more keywords…" data-overflowing-list-overflow-height-value="260" data-overflowing-list-collapsed-value="true">
+                <div data-controller="overflowing-list" data-overflowing-list-overflow-message-value="Show more keywords…" data-overflowing-list-overflow-height-value="260" data-overflowing-list-collapsed-value="true" data-action="turbo:load@document->overflowing-list#addShowMoreLinkIfNeeded">
                   <ul data-overflowing-list-target="list" class="keywords">
                     <li>
                       <a href="/keywords/keyword1">keyword1</a>


### PR DESCRIPTION
Fixes #1681

Should be more reliable now! The detection of overflow was sometimes happening before the DOM had finished loading and painting.