### PR TITLE
Remove usleep, convert underlying ELFs and lots of tests to a/a

### DIFF
--- a/Sources/App/Controllers/PackageController+PackageResult.swift
+++ b/Sources/App/Controllers/PackageController+PackageResult.swift
@@ -31,8 +31,8 @@ extension PackageController.PackageResult {
     var releaseVersion: ReleaseVersion? { relation3 }
     var preReleaseVersion: PreReleaseVersion? { relation4 }
 
-    static func query(on database: Database, owner: String, repository: String) -> EventLoopFuture<Self> {
-        Package.query(on: database)
+    static func query(on database: Database, owner: String, repository: String) async throws -> Self {
+        let model = try await Package.query(on: database)
             .join(Repository.self,
                   on: \Repository.$package.$id == \Package.$id,
                   method: .inner)
@@ -62,7 +62,7 @@ extension PackageController.PackageResult {
         // only slight gains.
             .first()
             .unwrap(or: Abort(.notFound))
-            .map(Self.init(model:))
+        return Self.init(model: model)
     }
 }
 

--- a/Sources/App/Controllers/PackageController+ShowRoute.swift
+++ b/Sources/App/Controllers/PackageController+ShowRoute.swift
@@ -27,35 +27,36 @@ extension PackageController {
         ///   - owner: repository owner
         ///   - repository: repository name
         /// - Returns: model structs
-        static func query(on database: Database, owner: String, repository: String) -> EventLoopFuture<(model: PackageShow.Model, schema: PackageShow.PackageSchema)> {
-            PackageResult.query(on: database, owner: owner, repository: repository)
-                .and(History.query(on: database, owner: owner, repository: repository))
-                .and(ProductCount.query(on: database, owner: owner, repository: repository))
-                .and(BuildInfo.query(on: database, owner: owner, repository: repository))
-                .map {
-                    // This monster will go away when we switch to async/await,
-                    // leaving this in for now, it should be short-lived
-                    ($0.0.0.0, $0.0.0.1, $0.0.1, $0.1)
-                }
-                .map { (packageResult, historyResult, productTypes, buildInfo) -> (model: PackageShow.Model, schema: PackageShow.PackageSchema)? in
-                    guard
-                        let model = PackageShow.Model(
-                            result: packageResult,
-                            history: historyResult?.history(),
-                            productCounts: .init(
-                                libraries: productTypes.filter(\.isLibrary).count,
-                                executables: productTypes.filter(\.isExecutable).count),
-                            swiftVersionBuildInfo: buildInfo.swiftVersion,
-                            platformBuildInfo: buildInfo.platform
-                        ),
-                        let schema = PackageShow.PackageSchema(result: packageResult)
-                    else {
-                        return nil
-                    }
+        static func query(on database: Database, owner: String, repository: String) async throws -> (model: PackageShow.Model, schema: PackageShow.PackageSchema) {
+            let packageResult = try await PackageResult.query(on: database,
+                                                              owner: owner,
+                                                              repository: repository)
+            let historyRecord = try await History.query(on: database,
+                                                        owner: owner,
+                                                        repository: repository)
+            let productTypes = try await ProductCount.query(on: database,
+                                                            owner: owner,
+                                                            repository: repository)
+            let buildInfo = try await BuildInfo.query(on: database,
+                                                      owner: owner,
+                                                      repository: repository)
 
-                    return (model, schema)
-                }
-                .unwrap(or: Abort(.notFound))
+            guard
+                let model = PackageShow.Model(
+                    result: packageResult,
+                    history: historyRecord?.historyModel(),
+                    productCounts: .init(
+                        libraries: productTypes.filter(\.isLibrary).count,
+                        executables: productTypes.filter(\.isExecutable).count),
+                    swiftVersionBuildInfo: buildInfo.swiftVersion,
+                    platformBuildInfo: buildInfo.platform
+                ),
+                let schema = PackageShow.PackageSchema(result: packageResult)
+            else {
+                throw Abort(.notFound)
+            }
+
+            return (model, schema)
         }
     }
 
@@ -75,7 +76,7 @@ extension PackageController {
                 case releaseCount = "release_count"
             }
 
-            func history() -> PackageShow.Model.History? {
+            func historyModel() -> PackageShow.Model.History? {
                 guard let defaultBranch = defaultBranch,
                       let firstCommitDate = firstCommitDate else {
                     return nil
@@ -92,13 +93,13 @@ extension PackageController {
             }
         }
 
-        static func query(on database: Database, owner: String, repository: String) -> EventLoopFuture<Record?> {
+        static func query(on database: Database, owner: String, repository: String) async throws -> Record? {
             guard let db = database as? SQLDatabase else {
                 fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
             }
             // This query cannot expressed in Fluent, because it doesn't support
             // GROUP BY clauses.
-            return db.raw(#"""
+            return try await db.raw(#"""
                 SELECT p.url, r.default_branch, r.first_commit_date, r.commit_count, count(v.reference) AS "release_count"
                 FROM packages p
                 JOIN repositories r ON r.package_id = p.id
@@ -115,12 +116,12 @@ extension PackageController {
     }
 
     enum ProductCount {
-        static func query(on database: Database, owner: String, repository: String) -> EventLoopFuture<[ProductType]> {
-            Joined4<Package, Repository, Version, Product>
+        static func query(on database: Database, owner: String, repository: String) async throws -> [ProductType] {
+            try await Joined4<Package, Repository, Version, Product>
                 .query(on: database, owner: owner, repository: repository)
                 .field(Product.self, \.$type)
                 .all()
-                .mapEachCompact { $0.product.type }
+                .compactMap(\.product.type)
         }
     }
 
@@ -133,14 +134,14 @@ extension PackageController {
         var platform: ModelBuildInfo<PlatformResults>?
         var swiftVersion: ModelBuildInfo<SwiftVersionResults>?
 
-        static func query(on database: Database, owner: String, repository: String) -> EventLoopFuture<Self> {
-            BuildsRoute.BuildInfo.query(on: database, owner: owner, repository: repository)
-                .map { builds in
-                    Self.init(
-                        platform: platformBuildInfo(builds: builds),
-                        swiftVersion: swiftVersionBuildInfo(builds: builds)
-                    )
-                }
+        static func query(on database: Database, owner: String, repository: String) async throws -> Self {
+            let builds = try await BuildsRoute.BuildInfo.query(on: database,
+                                                               owner: owner,
+                                                               repository: repository)
+            return Self.init(
+                platform: platformBuildInfo(builds: builds),
+                swiftVersion: swiftVersionBuildInfo(builds: builds)
+            )
         }
 
         static func platformBuildInfo(

--- a/Sources/App/Core/Query+Support/JoinedQueryBuilder.swift
+++ b/Sources/App/Core/Query+Support/JoinedQueryBuilder.swift
@@ -124,6 +124,11 @@ struct JoinedQueryBuilder<J: ModelInitializable> {
             .mapEach(J.init(model:))
     }
 
+    func first() async throws -> J? {
+        try await queryBuilder.first()
+            .map(J.init(model:))
+    }
+
     func first() -> EventLoopFuture<J?> {
         queryBuilder.first()
             .optionalMap(J.init(model:))

--- a/Tests/AppTests/BuildIndexModelTests.swift
+++ b/Tests/AppTests/BuildIndexModelTests.swift
@@ -20,21 +20,21 @@ import XCTVapor
 
 class BuildIndexModelTests: AppTestCase {
 
-    func test_init_no_name() throws {
+    func test_init_no_name() async throws {
         // Tests behaviour when we're lacking data
         // setup package without package name
         let pkg = try savePackage(on: app.db, "1".url)
-        try Repository(package: pkg,
-                       defaultBranch: "main",
-                       forks: 42,
-                       license: .mit,
-                       name: "bar",
-                       owner: "foo",
-                       stars: 17,
-                       summary: "summary").save(on: app.db).wait()
+        try await Repository(package: pkg,
+                             defaultBranch: "main",
+                             forks: 42,
+                             license: .mit,
+                             name: "bar",
+                             owner: "foo",
+                             stars: 17,
+                             summary: "summary").save(on: app.db)
         try Version(package: pkg, latest: .defaultBranch).save(on: app.db).wait()
-        let (pkgInfo, buildInfo) = try PackageController.BuildsRoute
-            .query(on: app.db, owner: "foo", repository: "bar").wait()
+        let (pkgInfo, buildInfo) = try await PackageController.BuildsRoute
+            .query(on: app.db, owner: "foo", repository: "bar")
 
         // MUT
         let m = BuildIndex.Model(packageInfo: pkgInfo, buildInfo: buildInfo)

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -33,7 +33,7 @@ class PackageController_routesTests: AppTestCase {
     }
 
     func test_show_checkingGitHubRepository_notFound() throws {
-        Current.fetchHTTPStatusCode = { _ in .mock(.notFound) }
+        Current.fetchHTTPStatusCode = { _ in .notFound }
 
         // MUT
         try app.test(.GET, "/unknown/package") {
@@ -42,7 +42,7 @@ class PackageController_routesTests: AppTestCase {
     }
 
     func test_show_checkingGitHubRepository_found() throws {
-        Current.fetchHTTPStatusCode = { _ in .mock(.ok) }
+        Current.fetchHTTPStatusCode = { _ in .ok }
 
         // MUT
         try app.test(.GET, "/unknown/package") {
@@ -83,7 +83,7 @@ class PackageController_routesTests: AppTestCase {
 
     func test_ShowModel_packageMissing() async throws {
         // setup
-        Current.fetchHTTPStatusCode = { _ in .mock(.ok) }
+        Current.fetchHTTPStatusCode = { _ in .ok }
 
         // MUT
         let model = try await PackageController.ShowModel(db: app.db, owner: "owner", repository: "package")
@@ -99,7 +99,7 @@ class PackageController_routesTests: AppTestCase {
 
     func test_ShowModel_packageDoesNotExist() async throws {
         // setup
-        Current.fetchHTTPStatusCode = { _ in .mock(.notFound) }
+        Current.fetchHTTPStatusCode = { _ in .notFound }
 
         // MUT
         let model = try await PackageController.ShowModel(db: app.db, owner: "owner", repository: "package")
@@ -200,25 +200,4 @@ class PackageController_routesTests: AppTestCase {
 }
 
 
-private struct FetchError: Error {
-    init() {
-        // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1606#issuecomment-1075391125 as to why we're adding this delay
-        usleep(.milliseconds(100))
-    }
-}
-
-
-private extension HTTPStatus {
-    static func mock(_ status: Self) -> Self {
-        // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1606#issuecomment-1075391125 as to why we're adding this delay
-        usleep(.milliseconds(100))
-        return status
-    }
-}
-
-
-private extension useconds_t {
-    static func milliseconds(_ count: Int) -> Self {
-        useconds_t(count * 1_000)
-    }
-}
+private struct FetchError: Error { }

--- a/Tests/AppTests/PackageResultTests.swift
+++ b/Tests/AppTests/PackageResultTests.swift
@@ -20,40 +20,40 @@ import XCTest
 class PackageResultTests: AppTestCase {
     typealias PackageResult = PackageController.PackageResult
 
-    func test_joined5() throws {
+    func test_joined5() async throws {
         do {
             let pkg = try savePackage(on: app.db, "1".url)
-            try Repository(package: pkg,
-                           defaultBranch: "main",
-                           forks: 42,
-                           license: .mit,
-                           name: "bar",
-                           owner: "foo",
-                           stars: 17,
-                           summary: "summary").save(on: app.db).wait()
+            try await Repository(package: pkg,
+                                 defaultBranch: "main",
+                                 forks: 42,
+                                 license: .mit,
+                                 name: "bar",
+                                 owner: "foo",
+                                 stars: 17,
+                                 summary: "summary").save(on: app.db)
             do {
-                try App.Version(package: pkg,
-                                latest: .defaultBranch,
-                                reference: .branch("main")
-                ).save(on: app.db).wait()
+                try await App.Version(package: pkg,
+                                      latest: .defaultBranch,
+                                      reference: .branch("main")
+                ).save(on: app.db)
             }
             do {
-                try App.Version(package: pkg,
-                                latest: .release,
-                                reference: .tag(1, 2, 3)
-                ).save(on: app.db).wait()
+                try await App.Version(package: pkg,
+                                      latest: .release,
+                                      reference: .tag(1, 2, 3)
+                ).save(on: app.db)
             }
             do {
-                try App.Version(package: pkg,
-                                latest: .preRelease,
-                                reference: .tag(2, 0, 0, "b1")
-                ).save(on: app.db).wait()
+                try await App.Version(package: pkg,
+                                      latest: .preRelease,
+                                      reference: .tag(2, 0, 0, "b1")
+                ).save(on: app.db)
             }
         }
 
         // MUT
-        let res = try PackageController.PackageResult
-            .query(on: app.db, owner: "foo", repository: "bar").wait()
+        let res = try await PackageController.PackageResult
+            .query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
         XCTAssertEqual(res.model.url, "1")
@@ -63,35 +63,35 @@ class PackageResultTests: AppTestCase {
         XCTAssertEqual(res.preReleaseVersion?.reference, .tag(2, 0, 0, "b1"))
     }
 
-    func test_joined5_no_preRelease() throws {
+    func test_joined5_no_preRelease() async throws {
         do {
             // FIXME: add unrelated package and version to test right/left join correctness
             let pkg = try savePackage(on: app.db, "1".url)
-            try Repository(package: pkg,
-                           defaultBranch: "main",
-                           forks: 42,
-                           license: .mit,
-                           name: "bar",
-                           owner: "foo",
-                           stars: 17,
-                           summary: "summary").save(on: app.db).wait()
+            try await Repository(package: pkg,
+                                 defaultBranch: "main",
+                                 forks: 42,
+                                 license: .mit,
+                                 name: "bar",
+                                 owner: "foo",
+                                 stars: 17,
+                                 summary: "summary").save(on: app.db)
             do {
-                try App.Version(package: pkg,
-                                latest: .defaultBranch,
-                                reference: .branch("main")
-                ).save(on: app.db).wait()
+                try await App.Version(package: pkg,
+                                      latest: .defaultBranch,
+                                      reference: .branch("main")
+                ).save(on: app.db)
             }
             do {
-                try App.Version(package: pkg,
-                                latest: .release,
-                                reference: .tag(1, 2, 3)
-                ).save(on: app.db).wait()
+                try await App.Version(package: pkg,
+                                      latest: .release,
+                                      reference: .tag(1, 2, 3)
+                ).save(on: app.db)
             }
         }
 
         // MUT
-        let res = try PackageController.PackageResult
-            .query(on: app.db, owner: "foo", repository: "bar").wait()
+        let res = try await PackageController.PackageResult
+            .query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
         XCTAssertEqual(res.model.url, "1")
@@ -100,29 +100,29 @@ class PackageResultTests: AppTestCase {
         XCTAssertEqual(res.releaseVersion?.reference, .tag(1, 2, 3))
     }
 
-    func test_joined5_defaultBranch_only() throws {
+    func test_joined5_defaultBranch_only() async throws {
         do {
             // FIXME: add unrelated package and version to test right/left join correctness
             let pkg = try savePackage(on: app.db, "1".url)
-            try Repository(package: pkg,
-                           defaultBranch: "main",
-                           forks: 42,
-                           license: .mit,
-                           name: "bar",
-                           owner: "foo",
-                           stars: 17,
-                           summary: "summary").save(on: app.db).wait()
+            try await Repository(package: pkg,
+                                 defaultBranch: "main",
+                                 forks: 42,
+                                 license: .mit,
+                                 name: "bar",
+                                 owner: "foo",
+                                 stars: 17,
+                                 summary: "summary").save(on: app.db)
             do {
-                try App.Version(package: pkg,
-                                latest: .defaultBranch,
-                                reference: .branch("main")
-                ).save(on: app.db).wait()
+                try await App.Version(package: pkg,
+                                      latest: .defaultBranch,
+                                      reference: .branch("main")
+                ).save(on: app.db)
             }
         }
 
         // MUT
-        let res = try PackageController.PackageResult
-            .query(on: app.db, owner: "foo", repository: "bar").wait()
+        let res = try await PackageController.PackageResult
+            .query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
         XCTAssertEqual(res.model.url, "1")
@@ -130,75 +130,75 @@ class PackageResultTests: AppTestCase {
         XCTAssertEqual(res.defaultBranchVersion.reference, .branch("main"))
     }
 
-    func test_query_owner_repository() throws {
+    func test_query_owner_repository() async throws {
         // setup
         let pkg = try savePackage(on: app.db, "1".url)
-        try Repository(package: pkg,
-                       defaultBranch: "main",
-                       forks: 42,
-                       license: .mit,
-                       name: "bar",
-                       owner: "foo",
-                       stars: 17,
-                       summary: "summary").save(on: app.db).wait()
+        try await Repository(package: pkg,
+                             defaultBranch: "main",
+                             forks: 42,
+                             license: .mit,
+                             name: "bar",
+                             owner: "foo",
+                             stars: 17,
+                             summary: "summary").save(on: app.db)
         let version = try App.Version(package: pkg,
                                       latest: .defaultBranch,
                                       packageName: "test package",
                                       reference: .branch("main"))
-        try version.save(on: app.db).wait()
+        try await version.save(on: app.db)
 
         // MUT
-        let res = try PackageResult.query(on: app.db, owner: "foo", repository: "bar").wait()
+        let res = try await PackageResult.query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
         XCTAssertEqual(res.package.id, pkg.id)
         XCTAssertEqual(res.repository.name, "bar")
     }
 
-    func test_query_owner_repository_case_insensitivity() throws {
+    func test_query_owner_repository_case_insensitivity() async throws {
         // setup
         let pkg = try savePackage(on: app.db, "1".url)
-        try Repository(package: pkg,
-                       defaultBranch: "main",
-                       forks: 42,
-                       license: .mit,
-                       name: "bar",
-                       owner: "foo",
-                       stars: 17,
-                       summary: "summary").save(on: app.db).wait()
+        try await Repository(package: pkg,
+                             defaultBranch: "main",
+                             forks: 42,
+                             license: .mit,
+                             name: "bar",
+                             owner: "foo",
+                             stars: 17,
+                             summary: "summary").save(on: app.db)
         let version = try App.Version(package: pkg,
                                       latest: .defaultBranch,
                                       packageName: "test package",
                                       reference: .branch("main"))
-        try version.save(on: app.db).wait()
+        try await version.save(on: app.db)
 
         // MUT
-        let res = try PackageResult.query(on: app.db, owner: "Foo", repository: "bar").wait()
+        let res = try await PackageResult.query(on: app.db, owner: "Foo", repository: "bar")
 
         // validate
         XCTAssertEqual(res.package.id, pkg.id)
     }
 
-    func test_activity() throws {
+    func test_activity() async throws {
         // setup
         let m: TimeInterval = 60
         let H = 60*m
         let d = 24*H
         let pkg = try savePackage(on: app.db, "https://github.com/Alamofire/Alamofire")
-        try Repository(package: pkg,
-                       lastIssueClosedAt: Date(timeIntervalSinceNow: -5*d),
-                       lastPullRequestClosedAt: Date(timeIntervalSinceNow: -6*d),
-                       name: "bar",
-                       openIssues: 27,
-                       openPullRequests: 1,
-                       owner: "foo").create(on: app.db).wait()
-        try Version(package: pkg, latest: .defaultBranch).save(on: app.db).wait()
-        let pr = try PackageResult.query(on: app.db, owner: "foo", repository: "bar")
-            .wait()
-
+        try await Repository(package: pkg,
+                             lastIssueClosedAt: Date(timeIntervalSinceNow: -5*d),
+                             lastPullRequestClosedAt: Date(timeIntervalSinceNow: -6*d),
+                             name: "bar",
+                             openIssues: 27,
+                             openPullRequests: 1,
+                             owner: "foo").create(on: app.db)
+        try await Version(package: pkg, latest: .defaultBranch).save(on: app.db)
+        let pr = try await PackageResult.query(on: app.db, owner: "foo", repository: "bar")
+        
+        
         // MUT
         let res = pr.activity()
-
+        
         // validate
         XCTAssertEqual(res,
                        .init(openIssuesCount: 27,

--- a/Tests/AppTests/PackageShowModelTests.swift
+++ b/Tests/AppTests/PackageShowModelTests.swift
@@ -21,17 +21,17 @@ import SnapshotTesting
 class PackageShowModelTests: SnapshotTestCase {
     typealias PackageResult = PackageController.PackageResult
 
-    func test_init_no_packageName() throws {
+    func test_init_no_packageName() async throws {
         // Tests behaviour when we're lacking data
         // setup package without package name
         let pkg = try savePackage(on: app.db, "1".url)
-        try Repository(package: pkg, name: "bar", owner: "foo").save(on: app.db).wait()
+        try await Repository(package: pkg, name: "bar", owner: "foo").save(on: app.db)
         let version = try App.Version(package: pkg,
                                       latest: .defaultBranch,
                                       packageName: nil,
                                       reference: .branch("main"))
-        try version.save(on: app.db).wait()
-        let pr = try PackageResult.query(on: app.db, owner: "foo", repository: "bar").wait()
+        try await version.save(on: app.db)
+        let pr = try await PackageResult.query(on: app.db, owner: "foo", repository: "bar")
 
         // MUT
         let m = PackageShow.Model(result: pr,
@@ -267,14 +267,14 @@ class PackageShowModelTests: SnapshotTestCase {
         }
     }
 
-    func test_languagePlatformInfo() throws {
+    func test_languagePlatformInfo() async throws {
         // setup
         let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg,
-                       defaultBranch: "default",
-                       name: "bar",
-                       owner: "foo").save(on: app.db).wait()
-        try [
+        try await Repository(package: pkg,
+                             defaultBranch: "default",
+                             name: "bar",
+                             owner: "foo").save(on: app.db)
+        try await [
             try App.Version(package: pkg, reference: .branch("branch")),
             try App.Version(package: pkg,
                             commitDate: daysAgo(1),
@@ -295,10 +295,10 @@ class PackageShowModelTests: SnapshotTestCase {
                             reference: .tag(.init(3, 0, 0, "beta")),
                             supportedPlatforms: [.macos("10.14"), .ios("13")],
                             swiftVersions: ["5", "5.2"].asSwiftVersions),
-        ].save(on: app.db).wait()
-        let pr = try PackageResult.query(on: app.db,
-                                         owner: "foo",
-                                         repository: "bar").wait()
+        ].save(on: app.db)
+        let pr = try await PackageResult.query(on: app.db,
+                                               owner: "foo",
+                                               repository: "bar")
 
         // MUT
         let lpInfo = PackageShow.Model

--- a/Tests/AppTests/PackageShowTests.swift
+++ b/Tests/AppTests/PackageShowTests.swift
@@ -21,15 +21,15 @@ class PackageShowTests: AppTestCase {
 
     typealias PackageResult = PackageController.PackageResult
 
-    func test_releaseInfo() throws {
+    func test_releaseInfo() async throws {
         // setup
         Current.date = { .t0 }
         let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg,
-                       defaultBranch: "default",
-                       name: "bar",
-                       owner: "foo").save(on: app.db).wait()
-        try [
+        try await Repository(package: pkg,
+                             defaultBranch: "default",
+                             name: "bar",
+                             owner: "foo").save(on: app.db)
+        try await [
             try Version(package: pkg,
                         latest: nil,
                         reference: .branch("branch")),
@@ -48,10 +48,10 @@ class PackageShowTests: AppTestCase {
                         commitDate: daysAgo(2),
                         latest: .preRelease,
                         reference: .tag(.init(3, 0, 0, "beta"))),
-        ].save(on: app.db).wait()
-        let pr = try PackageResult.query(on: app.db,
-                                         owner: "foo",
-                                         repository: "bar").wait()
+        ].save(on: app.db)
+        let pr = try await PackageResult.query(on: app.db,
+                                               owner: "foo",
+                                               repository: "bar")
 
         // MUT
         let info = PackageShow.releaseInfo(
@@ -67,16 +67,16 @@ class PackageShowTests: AppTestCase {
         XCTAssertEqual(info.latest?.date, "1 day ago")
     }
 
-    func test_releaseInfo_exclude_non_latest() throws {
+    func test_releaseInfo_exclude_non_latest() async throws {
         // Test to ensure that we don't include versions with `latest IS NULL`
         // setup
         Current.date = { .t0 }
         let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg,
-                       defaultBranch: "default",
-                       name: "bar",
-                       owner: "foo").save(on: app.db).wait()
-        try [
+        try await Repository(package: pkg,
+                             defaultBranch: "default",
+                             name: "bar",
+                             owner: "foo").save(on: app.db)
+        try await [
             try Version(package: pkg,
                         commitDate: daysAgo(1),
                         latest: .defaultBranch,
@@ -89,10 +89,10 @@ class PackageShowTests: AppTestCase {
                         commitDate: daysAgo(2),
                         latest: nil,
                         reference: .tag(.init(2, 0, 0, "beta"))),
-        ].save(on: app.db).wait()
-        let pr = try PackageResult.query(on: app.db,
-                                         owner: "foo",
-                                         repository: "bar").wait()
+        ].save(on: app.db)
+        let pr = try await PackageResult.query(on: app.db,
+                                               owner: "foo",
+                                               repository: "bar")
 
         // MUT
         let info = PackageShow.releaseInfo(


### PR DESCRIPTION
Fixes #1630 

All tests pass reliably locally without `usleep`.