### PR TITLE
Add Homepage URL to Package Page

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -221,6 +221,7 @@ func insertOrUpdateRepository(on database: Database,
         .first() ?? Repository(packageId: pkgId)
     repo.defaultBranch = repository.defaultBranch
     repo.forks = repository.forkCount
+    repo.homepageUrl = repository.homepageUrl
     repo.isArchived = repository.isArchived
     repo.isInOrganization = repository.isInOrganization
     repo.keywords = Set(repository.topics.map { $0.lowercased() }).sorted()

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -232,8 +232,10 @@ extension Github {
                     }
                     description
                     forkCount
+                    homepageUrl
                     isArchived
                     isFork
+                    isInOrganization
                     licenseInfo {
                       name
                       key
@@ -280,7 +282,6 @@ extension Github {
                       }
                     }
                     stargazerCount
-                    isInOrganization
                   }
                 }
                 """)
@@ -293,8 +294,10 @@ extension Github {
             var defaultBranchRef: DefaultBranchRef?
             var description: String?
             var forkCount: Int
+            var homepageUrl: String?
             var isArchived: Bool
             var isFork: Bool
+            var isInOrganization: Bool
             var licenseInfo: LicenseInfo?
             var mergedPullRequests: IssueNodes
             var name: String
@@ -304,7 +307,6 @@ extension Github {
             var releases: ReleaseNodes
             var repositoryTopics: RepositoryTopicNodes
             var stargazerCount: Int
-            var isInOrganization: Bool
             // derived properties
             var defaultBranch: String? { defaultBranchRef?.name }
             var lastIssueClosedAt: Date? {

--- a/Sources/App/Migrations/048/UpdateRepositoryAddHomepageUrl.swift
+++ b/Sources/App/Migrations/048/UpdateRepositoryAddHomepageUrl.swift
@@ -1,0 +1,29 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+
+struct UpdateRepositoryAddHomepageUrl: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("repositories")
+            .field("homepage_url", .string)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("repositories")
+            .deleteField("homepage_url")
+            .update()
+    }
+}

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -56,6 +56,9 @@ final class Repository: Model, Content {
     
     @Field(key: "forks")
     var forks: Int
+    
+    @Field(key: "homepage_url")
+    var homepageUrl: String?
 
     @Field(key: "is_archived")
     var isArchived: Bool
@@ -129,6 +132,7 @@ final class Repository: Model, Content {
          firstCommitDate: Date? = nil,
          forks: Int = 0,
          forkedFrom: Repository? = nil,
+         homepageUrl: String? = nil,
          isArchived: Bool = false,
          isInOrganization: Bool = false,
          keywords: [String] = [],
@@ -159,6 +163,7 @@ final class Repository: Model, Content {
         if let forkId = forkedFrom?.id {
             self.$forkedFrom.id = forkId
         }
+        self.homepageUrl = homepageUrl
         self.isArchived = isArchived
         self.isInOrganization = isInOrganization
         self.keywords = keywords

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -43,6 +43,7 @@ extension PackageShow {
         var url: String
         var score: Int?
         var isArchived: Bool
+        var homepageUrl: String?
         
         internal init(packageId: Package.Id,
                       repositoryOwner: String,
@@ -65,7 +66,8 @@ extension PackageShow {
                       title: String,
                       url: String,
                       score: Int? = nil,
-                      isArchived: Bool) {
+                      isArchived: Bool,
+                      homepageUrl: String? = nil) {
             self.packageId = packageId
             self.repositoryOwner = repositoryOwner
             self.repositoryOwnerName = repositoryOwnerName
@@ -88,6 +90,7 @@ extension PackageShow {
             self.url = url
             self.score = score
             self.isArchived = isArchived
+            self.homepageUrl = homepageUrl
         }
         
         init?(result: PackageController.PackageResult,
@@ -134,7 +137,8 @@ extension PackageShow {
                 title: result.defaultBranchVersion.packageName ?? repositoryName,
                 url: result.package.url,
                 score: result.package.score,
-                isArchived: repository.isArchived
+                isArchived: repository.isArchived,
+                homepageUrl: repository.homepageUrl
             )
 
         }

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -239,7 +239,7 @@ enum PackageShow {
                         .li(
                             .a(
                                 .href(homepageUrl),
-                                "View Homepage"
+                                "Package Homepage"
                             )
                         )
                     }

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -234,7 +234,15 @@ enum PackageShow {
                                 .text(" and try again.")
                             )
                         )
-                    )
+                    ),
+                    .unwrap(model.homepageUrl) { homepageUrl in
+                        .li(
+                            .a(
+                                .href(homepageUrl),
+                                "View Homepage"
+                            )
+                        )
+                    }
                 )
             )
         }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -232,6 +232,9 @@ public func configure(_ app: Application) throws -> String {
     do {  // Migration 047 - Remove `version_count` from `stats` materialized view.
         app.migrations.add(RemoveVersionCountFromStats())
     }
+    do {  // Migration 048 - add repositories.homepage_url
+        app.migrations.add(UpdateRepositoryAddHomepageUrl())
+    }
 
     app.commands.use(AnalyzeCommand(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/Fixtures/github-graphql-resource.json
+++ b/Tests/AppTests/Fixtures/github-graphql-resource.json
@@ -1173,7 +1173,8 @@
         ]
       },
       "stargazerCount": 35831,
-      "isInOrganization": true
+      "isInOrganization": true,
+      "homepageUrl": "https://swiftpackageindex.com/Alamofire/Alamofire"
     }
   }
 }

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -120,6 +120,7 @@ class GithubTests: AppTestCase {
                        "networking")
         XCTAssertEqual(res.repository?.stargazerCount, 35831)
         XCTAssertEqual(res.repository?.isInOrganization, true)
+        XCTAssertEqual(res.repository?.homepageUrl, "https://swiftpackageindex.com/Alamofire/Alamofire")
         // derived properties
         XCTAssertEqual(res.repository?.lastIssueClosedAt,
                        iso8601.date(from: "2021-06-09T00:59:39Z"))

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -148,6 +148,8 @@ class IngestorTests: AppTestCase {
                         .success((jpr,
                                   .init(defaultBranch: "main",
                                         forks: 1,
+                                        homepageUrl: "https://swiftpackageindex.com/Alamofire/Alamofire",
+                                        isInOrganization: true,
                                         issuesClosedAtDates: [
                                             Date(timeIntervalSince1970: 0),
                                             Date(timeIntervalSince1970: 2),
@@ -173,8 +175,7 @@ class IngestorTests: AppTestCase {
                                         repositoryTopics: ["foo", "bar", "Bar", "baz"],
                                         name: "bar",
                                         stars: 2,
-                                        summary: "package desc",
-                                        isInOrganization: true),
+                                        summary: "package desc"),
                                   licenseInfo: .init(htmlUrl: "license url"),
                                   readmeInfo: .init(downloadUrl: "readme url", htmlUrl: "readme html url")))
                        ]
@@ -190,6 +191,7 @@ class IngestorTests: AppTestCase {
             .unwrap()
         XCTAssertEqual(repo.defaultBranch, "main")
         XCTAssertEqual(repo.forks, 1)
+        XCTAssertEqual(repo.homepageUrl, "https://swiftpackageindex.com/Alamofire/Alamofire")
         XCTAssertEqual(repo.isInOrganization, true)
         XCTAssertEqual(repo.keywords, ["bar", "baz", "foo"])
         XCTAssertEqual(repo.lastIssueClosedAt, Date(timeIntervalSince1970: 2))
@@ -342,6 +344,8 @@ class IngestorTests: AppTestCase {
             Github.Metadata.init(
                 defaultBranch: "main",
                 forks: 0,
+                homepageUrl: nil,
+                isInOrganization: false,
                 issuesClosedAtDates: [],
                 license: .mit,
                 openIssues: 0,
@@ -350,8 +354,7 @@ class IngestorTests: AppTestCase {
                 pullRequestsClosedAtDates: [],
                 name: "name",
                 stars: 0,
-                summary: "desc",
-                isInOrganization: false)
+                summary: "desc")
         }
         var reportedLevel: AppError.Level? = nil
         var reportedError: String? = nil

--- a/Tests/AppTests/Mocks/GithubMetadata+mock.swift
+++ b/Tests/AppTests/Mocks/GithubMetadata+mock.swift
@@ -20,6 +20,8 @@ import Foundation
 extension Github.Metadata {
     static let mock: Self = .init(defaultBranch: "main",
                                   forks: 1,
+                                  homepageUrl: nil,
+                                  isInOrganization: false,
                                   issuesClosedAtDates: [],
                                   license: .mit,
                                   openIssues: 3,
@@ -30,13 +32,14 @@ extension Github.Metadata {
                                   repositoryTopics: [],
                                   name: "packageName",
                                   stars: 2,
-                                  summary: "desc",
-                                  isInOrganization: false)
+                                  summary: "desc")
 
     static func mock(for packageUrl: String) -> Self {
         let (owner, name) = try! Github.parseOwnerName(url: packageUrl)
         return .init(defaultBranch: "main",
                      forks: packageUrl.count,
+                     homepageUrl: nil,
+                     isInOrganization: false,
                      issuesClosedAtDates: [],
                      license: .mit,
                      openIssues: 3,
@@ -47,12 +50,13 @@ extension Github.Metadata {
                      repositoryTopics: [],
                      name: name,
                      stars: packageUrl.count + 1,
-                     summary: "This is package " + packageUrl,
-                     isInOrganization: false)
+                     summary: "This is package " + packageUrl)
     }
 
     init(defaultBranch: String,
          forks: Int,
+         homepageUrl: String?,
+         isInOrganization: Bool,
          issuesClosedAtDates: [Date],
          license: License,
          openIssues: Int,
@@ -63,8 +67,7 @@ extension Github.Metadata {
          repositoryTopics: [String] = [],
          name: String,
          stars: Int,
-         summary: String,
-         isInOrganization: Bool
+         summary: String
     ) {
         let topics = repositoryTopics
             .map {
@@ -78,8 +81,10 @@ extension Github.Metadata {
                               defaultBranchRef: .init(name: defaultBranch),
                               description: summary,
                               forkCount: forks,
+                              homepageUrl: homepageUrl,
                               isArchived: false,
                               isFork: false,
+                              isInOrganization: isInOrganization,
                               licenseInfo: .init(name: license.fullName, key: license.rawValue),
                               mergedPullRequests: .init(closedAtDates: []),
                               name: name,
@@ -89,8 +94,7 @@ extension Github.Metadata {
                               releases: .init(nodes: releases),
                               repositoryTopics: .init(totalCount: topics.count,
                                                       nodes: topics),
-                              stargazerCount: stars,
-                              isInOrganization: isInOrganization)
+                              stargazerCount: stars)
         )
     }
 }

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -29,7 +29,9 @@ class WebpageSnapshotTests: SnapshotTestCase {
     }
     
     func test_PackageShowView() throws {
-        let page = { PackageShow.View(path: "", model: .mock, packageSchema: .mock).document() }
+        var model = PackageShow.Model.mock
+        model.homepageUrl = "https://swiftpackageindex.com/"
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
         
         assertSnapshot(matching: page, as: .html)
     }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -280,7 +280,7 @@
                   </div>
                 </li>
                 <li>
-                  <a href="https://swiftpackageindex.com/">View Homepage</a>
+                  <a href="https://swiftpackageindex.com/">Package Homepage</a>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -279,6 +279,9 @@
                     </p>
                   </div>
                 </li>
+                <li>
+                  <a href="https://swiftpackageindex.com/">View Homepage</a>
+                </li>
               </ul>
             </section>
             <hr class="minor"/>


### PR DESCRIPTION
Closes #1690 

Added repository homepage URL to sidebar. @daveverwer to relocate.

Example: https://swiftpackageindex.com/tuist/tuist

⚠️  Schema change.
⚠️  Requires re-ingest of repository metadata.
