### PR TITLE
Prevent negative package scores

### DIFF
--- a/Sources/App/Core/Score.swift
+++ b/Sources/App/Core/Score.swift
@@ -28,7 +28,7 @@ enum Score {
         var score = 0
         
         // Is the package archived and no longer receiving updates?
-        if candidate.isArchived == false { score += 10 }
+        if candidate.isArchived == false { score += 20 }
         
         // Is the license open-source and compatible with the App Store?
         switch candidate.licenseKind {

--- a/Sources/App/Core/Score.swift
+++ b/Sources/App/Core/Score.swift
@@ -28,7 +28,7 @@ enum Score {
         var score = 0
         
         // Is the package archived and no longer receiving updates?
-        if candidate.isArchived { score -= 10 }
+        if candidate.isArchived == false { score += 10 }
         
         // Is the license open-source and compatible with the App Store?
         switch candidate.licenseKind {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -191,8 +191,8 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(targets.map(\.name), ["t1", "t1", "t1", "t2", "t2", "t2"])
         
         // validate score
-        XCTAssertEqual(pkg1.score, 15)
-        XCTAssertEqual(pkg2.score, 25)
+        XCTAssertEqual(pkg1.score, 35)
+        XCTAssertEqual(pkg2.score, 45)
         
         // ensure stats, recent packages, and releases are refreshed
         XCTAssertEqual(try Stats.fetch(on: app.db).wait(), .init(packageCount: 2))

--- a/Tests/AppTests/ScoreTests.swift
+++ b/Tests/AppTests/ScoreTests.swift
@@ -25,83 +25,83 @@ class ScoreTests: AppTestCase {
                                            likeCount: 0,
                                            isArchived: false,
                                            numberOfDependencies: nil)),
-                       0)
+                       20)
         XCTAssertEqual(Score.compute(.init(licenseKind: .incompatibleWithAppStore,
                                            releaseCount: 0,
                                            likeCount: 0,
                                            isArchived: false,
                                            numberOfDependencies: nil)),
-                       3)
+                       23)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 0,
                                            likeCount: 0,
                                            isArchived: false,
                                            numberOfDependencies: nil)),
-                       10)
+                       30)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 10,
                                            likeCount: 0,
                                            isArchived: false,
                                            numberOfDependencies: nil)),
-                       20)
+                       40)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 10,
                                            likeCount: 50,
                                            isArchived: false,
                                            numberOfDependencies: nil)),
-                       30)
+                       50)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 10,
                                            likeCount: 50,
                                            isArchived: true,
                                            numberOfDependencies: nil)),
-                       20)
+                       30)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 20,
                                            likeCount: 20_000,
                                            isArchived: false,
                                            numberOfDependencies: nil)),
-                       67)
+                       87)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 20,
                                            likeCount: 20_000,
                                            isArchived: false,
                                            numberOfDependencies: 4)),
-                       69)
+                       89)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 20,
                                            likeCount: 20_000,
                                            isArchived: false,
                                            numberOfDependencies: 2)),
-                       72)
+                       92)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 20,
                                            likeCount: 20_000,
                                            isArchived: false,
                                            numberOfDependencies: 2,
                                            lastActivityAt: Current.date().addingDays(-400))),
-                       72)
+                       92)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 20,
                                            likeCount: 20_000,
                                            isArchived: false,
                                            numberOfDependencies: 2,
                                            lastActivityAt: Current.date().addingDays(-300))),
-                       77)
+                       97)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 20,
                                            likeCount: 20_000,
                                            isArchived: false,
                                            numberOfDependencies: 2,
                                            lastActivityAt: Current.date().addingDays(-100))),
-                       82)
+                       102)
         XCTAssertEqual(Score.compute(.init(licenseKind: .compatibleWithAppStore,
                                            releaseCount: 20,
                                            likeCount: 20_000,
                                            isArchived: false,
                                            numberOfDependencies: 2,
                                            lastActivityAt: Current.date().addingDays(-10))),
-                       87)
+                       107)
     }
     
     func test_compute_package_versions() throws {
@@ -123,7 +123,7 @@ class ScoreTests: AppTestCase {
             .wait()
 
         // MUT
-        XCTAssertEqual(Score.compute(package: jpr, versions: versions), 62)
+        XCTAssertEqual(Score.compute(package: jpr, versions: versions), 82)
     }
 
 }


### PR DESCRIPTION
Fixes #1693 

I also increased the penalty for an archived repository, too. They really should be de-emphasised.