### PR TITLE
Add `Analyze` namespace around analysis functions

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -18,56 +18,60 @@ import Vapor
 import ShellOut
 
 
-struct AnalyzeCommand: Command {
-    let defaultLimit = 1
-    
-    struct Signature: CommandSignature {
-        @Option(name: "limit", short: "l")
-        var limit: Int?
-        @Option(name: "id")
-        var id: UUID?
-    }
-    
-    var help: String { "Run package analysis (fetching git repository and inspecting content)" }
+enum Analyze {
 
-    enum Mode {
-        case id(Package.Id)
-        case limit(Int)
-    }
+    struct Command: Vapor.Command {
+        let defaultLimit = 1
 
-    func run(using context: CommandContext, signature: Signature) throws {
-        let limit = signature.limit ?? defaultLimit
+        struct Signature: CommandSignature {
+            @Option(name: "limit", short: "l")
+            var limit: Int?
+            @Option(name: "id")
+            var id: UUID?
+        }
 
-        let client = context.application.client
-        let db = context.application.db
-        let logger = Logger(component: "analyze")
-        let threadPool = context.application.threadPool
+        var help: String { "Run package analysis (fetching git repository and inspecting content)" }
 
-        Self.resetMetrics()
+        enum Mode {
+            case id(Package.Id)
+            case limit(Int)
+        }
 
-        let mode = signature.id.map(Mode.id) ?? .limit(limit)
-        try analyze(client: client,
-                    database: db,
-                    logger: logger,
-                    threadPool: threadPool,
-                    mode: mode)
+        func run(using context: CommandContext, signature: Signature) throws {
+            let limit = signature.limit ?? defaultLimit
+
+            let client = context.application.client
+            let db = context.application.db
+            let logger = Logger(component: "analyze")
+            let threadPool = context.application.threadPool
+
+            Analyze.resetMetrics()
+
+            let mode = signature.id.map(Mode.id) ?? .limit(limit)
+            try analyze(client: client,
+                        database: db,
+                        logger: logger,
+                        threadPool: threadPool,
+                        mode: mode)
             .wait()
 
-        try Self.trimCheckouts()
+            try Analyze.trimCheckouts()
 
-        do {
-            try AppMetrics.push(client: client,
-                                logger: logger,
-                                jobName: "analyze")
+            do {
+                try AppMetrics.push(client: client,
+                                    logger: logger,
+                                    jobName: "analyze")
                 .wait()
-        } catch {
-            logger.warning("\(error.localizedDescription)")
+            } catch {
+                logger.warning("\(error.localizedDescription)")
+            }
         }
     }
+
 }
 
+extension Analyze {
 
-extension AnalyzeCommand {
     static func resetMetrics() {
         AppMetrics.analyzeTrimCheckoutsCount?.set(0)
         AppMetrics.analyzeUpdateRepositorySuccessCount?.set(0)
@@ -77,6 +81,7 @@ extension AnalyzeCommand {
         AppMetrics.analyzeVersionsDeletedCount?.set(0)
     }
 
+    
     static func trimCheckouts() throws {
         let checkoutDir = URL(
             fileURLWithPath: Current.fileManager.checkoutsDirectory(),
@@ -86,7 +91,7 @@ extension AnalyzeCommand {
             .map { dir -> (String, Date)? in
                 let url = checkoutDir.appendingPathComponent(dir)
                 guard let mod = try Current.fileManager
-                        .attributesOfItem(atPath: url.path)[.modificationDate] as? Date
+                    .attributesOfItem(atPath: url.path)[.modificationDate] as? Date
                 else { return nil }
                 return (url.path, mod)
             }
@@ -100,99 +105,98 @@ extension AnalyzeCommand {
                 }
             }
     }
-}
 
 
-/// Analyze via a given mode: either one `Package` identified by its `Id` or a limited number of `Package`s.
-/// - Parameters:
-///   - client: `Client` object
-///   - database: `Database` object
-///   - logger: `Logger` object
-///   - threadPool: `NIOThreadPool` (for running shell commands)
-///   - mode: process a single `Package.Id` or a `limit` number of packages
-/// - Returns: future
-func analyze(client: Client,
-             database: Database,
-             logger: Logger,
-             threadPool: NIOThreadPool,
-             mode: AnalyzeCommand.Mode) -> EventLoopFuture<Void> {
-    let start = DispatchTime.now().uptimeNanoseconds
-    switch mode {
-        case .id(let id):
-            logger.info("Analyzing (id: \(id)) ...")
-            return Package.fetchCandidate(database, id: id)
-                .map { [$0] }
-                .flatMap {
-                    analyze(client: client,
-                            database: database,
-                            logger: logger,
-                            threadPool: threadPool,
-                            packages: $0)
-                }
-                .map {
-                    AppMetrics.analyzeDurationSeconds?.time(since: start)
-                }
-        case .limit(let limit):
-            logger.info("Analyzing (limit: \(limit)) ...")
-            return Package.fetchCandidates(database, for: .analysis, limit: limit)
-                .flatMap { analyze(client: client,
-                                   database: database,
-                                   logger: logger,
-                                   threadPool: threadPool,
-                                   packages: $0)
-                }
-                .map {
-                    AppMetrics.analyzeDurationSeconds?.time(since: start)
-                }
-            
-    }
-}
+    /// Analyze via a given mode: either one `Package` identified by its `Id` or a limited number of `Package`s.
+    /// - Parameters:
+    ///   - client: `Client` object
+    ///   - database: `Database` object
+    ///   - logger: `Logger` object
+    ///   - threadPool: `NIOThreadPool` (for running shell commands)
+    ///   - mode: process a single `Package.Id` or a `limit` number of packages
+    /// - Returns: future
+    static func analyze(client: Client,
+                        database: Database,
+                        logger: Logger,
+                        threadPool: NIOThreadPool,
+                        mode: Analyze.Command.Mode) -> EventLoopFuture<Void> {
+        let start = DispatchTime.now().uptimeNanoseconds
+        switch mode {
+            case .id(let id):
+                logger.info("Analyzing (id: \(id)) ...")
+                return Package.fetchCandidate(database, id: id)
+                    .map { [$0] }
+                    .flatMap {
+                        analyze(client: client,
+                                database: database,
+                                logger: logger,
+                                threadPool: threadPool,
+                                packages: $0)
+                    }
+                    .map {
+                        AppMetrics.analyzeDurationSeconds?.time(since: start)
+                    }
+            case .limit(let limit):
+                logger.info("Analyzing (limit: \(limit)) ...")
+                return Package.fetchCandidates(database, for: .analysis, limit: limit)
+                    .flatMap { analyze(client: client,
+                                       database: database,
+                                       logger: logger,
+                                       threadPool: threadPool,
+                                       packages: $0)
+                    }
+                    .map {
+                        AppMetrics.analyzeDurationSeconds?.time(since: start)
+                    }
 
-
-/// Main analysis function. Updates repostory checkouts, runs package dump, reconciles versions and updates packages.
-/// - Parameters:
-///   - client: `Client` object
-///   - database: `Database` object
-///   - logger: `Logger` object
-///   - threadPool: `NIOThreadPool` (for running shell commands)
-///   - packages: packages to be analysed
-/// - Returns: future
-func analyze(client: Client,
-             database: Database,
-             logger: Logger,
-             threadPool: NIOThreadPool,
-             packages: [Joined<Package, Repository>]) -> EventLoopFuture<Void> {
-    AppMetrics.analyzeCandidatesCount?.set(packages.count)
-    // get or create directory
-    let checkoutDir = Current.fileManager.checkoutsDirectory()
-    logger.info("Checkout directory: \(checkoutDir)")
-    if !Current.fileManager.fileExists(atPath: checkoutDir) {
-        logger.info("Creating checkouts directory at path: \(checkoutDir)")
-        do {
-            try Current.fileManager.createDirectory(atPath: checkoutDir,
-                                                    withIntermediateDirectories: false,
-                                                    attributes: nil)
-        } catch {
-            let msg = "Failed to create checkouts directory: \(error.localizedDescription)"
-            return Current.reportError(client,
-                                       .critical,
-                                       AppError.genericError(nil, msg))
         }
     }
-    
-    let packages = refreshCheckouts(eventLoop: database.eventLoop,
-                                    logger: logger,
-                                    threadPool: threadPool,
-                                    packages: packages)
-        .flatMap { updateRepositories(on: database, packages: $0) }
-    
-    let packageResults = packages.flatMap { packages in
-        database.transaction { tx in
-            diffVersions(client: client,
-                         logger: logger,
-                         threadPool: threadPool,
-                         transaction: tx,
-                         packages: packages)
+
+
+    /// Main analysis function. Updates repostory checkouts, runs package dump, reconciles versions and updates packages.
+    /// - Parameters:
+    ///   - client: `Client` object
+    ///   - database: `Database` object
+    ///   - logger: `Logger` object
+    ///   - threadPool: `NIOThreadPool` (for running shell commands)
+    ///   - packages: packages to be analysed
+    /// - Returns: future
+    static func analyze(client: Client,
+                        database: Database,
+                        logger: Logger,
+                        threadPool: NIOThreadPool,
+                        packages: [Joined<Package, Repository>]) -> EventLoopFuture<Void> {
+        AppMetrics.analyzeCandidatesCount?.set(packages.count)
+        // get or create directory
+        let checkoutDir = Current.fileManager.checkoutsDirectory()
+        logger.info("Checkout directory: \(checkoutDir)")
+        if !Current.fileManager.fileExists(atPath: checkoutDir) {
+            logger.info("Creating checkouts directory at path: \(checkoutDir)")
+            do {
+                try Current.fileManager.createDirectory(atPath: checkoutDir,
+                                                        withIntermediateDirectories: false,
+                                                        attributes: nil)
+            } catch {
+                let msg = "Failed to create checkouts directory: \(error.localizedDescription)"
+                return Current.reportError(client,
+                                           .critical,
+                                           AppError.genericError(nil, msg))
+            }
+        }
+
+        let packages = refreshCheckouts(eventLoop: database.eventLoop,
+                                        logger: logger,
+                                        threadPool: threadPool,
+                                        packages: packages)
+            .flatMap { updateRepositories(on: database, packages: $0) }
+
+        let packageResults = packages.flatMap { packages in
+            database.transaction { tx in
+                diffVersions(client: client,
+                             logger: logger,
+                             threadPool: threadPool,
+                             transaction: tx,
+                             packages: packages)
                 .flatMap { mergeReleaseInfo(on: tx, packageDeltas: $0) }
                 .flatMap { applyVersionDelta(on: tx, packageDeltas: $0) }
                 .map { getPackageInfo(packageAndVersions: $0) }
@@ -204,482 +208,482 @@ func analyze(client: Client,
                                          logger: logger,
                                          transaction: tx,
                                          packageResults: $0)}
-        }
-    }
-    
-    let statusOps = packageResults
-        .map(\.packages)
-        .flatMap { updatePackages(client: client,
-                                  database: database,
-                                  logger: logger,
-                                  results: $0,
-                                  stage: .analysis) }
-    
-    let materializedViewRefresh = statusOps
-        .flatMap { RecentPackage.refresh(on: database) }
-        .flatMap { RecentRelease.refresh(on: database) }
-        .flatMap { Search.refresh(on: database) }
-        .flatMap { Stats.refresh(on: database) }
-    
-    return materializedViewRefresh
-}
-
-
-/// Refresh git checkouts (working copies) for a list of packages.
-/// - Parameters:
-///   - eventLoop: `EventLoop` object
-///   - logger: `Logger` object
-///   - threadPool: `NIOThreadPool` (for running shell commands)
-///   - packages: list of `Packages`
-/// - Returns: future with `Result`s
-func refreshCheckouts(eventLoop: EventLoop,
-                      logger: Logger,
-                      threadPool: NIOThreadPool,
-                      packages: [Joined<Package, Repository>]) -> EventLoopFuture<[Result<Joined<Package, Repository>, Error>]> {
-    let ops = packages.map { refreshCheckout(eventLoop: eventLoop,
-                                             logger: logger,
-                                             threadPool: threadPool,
-                                             package: $0) }
-    return EventLoopFuture.whenAllComplete(ops, on: eventLoop)
-}
-
-
-/// Run `git clone` for a given url in a given directory.
-/// - Parameters:
-///   - logger: `Logger` object
-///   - cacheDir: checkout directory
-///   - url: url to clone from
-/// - Throws: Shell errors
-func clone(logger: Logger, cacheDir: String, url: String) throws {
-    logger.info("cloning \(url) to \(cacheDir)")
-    try Current.shell.run(command: .gitClone(url: URL(string: url)!, to: cacheDir),
-                          at: Current.fileManager.checkoutsDirectory())
-}
-
-
-/// Run `git fetch` and a set of supporting git commands (in order to allow the fetch to succeed more reliably).
-/// - Parameters:
-///   - logger: `Logger` object
-///   - cacheDir: checkout directory
-///   - branch: branch to check out
-///   - url: url to fetch from
-/// - Throws: Shell errors
-func fetch(logger: Logger, cacheDir: String, branch: String, url: String) throws {
-    logger.info("pulling \(url) in \(cacheDir)")
-    // clean up stray lock files that might have remained from aborted commands
-    try ["HEAD.lock", "index.lock"].forEach { fileName in
-        let filePath = cacheDir + "/.git/\(fileName)"
-        if Current.fileManager.fileExists(atPath: filePath) {
-            logger.info("Removing stale \(fileName) at path: \(filePath)")
-            try Current.shell.run(command: .removeFile(from: filePath))
-        }
-    }
-    // git reset --hard to deal with stray .DS_Store files on macOS
-    try Current.shell.run(command: .gitReset(hard: true), at: cacheDir)
-    try Current.shell.run(command: .gitClean, at: cacheDir)
-    try Current.shell.run(command: .gitFetch, at: cacheDir)
-    try Current.shell.run(command: .gitCheckout(branch: branch), at: cacheDir)
-    try Current.shell.run(command: .gitReset(to: branch, hard: true),
-                          at: cacheDir)
-}
-
-
-/// Refresh git checkout (working copy) for a given package.
-/// - Parameters:
-///   - eventLoop: `EventLoop` object
-///   - logger: `Logger` object
-///   - threadPool: `NIOThreadPool` (for running shell commands)
-///   - package: `Package` to refresh
-/// - Returns: future
-func refreshCheckout(eventLoop: EventLoop,
-                     logger: Logger,
-                     threadPool: NIOThreadPool,
-                     package: Joined<Package, Repository>) -> EventLoopFuture<Joined<Package, Repository>> {
-    guard let cacheDir = Current.fileManager.cacheDirectoryPath(for: package.model) else {
-        return eventLoop.future(
-            error: AppError.invalidPackageCachePath(package.model.id,
-                                                    package.model.url)
-        )
-    }
-    return threadPool.runIfActive(eventLoop: eventLoop) {
-        do {
-            guard Current.fileManager.fileExists(atPath: cacheDir) else {
-                try clone(logger: logger, cacheDir: cacheDir, url: package.model.url)
-                return
             }
+        }
 
-            // attempt to fetch - if anything goes wrong we delete the directory
-            // and fall back to cloning
+        let statusOps = packageResults
+            .map(\.packages)
+            .flatMap { updatePackages(client: client,
+                                      database: database,
+                                      logger: logger,
+                                      results: $0,
+                                      stage: .analysis) }
+
+        let materializedViewRefresh = statusOps
+            .flatMap { RecentPackage.refresh(on: database) }
+            .flatMap { RecentRelease.refresh(on: database) }
+            .flatMap { Search.refresh(on: database) }
+            .flatMap { Stats.refresh(on: database) }
+
+        return materializedViewRefresh
+    }
+
+
+    /// Refresh git checkouts (working copies) for a list of packages.
+    /// - Parameters:
+    ///   - eventLoop: `EventLoop` object
+    ///   - logger: `Logger` object
+    ///   - threadPool: `NIOThreadPool` (for running shell commands)
+    ///   - packages: list of `Packages`
+    /// - Returns: future with `Result`s
+    static func refreshCheckouts(eventLoop: EventLoop,
+                                 logger: Logger,
+                                 threadPool: NIOThreadPool,
+                                 packages: [Joined<Package, Repository>]) -> EventLoopFuture<[Result<Joined<Package, Repository>, Error>]> {
+        let ops = packages.map { refreshCheckout(eventLoop: eventLoop,
+                                                 logger: logger,
+                                                 threadPool: threadPool,
+                                                 package: $0) }
+        return EventLoopFuture.whenAllComplete(ops, on: eventLoop)
+    }
+
+
+    /// Run `git clone` for a given url in a given directory.
+    /// - Parameters:
+    ///   - logger: `Logger` object
+    ///   - cacheDir: checkout directory
+    ///   - url: url to clone from
+    /// - Throws: Shell errors
+    static func clone(logger: Logger, cacheDir: String, url: String) throws {
+        logger.info("cloning \(url) to \(cacheDir)")
+        try Current.shell.run(command: .gitClone(url: URL(string: url)!, to: cacheDir),
+                              at: Current.fileManager.checkoutsDirectory())
+    }
+
+
+    /// Run `git fetch` and a set of supporting git commands (in order to allow the fetch to succeed more reliably).
+    /// - Parameters:
+    ///   - logger: `Logger` object
+    ///   - cacheDir: checkout directory
+    ///   - branch: branch to check out
+    ///   - url: url to fetch from
+    /// - Throws: Shell errors
+    static func fetch(logger: Logger, cacheDir: String, branch: String, url: String) throws {
+        logger.info("pulling \(url) in \(cacheDir)")
+        // clean up stray lock files that might have remained from aborted commands
+        try ["HEAD.lock", "index.lock"].forEach { fileName in
+            let filePath = cacheDir + "/.git/\(fileName)"
+            if Current.fileManager.fileExists(atPath: filePath) {
+                logger.info("Removing stale \(fileName) at path: \(filePath)")
+                try Current.shell.run(command: .removeFile(from: filePath))
+            }
+        }
+        // git reset --hard to deal with stray .DS_Store files on macOS
+        try Current.shell.run(command: .gitReset(hard: true), at: cacheDir)
+        try Current.shell.run(command: .gitClean, at: cacheDir)
+        try Current.shell.run(command: .gitFetch, at: cacheDir)
+        try Current.shell.run(command: .gitCheckout(branch: branch), at: cacheDir)
+        try Current.shell.run(command: .gitReset(to: branch, hard: true),
+                              at: cacheDir)
+    }
+
+
+    /// Refresh git checkout (working copy) for a given package.
+    /// - Parameters:
+    ///   - eventLoop: `EventLoop` object
+    ///   - logger: `Logger` object
+    ///   - threadPool: `NIOThreadPool` (for running shell commands)
+    ///   - package: `Package` to refresh
+    /// - Returns: future
+    static func refreshCheckout(eventLoop: EventLoop,
+                                logger: Logger,
+                                threadPool: NIOThreadPool,
+                                package: Joined<Package, Repository>) -> EventLoopFuture<Joined<Package, Repository>> {
+        guard let cacheDir = Current.fileManager.cacheDirectoryPath(for: package.model) else {
+            return eventLoop.future(
+                error: AppError.invalidPackageCachePath(package.model.id,
+                                                        package.model.url)
+            )
+        }
+        return threadPool.runIfActive(eventLoop: eventLoop) {
             do {
-                try fetch(logger: logger,
-                          cacheDir: cacheDir,
-                          branch: package.repository?.defaultBranch ?? "master",
-                          url: package.model.url)
+                guard Current.fileManager.fileExists(atPath: cacheDir) else {
+                    try clone(logger: logger, cacheDir: cacheDir, url: package.model.url)
+                    return
+                }
+
+                // attempt to fetch - if anything goes wrong we delete the directory
+                // and fall back to cloning
+                do {
+                    try fetch(logger: logger,
+                              cacheDir: cacheDir,
+                              branch: package.repository?.defaultBranch ?? "master",
+                              url: package.model.url)
+                } catch {
+                    logger.info("fetch failed: \(error.localizedDescription)")
+                    logger.info("removing directory")
+                    try Current.shell.run(command: .removeFile(from: cacheDir, arguments: ["-r", "-f"]))
+                    try clone(logger: logger, cacheDir: cacheDir, url: package.model.url)
+                }
             } catch {
-                logger.info("fetch failed: \(error.localizedDescription)")
-                logger.info("removing directory")
-                try Current.shell.run(command: .removeFile(from: cacheDir, arguments: ["-r", "-f"]))
-                try clone(logger: logger, cacheDir: cacheDir, url: package.model.url)
+                throw AppError.analysisError(package.model.id, "refreshCheckout failed: \(error.localizedDescription)")
             }
-        } catch {
-            throw AppError.analysisError(package.model.id, "refreshCheckout failed: \(error.localizedDescription)")
         }
+        .map { package }
     }
-    .map { package }
-}
 
 
-/// Update the `Repository`s of a given set of `Package`s with git repository data (commit count, first commit date, etc).
-/// - Parameters:
-///   - database: `Database` object
-///   - packages: `Package`s to update
-/// - Returns: results future
-func updateRepositories(on database: Database,
-                        packages: [Result<Joined<Package, Repository>, Error>]) -> EventLoopFuture<[Result<Joined<Package, Repository>, Error>]> {
-    let ops = packages.map { result -> EventLoopFuture<Joined<Package, Repository>> in
-        switch result {
-            case .success(let pkg):
-                AppMetrics.analyzeUpdateRepositorySuccessCount?.inc()
-                return updateRepository(on: database, package: pkg)
-                    .transform(to: pkg)
-            case .failure(let error):
-                AppMetrics.analyzeUpdateRepositoryFailureCount?.inc()
-                return database.eventLoop.future(error: error)
+    /// Update the `Repository`s of a given set of `Package`s with git repository data (commit count, first commit date, etc).
+    /// - Parameters:
+    ///   - database: `Database` object
+    ///   - packages: `Package`s to update
+    /// - Returns: results future
+    static func updateRepositories(on database: Database,
+                                   packages: [Result<Joined<Package, Repository>, Error>]) -> EventLoopFuture<[Result<Joined<Package, Repository>, Error>]> {
+        let ops = packages.map { result -> EventLoopFuture<Joined<Package, Repository>> in
+            switch result {
+                case .success(let pkg):
+                    AppMetrics.analyzeUpdateRepositorySuccessCount?.inc()
+                    return updateRepository(on: database, package: pkg)
+                        .transform(to: pkg)
+                case .failure(let error):
+                    AppMetrics.analyzeUpdateRepositoryFailureCount?.inc()
+                    return database.eventLoop.future(error: error)
+            }
         }
-    }
-    return EventLoopFuture.whenAllComplete(ops, on: database.eventLoop)
-}
-
-
-/// Update the `Repository` of a given `Package` with git repository data (commit count, first commit date, etc).
-/// - Parameters:
-///   - database: `Database` object
-///   - package: `Package` to update
-/// - Returns: result future
-func updateRepository(on database: Database, package: Joined<Package, Repository>) -> EventLoopFuture<Void> {
-    guard let repo = package.repository else {
-        return database.eventLoop.future(
-            error: AppError.genericError(package.model.id, "updateRepository: no repository")
-        )
-    }
-    guard let gitDirectory = Current.fileManager.cacheDirectoryPath(for: package.model) else {
-        return database.eventLoop.future(
-            error: AppError.invalidPackageCachePath(package.model.id,
-                                                    package.model.url)
-        )
+        return EventLoopFuture.whenAllComplete(ops, on: database.eventLoop)
     }
 
-    repo.commitCount = (try? Current.git.commitCount(gitDirectory)) ?? 0
-    repo.firstCommitDate = try? Current.git.firstCommitDate(gitDirectory)
-    repo.lastCommitDate = try? Current.git.lastCommitDate(gitDirectory)
 
-    return repo.update(on: database)
-}
+    /// Update the `Repository` of a given `Package` with git repository data (commit count, first commit date, etc).
+    /// - Parameters:
+    ///   - database: `Database` object
+    ///   - package: `Package` to update
+    /// - Returns: result future
+    static func updateRepository(on database: Database, package: Joined<Package, Repository>) -> EventLoopFuture<Void> {
+        guard let repo = package.repository else {
+            return database.eventLoop.future(
+                error: AppError.genericError(package.model.id, "updateRepository: no repository")
+            )
+        }
+        guard let gitDirectory = Current.fileManager.cacheDirectoryPath(for: package.model) else {
+            return database.eventLoop.future(
+                error: AppError.invalidPackageCachePath(package.model.id,
+                                                        package.model.url)
+            )
+        }
+
+        repo.commitCount = (try? Current.git.commitCount(gitDirectory)) ?? 0
+        repo.firstCommitDate = try? Current.git.firstCommitDate(gitDirectory)
+        repo.lastCommitDate = try? Current.git.lastCommitDate(gitDirectory)
+
+        return repo.update(on: database)
+    }
 
 
-/// Find new and outdated versions for a set of `Package`s, based on a comparison of their immutable references - the pair (`Reference`, `CommitHash`) of each version.
-/// - Parameters:
-///   - client: `Client` object (for Rollbar error reporting)
-///   - logger: `Logger` object
-///   - threadPool: `NIOThreadPool` (for running `git tag` commands)
-///   - transaction: database transaction
-///   - packages: `Package`s to reconcile
-/// - Returns: results future with each `Package` and its pair of new and outdated `Version`s
-func diffVersions(client: Client,
-                  logger: Logger,
-                  threadPool: NIOThreadPool,
-                  transaction: Database,
-                  packages: [Result<Joined<Package, Repository>, Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, VersionDelta), Error>]> {
-    packages.whenAllComplete(on: transaction.eventLoop) { pkg in
-        diffVersions(client: client,
-                     logger: logger,
-                     threadPool: threadPool,
-                     transaction: transaction,
-                     package: pkg)
+    /// Find new and outdated versions for a set of `Package`s, based on a comparison of their immutable references - the pair (`Reference`, `CommitHash`) of each version.
+    /// - Parameters:
+    ///   - client: `Client` object (for Rollbar error reporting)
+    ///   - logger: `Logger` object
+    ///   - threadPool: `NIOThreadPool` (for running `git tag` commands)
+    ///   - transaction: database transaction
+    ///   - packages: `Package`s to reconcile
+    /// - Returns: results future with each `Package` and its pair of new and outdated `Version`s
+    static func diffVersions(client: Client,
+                             logger: Logger,
+                             threadPool: NIOThreadPool,
+                             transaction: Database,
+                             packages: [Result<Joined<Package, Repository>, Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, VersionDelta), Error>]> {
+        packages.whenAllComplete(on: transaction.eventLoop) { pkg in
+            diffVersions(client: client,
+                         logger: logger,
+                         threadPool: threadPool,
+                         transaction: transaction,
+                         package: pkg)
             .map { (pkg, $0) }
-    }
-}
-
-
-/// Find new, outdated, and unchanged versions for a given `Package`, based on a comparison of their immutable references - the pair (`Reference`, `CommitHash`) of each version.
-/// - Parameters:
-///   - client: `Client` object (for Rollbar error reporting)
-///   - logger: `Logger` object
-///   - threadPool: `NIOThreadPool` (for running `git tag` commands)
-///   - transaction: database transaction
-///   - package: `Package` to reconcile
-/// - Returns: future with array of pair of new, outdated, and unchanged `Version`s
-func diffVersions(client: Client,
-                  logger: Logger,
-                  threadPool: NIOThreadPool,
-                  transaction: Database,
-                  package: Joined<Package, Repository>) -> EventLoopFuture<VersionDelta> {
-    guard let pkgId = package.model.id else {
-        return transaction.eventLoop.future(error: AppError.genericError(nil, "PANIC: package id nil for package \(package.model.url)"))
+        }
     }
 
-    let existing = Version.query(on: transaction)
-        .filter(\.$package.$id == pkgId)
-        .all()
-    let incoming = getIncomingVersions(client: client,
-                                       logger: logger,
-                                       threadPool: threadPool,
-                                       transaction: transaction,
-                                       package: package)
-    return existing.and(incoming)
-        .map { existing, incoming in
-            let throttled = throttle(
-                lastestExistingVersion: existing.latestBranchVersion,
-                incoming: incoming
-            )
-            let origDiff = Version.diff(local: existing, incoming: incoming)
-            let newDiff = Version.diff(local: existing, incoming: throttled)
-            let delta = origDiff.toAdd.count - newDiff.toAdd.count
-            if delta > 0 {
-                logger.info("throttled \(delta) incoming revisions")
-                AppMetrics.buildThrottleCount?.inc(delta)
+
+    /// Find new, outdated, and unchanged versions for a given `Package`, based on a comparison of their immutable references - the pair (`Reference`, `CommitHash`) of each version.
+    /// - Parameters:
+    ///   - client: `Client` object (for Rollbar error reporting)
+    ///   - logger: `Logger` object
+    ///   - threadPool: `NIOThreadPool` (for running `git tag` commands)
+    ///   - transaction: database transaction
+    ///   - package: `Package` to reconcile
+    /// - Returns: future with array of pair of new, outdated, and unchanged `Version`s
+    static func diffVersions(client: Client,
+                             logger: Logger,
+                             threadPool: NIOThreadPool,
+                             transaction: Database,
+                             package: Joined<Package, Repository>) -> EventLoopFuture<VersionDelta> {
+        guard let pkgId = package.model.id else {
+            return transaction.eventLoop.future(error: AppError.genericError(nil, "PANIC: package id nil for package \(package.model.url)"))
+        }
+
+        let existing = Version.query(on: transaction)
+            .filter(\.$package.$id == pkgId)
+            .all()
+        let incoming = getIncomingVersions(client: client,
+                                           logger: logger,
+                                           threadPool: threadPool,
+                                           transaction: transaction,
+                                           package: package)
+        return existing.and(incoming)
+            .map { existing, incoming in
+                let throttled = throttle(
+                    lastestExistingVersion: existing.latestBranchVersion,
+                    incoming: incoming
+                )
+                let origDiff = Version.diff(local: existing, incoming: incoming)
+                let newDiff = Version.diff(local: existing, incoming: throttled)
+                let delta = origDiff.toAdd.count - newDiff.toAdd.count
+                if delta > 0 {
+                    logger.info("throttled \(delta) incoming revisions")
+                    AppMetrics.buildThrottleCount?.inc(delta)
+                }
+                return newDiff
             }
-            return newDiff
-        }
-}
+    }
 
 
-/// Get incoming versions (from git repository)
-/// - Parameters:
-///   - client: `Client` object (for Rollbar error reporting)
-///   - logger: `Logger` object
-///   - threadPool: `NIOThreadPool` (for running `git tag` commands)
-///   - transaction: database transaction
-///   - package: `Package` to reconcile
-/// - Returns: future with incoming `Version`s
-func getIncomingVersions(client: Client,
-                         logger: Logger,
-                         threadPool: NIOThreadPool,
-                         transaction: Database,
-                         package: Joined<Package, Repository>) -> EventLoopFuture<[Version]> {
-    guard let cacheDir = Current.fileManager.cacheDirectoryPath(for: package.model) else {
-        return transaction.eventLoop.future(
-            error: AppError.invalidPackageCachePath(
-                package.model.id,
-                package.model.url
+    /// Get incoming versions (from git repository)
+    /// - Parameters:
+    ///   - client: `Client` object (for Rollbar error reporting)
+    ///   - logger: `Logger` object
+    ///   - threadPool: `NIOThreadPool` (for running `git tag` commands)
+    ///   - transaction: database transaction
+    ///   - package: `Package` to reconcile
+    /// - Returns: future with incoming `Version`s
+    static func getIncomingVersions(client: Client,
+                                    logger: Logger,
+                                    threadPool: NIOThreadPool,
+                                    transaction: Database,
+                                    package: Joined<Package, Repository>) -> EventLoopFuture<[Version]> {
+        guard let cacheDir = Current.fileManager.cacheDirectoryPath(for: package.model) else {
+            return transaction.eventLoop.future(
+                error: AppError.invalidPackageCachePath(
+                    package.model.id,
+                    package.model.url
+                )
             )
-        )
-    }
-    guard let pkgId = package.model.id else {
-        return transaction.eventLoop.future(error: AppError.genericError(nil, "PANIC: package id nil for package \(package.model.url)"))
-    }
-
-    let defaultBranch = package.repository?.defaultBranch
-        .map { Reference.branch($0) }
-
-    let tags: EventLoopFuture<[Reference]> = threadPool.runIfActive(eventLoop: transaction.eventLoop) {
-        logger.info("listing tags for package \(package.model.url)")
-        return try Current.git.getTags(cacheDir)
-    }
-    .flatMapError {
-        let appError = AppError.genericError(pkgId, "Git.tag failed: \($0.localizedDescription)")
-        logger.report(error: appError)
-        return Current.reportError(client, .error, appError)
-            .transform(to: [])
-    }
-
-    let references = tags.map { tags in [defaultBranch].compactMap { $0 } + tags }
-    return references
-        .flatMapEachThrowing { ref in
-            let revInfo = try Current.git.revisionInfo(ref, cacheDir)
-            let url = package.model.versionUrl(for: ref)
-            return try Version(package: package.model,
-                               commit: revInfo.commit,
-                               commitDate: revInfo.date,
-                               reference: ref,
-                               url: url)
         }
-}
+        guard let pkgId = package.model.id else {
+            return transaction.eventLoop.future(error: AppError.genericError(nil, "PANIC: package id nil for package \(package.model.url)"))
+        }
 
+        let defaultBranch = package.repository?.defaultBranch
+            .map { Reference.branch($0) }
 
-func throttle(lastestExistingVersion: Version?, incoming: [Version]) -> [Version] {
-    guard let existingVersion = lastestExistingVersion else {
-        // there's no existing branch version -> leave incoming alone (which will lead to addition)
-        return incoming
+        let tags: EventLoopFuture<[Reference]> = threadPool.runIfActive(eventLoop: transaction.eventLoop) {
+            logger.info("listing tags for package \(package.model.url)")
+            return try Current.git.getTags(cacheDir)
+        }
+            .flatMapError {
+                let appError = AppError.genericError(pkgId, "Git.tag failed: \($0.localizedDescription)")
+                logger.report(error: appError)
+                return Current.reportError(client, .error, appError)
+                    .transform(to: [])
+            }
+
+        let references = tags.map { tags in [defaultBranch].compactMap { $0 } + tags }
+        return references
+            .flatMapEachThrowing { ref in
+                let revInfo = try Current.git.revisionInfo(ref, cacheDir)
+                let url = package.model.versionUrl(for: ref)
+                return try Version(package: package.model,
+                                   commit: revInfo.commit,
+                                   commitDate: revInfo.date,
+                                   reference: ref,
+                                   url: url)
+            }
     }
 
-    guard let incomingVersion = incoming.latestBranchVersion else {
-        // there's no incoming branch version -> leave incoming alone (which will lead to removal)
-        return incoming
-    }
 
-    let ageOfExistingVersion = Current.date().timeIntervalSinceReferenceDate - existingVersion.commitDate.timeIntervalSinceReferenceDate
+    static func throttle(lastestExistingVersion: Version?, incoming: [Version]) -> [Version] {
+        guard let existingVersion = lastestExistingVersion else {
+            // there's no existing branch version -> leave incoming alone (which will lead to addition)
+            return incoming
+        }
 
-    // if existing version isn't older than our "window", keep it - otherwise
-    // use the latest incoming version
-    let resultingBranchVersion = ageOfExistingVersion < Constants.branchVersionRefreshDelay
+        guard let incomingVersion = incoming.latestBranchVersion else {
+            // there's no incoming branch version -> leave incoming alone (which will lead to removal)
+            return incoming
+        }
+
+        let ageOfExistingVersion = Current.date().timeIntervalSinceReferenceDate - existingVersion.commitDate.timeIntervalSinceReferenceDate
+
+        // if existing version isn't older than our "window", keep it - otherwise
+        // use the latest incoming version
+        let resultingBranchVersion = ageOfExistingVersion < Constants.branchVersionRefreshDelay
         ? existingVersion
         : incomingVersion
 
-    return incoming
-        .filter(!\.isBranch)        // remove all branch versions
+        return incoming
+            .filter(!\.isBranch)        // remove all branch versions
         + [resultingBranchVersion]  // add resulting version
-}
-
-
-/// Merge release details from `Repository.releases` into the list of added `Version`s in a package delta.
-/// - Parameters:
-///   - transaction: transaction to run the save and delete in
-///   - packageDeltas: tuples containing the `Package` and its new and outdated `Version`s
-/// - Returns: future with an array of each `Package` paired with its update package delta for further processing
-func mergeReleaseInfo(on transaction: Database,
-                      packageDeltas: [Result<(Joined<Package, Repository>, VersionDelta), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, VersionDelta), Error>]> {
-    packageDeltas.whenAllComplete(on: transaction.eventLoop) { pkg, delta in
-        mergeReleaseInfo(on: transaction, package: pkg, versions: delta.toAdd)
-            .map { (pkg, .init(toAdd: $0,
-                               toDelete: delta.toDelete,
-                               toKeep: delta.toKeep)) }
     }
-}
 
 
-/// Merge release details from `Repository.releases` into a given list of `Version`s.
-/// - Parameters:
-///   - transaction: transaction to run the save and delete in
-///   - package: `Package` the `Version`s belong to
-///   - versions: list of `Verion`s to update
-/// - Returns: update `Version`s
-func mergeReleaseInfo(on transaction: Database,
-                      package: Joined<Package, Repository>,
-                      versions: [Version]) -> EventLoopFuture<[Version]> {
-    guard let releases = package.repository?.releases else {
+    /// Merge release details from `Repository.releases` into the list of added `Version`s in a package delta.
+    /// - Parameters:
+    ///   - transaction: transaction to run the save and delete in
+    ///   - packageDeltas: tuples containing the `Package` and its new and outdated `Version`s
+    /// - Returns: future with an array of each `Package` paired with its update package delta for further processing
+    static func mergeReleaseInfo(on transaction: Database,
+                                 packageDeltas: [Result<(Joined<Package, Repository>, VersionDelta), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, VersionDelta), Error>]> {
+        packageDeltas.whenAllComplete(on: transaction.eventLoop) { pkg, delta in
+            mergeReleaseInfo(on: transaction, package: pkg, versions: delta.toAdd)
+                .map { (pkg, .init(toAdd: $0,
+                                   toDelete: delta.toDelete,
+                                   toKeep: delta.toKeep)) }
+        }
+    }
+
+
+    /// Merge release details from `Repository.releases` into a given list of `Version`s.
+    /// - Parameters:
+    ///   - transaction: transaction to run the save and delete in
+    ///   - package: `Package` the `Version`s belong to
+    ///   - versions: list of `Verion`s to update
+    /// - Returns: update `Version`s
+    static func mergeReleaseInfo(on transaction: Database,
+                                 package: Joined<Package, Repository>,
+                                 versions: [Version]) -> EventLoopFuture<[Version]> {
+        guard let releases = package.repository?.releases else {
+            return transaction.eventLoop.future(versions)
+        }
+        let tagToRelease = Dictionary(releases
+            .filter { !$0.isDraft }
+            .map { ($0.tagName, $0) },
+                                      uniquingKeysWith: { $1 })
+        versions.forEach { version in
+            guard let tagName = version.reference.tagName,
+                  let rel = tagToRelease[tagName] else {
+                return
+            }
+            version.publishedAt = rel.publishedAt
+            version.releaseNotes = rel.description
+            version.releaseNotesHTML = rel.descriptionHTML
+            version.url = rel.url
+        }
         return transaction.eventLoop.future(versions)
     }
-    let tagToRelease = Dictionary(releases
-                                    .filter { !$0.isDraft }
-                                    .map { ($0.tagName, $0) },
-                                  uniquingKeysWith: { $1 })
-    versions.forEach { version in
-        guard let tagName = version.reference.tagName,
-              let rel = tagToRelease[tagName] else {
-            return
+
+
+    /// Saves and deletes the versions specified in the version delta parameter.
+    /// - Parameters:
+    ///   - transaction: transaction to run the save and delete in
+    ///   - packageDeltas: tuples containing the `Package` and its new and outdated `Version`s
+    /// - Returns: future with an array of each `Package` paired with its new `Version`s
+    static func applyVersionDelta(on transaction: Database,
+                           packageDeltas: [Result<(Joined<Package, Repository>, VersionDelta), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [Version]), Error>]> {
+        packageDeltas.whenAllComplete(on: transaction.eventLoop) { pkg, delta in
+            applyVersionDelta(on: transaction, delta: delta)
+                .transform(to: (pkg, delta.toAdd))
         }
-        version.publishedAt = rel.publishedAt
-        version.releaseNotes = rel.description
-        version.releaseNotesHTML = rel.descriptionHTML
-        version.url = rel.url
     }
-    return transaction.eventLoop.future(versions)
-}
 
 
-/// Saves and deletes the versions specified in the version delta parameter.
-/// - Parameters:
-///   - transaction: transaction to run the save and delete in
-///   - packageDeltas: tuples containing the `Package` and its new and outdated `Version`s
-/// - Returns: future with an array of each `Package` paired with its new `Version`s
-func applyVersionDelta(on transaction: Database,
-                       packageDeltas: [Result<(Joined<Package, Repository>, VersionDelta), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [Version]), Error>]> {
-    packageDeltas.whenAllComplete(on: transaction.eventLoop) { pkg, delta in
-        applyVersionDelta(on: transaction, delta: delta)
-            .transform(to: (pkg, delta.toAdd))
+    /// Saves and deletes the versions specified in the version delta parameter.
+    /// - Parameters:
+    ///   - transaction: transaction to run the save and delete in
+    ///   - delta: tuple containing the versions to add and remove
+    /// - Returns: future
+    static func applyVersionDelta(on transaction: Database,
+                                  delta: VersionDelta) -> EventLoopFuture<Void> {
+        let delete = delta.toDelete.delete(on: transaction)
+        let insert = delta.toAdd.create(on: transaction)
+        delta.toAdd.forEach {
+            AppMetrics.analyzeVersionsAddedCount?.inc(1, .init($0.reference))
+        }
+        delta.toDelete.forEach {
+            AppMetrics.analyzeVersionsDeletedCount?.inc(1, .init($0.reference))
+        }
+        return delete.flatMap { insert }
     }
-}
 
 
-/// Saves and deletes the versions specified in the version delta parameter.
-/// - Parameters:
-///   - transaction: transaction to run the save and delete in
-///   - delta: tuple containing the versions to add and remove
-/// - Returns: future
-func applyVersionDelta(on transaction: Database,
-                       delta: VersionDelta) -> EventLoopFuture<Void> {
-    let delete = delta.toDelete.delete(on: transaction)
-    let insert = delta.toAdd.create(on: transaction)
-    delta.toAdd.forEach {
-        AppMetrics.analyzeVersionsAddedCount?.inc(1, .init($0.reference))
-    }
-    delta.toDelete.forEach {
-        AppMetrics.analyzeVersionsDeletedCount?.inc(1, .init($0.reference))
-    }
-    return delete.flatMap { insert }
-}
-
-
-/// Get package info (manifests, resolved dependencies) for an array of `Package`s.
-/// - Parameters:
-///   - logger: `Logger` object
-///   - packageAndVersions: `Result` containing the `Package` and the array of `Version`s to analyse
-/// - Returns: results future including the `Manifest`s
-func getPackageInfo(packageAndVersions: [Result<(Joined<Package, Repository>, [Version]), Error>]) -> [Result<(Joined<Package, Repository>, [(Version, Manifest, [ResolvedDependency]?)]), Error>] {
-    packageAndVersions.map { result in
-        result.flatMap { (pkg, versions) in
-            let m = versions.map { getPackageInfo(package: pkg, version: $0) }
-            let successes = m.compactMap { try? $0.get() }
-            if !versions.isEmpty && successes.isEmpty {
-                return .failure(AppError.noValidVersions(pkg.model.id, pkg.model.url))
+    /// Get package info (manifests, resolved dependencies) for an array of `Package`s.
+    /// - Parameters:
+    ///   - logger: `Logger` object
+    ///   - packageAndVersions: `Result` containing the `Package` and the array of `Version`s to analyse
+    /// - Returns: results future including the `Manifest`s
+    static func getPackageInfo(packageAndVersions: [Result<(Joined<Package, Repository>, [Version]), Error>]) -> [Result<(Joined<Package, Repository>, [(Version, Manifest, [ResolvedDependency]?)]), Error>] {
+        packageAndVersions.map { result in
+            result.flatMap { (pkg, versions) in
+                let m = versions.map { getPackageInfo(package: pkg, version: $0) }
+                let successes = m.compactMap { try? $0.get() }
+                if !versions.isEmpty && successes.isEmpty {
+                    return .failure(AppError.noValidVersions(pkg.model.id, pkg.model.url))
+                }
+                return .success((pkg, successes))
             }
-            return .success((pkg, successes))
         }
     }
-}
 
 
-/// Run `swift package dump-package` for a package at the given path.
-/// - Parameters:
-///   - path: path to the pacakge
-/// - Throws: Shell errors or AppError.invalidRevision if there is no Package.swift file
-/// - Returns: `Manifest` data
-func dumpPackage(at path: String) throws -> Manifest {
-    guard Current.fileManager.fileExists(atPath: path + "/Package.swift") else {
-        // It's important to check for Package.swift - otherwise `dump-package` will go
-        // up the tree through parent directories to find one
-        throw AppError.invalidRevision(nil, "no Package.swift")
-    }
-    let json = try Current.shell.run(command: .swiftDumpPackage, at: path)
-    return try JSONDecoder().decode(Manifest.self, from: Data(json.utf8))
-}
-
-
-/// Get `Manifest` and `[ResolvedDepedency]` for a given `Package` at version `Version`.
-/// - Parameters:
-///   - package: `Package` to analyse
-///   - version: `Version` to check out
-/// - Returns: `Result` with `Manifest` data
-func getPackageInfo(package: Joined<Package, Repository>, version: Version) -> Result<(Version, Manifest, [ResolvedDependency]?), Error> {
-    Result {
-        // check out version in cache directory
-        guard let cacheDir = Current.fileManager.cacheDirectoryPath(for: package.model) else {
-            throw AppError.invalidPackageCachePath(package.model.id,
-                                                   package.model.url)
+    /// Run `swift package dump-package` for a package at the given path.
+    /// - Parameters:
+    ///   - path: path to the pacakge
+    /// - Throws: Shell errors or AppError.invalidRevision if there is no Package.swift file
+    /// - Returns: `Manifest` data
+    static func dumpPackage(at path: String) throws -> Manifest {
+        guard Current.fileManager.fileExists(atPath: path + "/Package.swift") else {
+            // It's important to check for Package.swift - otherwise `dump-package` will go
+            // up the tree through parent directories to find one
+            throw AppError.invalidRevision(nil, "no Package.swift")
         }
-        try Current.shell.run(command: .gitCheckout(branch: version.reference.description), at: cacheDir)
+        let json = try Current.shell.run(command: .swiftDumpPackage, at: path)
+        return try JSONDecoder().decode(Manifest.self, from: Data(json.utf8))
+    }
 
-        do {
-            let manifest = try dumpPackage(at: cacheDir)
-            let resolvedDependencies = getResolvedDependencies(Current.fileManager,
-                                                               at: cacheDir)
-            return (version, manifest, resolvedDependencies)
-        } catch let AppError.invalidRevision(_, msg) {
-            // re-package error to attach version.id
-            throw AppError.invalidRevision(version.id, msg)
+
+    /// Get `Manifest` and `[ResolvedDepedency]` for a given `Package` at version `Version`.
+    /// - Parameters:
+    ///   - package: `Package` to analyse
+    ///   - version: `Version` to check out
+    /// - Returns: `Result` with `Manifest` data
+    static func getPackageInfo(package: Joined<Package, Repository>, version: Version) -> Result<(Version, Manifest, [ResolvedDependency]?), Error> {
+        Result {
+            // check out version in cache directory
+            guard let cacheDir = Current.fileManager.cacheDirectoryPath(for: package.model) else {
+                throw AppError.invalidPackageCachePath(package.model.id,
+                                                       package.model.url)
+            }
+            try Current.shell.run(command: .gitCheckout(branch: version.reference.description), at: cacheDir)
+
+            do {
+                let manifest = try dumpPackage(at: cacheDir)
+                let resolvedDependencies = getResolvedDependencies(Current.fileManager,
+                                                                   at: cacheDir)
+                return (version, manifest, resolvedDependencies)
+            } catch let AppError.invalidRevision(_, msg) {
+                // re-package error to attach version.id
+                throw AppError.invalidRevision(version.id, msg)
+            }
         }
     }
-}
 
 
-/// Update and save a given array of `Version` (as contained in `packageResults`) with data from the associated `Manifest`.
-/// - Parameters:
-///   - database: database connection
-///   - packageResults: results to process, containing the versions and their manifests
-/// - Returns: the input data for further processing, wrapped in a future
-func updateVersions(on database: Database,
-                    packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest, [ResolvedDependency]?)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
-    packageResults.whenAllComplete(on: database.eventLoop) { (pkg, pkgInfo) in
-        EventLoopFuture.andAllComplete(
-            pkgInfo.map { version, manifest, resolvedDependencies in
-                updateVersion(on: database,
-                              version: version,
-                              manifest: manifest,
-                              resolvedDependencies: resolvedDependencies)
-            },
-            on: database.eventLoop
-        )
+    /// Update and save a given array of `Version` (as contained in `packageResults`) with data from the associated `Manifest`.
+    /// - Parameters:
+    ///   - database: database connection
+    ///   - packageResults: results to process, containing the versions and their manifests
+    /// - Returns: the input data for further processing, wrapped in a future
+    static func updateVersions(on database: Database,
+                               packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest, [ResolvedDependency]?)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
+        packageResults.whenAllComplete(on: database.eventLoop) { (pkg, pkgInfo) in
+            EventLoopFuture.andAllComplete(
+                pkgInfo.map { version, manifest, resolvedDependencies in
+                    updateVersion(on: database,
+                                  version: version,
+                                  manifest: manifest,
+                                  resolvedDependencies: resolvedDependencies)
+                },
+                on: database.eventLoop
+            )
             .transform(
                 to: (
                     pkg,
@@ -688,216 +692,218 @@ func updateVersions(on database: Database,
                     }
                 )
             )
-    }
-}
-
-
-/// Persist version changes to the database.
-/// - Parameters:
-///   - database: `Database` object
-///   - version: version to update
-///   - manifest: `Manifest` data
-/// - Returns: future
-func updateVersion(on database: Database,
-                   version: Version,
-                   manifest: Manifest,
-                   resolvedDependencies: [ResolvedDependency]?) -> EventLoopFuture<Void> {
-    version.packageName = manifest.name
-    if let resolvedDependencies = resolvedDependencies {
-        // Don't overwrite information provided by the build system unless it's a non-nil (i.e. valid) value
-        version.resolvedDependencies = resolvedDependencies
-    }
-    version.swiftVersions = manifest.swiftLanguageVersions?.compactMap(SwiftVersion.init) ?? []
-    version.supportedPlatforms = manifest.platforms?.compactMap(Platform.init(from:)) ?? []
-    version.toolsVersion = manifest.toolsVersion?.version
-    return version.save(on: database)
-}
-
-
-/// Update (delete and re-create) `Product`s from the `Manifest` data provided in `packageResults`.
-/// - Parameters:
-///   - database: database connection
-///   - packageResults: results to process
-/// - Returns: the input data for further processing, wrapped in a future
-func updateProducts(on database: Database,
-                    packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
-    packageResults.whenAllComplete(on: database.eventLoop) { (pkg, versionsAndManifests) in
-        EventLoopFuture.andAllComplete(
-            versionsAndManifests.map { version, manifest in
-                deleteProducts(on: database, version: version)
-                    .flatMap {
-                        createProducts(on: database, version: version, manifest: manifest)
-                    }
-            },
-            on: database.eventLoop
-        )
-        .transform(to: (pkg, versionsAndManifests))
-    }
-}
-
-
-/// Delete `Product`s for a given `versionId`.
-/// - Parameters:
-///   - database: database connection
-///   - version: parent model object
-/// - Returns: future
-func deleteProducts(on database: Database, version: Version) -> EventLoopFuture<Void> {
-    guard let versionId = version.id else {
-        return database.eventLoop.future()
-    }
-    return Product.query(on: database)
-        .filter(\.$version.$id == versionId)
-        .delete()
-}
-
-
-/// Create and persist `Product`s for a given `Version` according to the given `Manifest`.
-/// - Parameters:
-///   - database: `Database` object
-///   - version: version to update
-///   - manifest: `Manifest` data
-/// - Returns: future
-func createProducts(on database: Database, version: Version, manifest: Manifest) -> EventLoopFuture<Void> {
-    manifest.products.compactMap { manifestProduct in
-        try? Product(version: version,
-                     type: .init(manifestProductType: manifestProduct.type),
-                     name: manifestProduct.name,
-                     targets: manifestProduct.targets)
-    }
-    .create(on: database)
-}
-
-
-/// Update (delete and re-create) `Target`s from the `Manifest` data provided in `packageResults`.
-/// - Parameters:
-///   - database: database connection
-///   - packageResults: results to process
-/// - Returns: the input data for further processing, wrapped in a future
-func updateTargets(on database: Database,
-                   packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
-    packageResults.whenAllComplete(on: database.eventLoop) { (pkg, versionsAndManifests) in
-        EventLoopFuture.andAllComplete(
-            versionsAndManifests.map { version, manifest in
-                deleteTargets(on: database, version: version)
-                    .flatMap {
-                        createTargets(on: database, version: version, manifest: manifest)
-                    }
-            },
-            on: database.eventLoop
-        )
-        .transform(to: (pkg, versionsAndManifests))
-    }
-}
-
-
-/// Delete `Target`s for a given `versionId`.
-/// - Parameters:
-///   - database: database connection
-///   - version: parent model object
-/// - Returns: future
-func deleteTargets(on database: Database, version: Version) -> EventLoopFuture<Void> {
-    guard let versionId = version.id else {
-        return database.eventLoop.future()
-    }
-    return Target.query(on: database)
-        .filter(\.$version.$id == versionId)
-        .delete()
-}
-
-
-/// Create and persist `Target`s for a given `Version` according to the given `Manifest`.
-/// - Parameters:
-///   - database: `Database` object
-///   - version: version to update
-///   - manifest: `Manifest` data
-/// - Returns: future
-func createTargets(on database: Database, version: Version, manifest: Manifest) -> EventLoopFuture<Void> {
-    manifest.targets.compactMap { manifestTarget in
-        try? Target(version: version, name: manifestTarget.name)
-    }
-    .create(on: database)
-}
-
-
-/// Update the significant versions (stable, beta, latest) for an array of `Package`s (contained in `packageResults`).
-/// - Parameters:
-///   - database: `Database` object
-///   - packageResults: packages to update
-/// - Returns: the input data for further processing, wrapped in a future
-func updateLatestVersions(on database: Database,
-                          packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
-    packageResults.whenAllComplete(on: database.eventLoop) { pkg, versionsAndManifests in
-        updateLatestVersions(on: database, package: pkg)
-            .map { _ in (pkg, versionsAndManifests) }
-    }
-}
-
-
-/// Update the significant versions (stable, beta, latest) for a given `Package`.
-/// - Parameters:
-///   - database: `Database` object
-///   - package: package to update
-/// - Returns: future
-func updateLatestVersions(on database: Database, package: Joined<Package, Repository>) -> EventLoopFuture<Void> {
-    package.model
-        .$versions.load(on: database)
-        .flatMap {
-            // find previous markers
-            let previous = package.model.versions
-                .filter { $0.latest != nil }
-
-            let versions = package.model.$versions.value ?? []
-
-            // find new significant releases
-            let (release, preRelease, defaultBranch) = Package.findSignificantReleases(
-                versions: versions,
-                branch: package.repository?.defaultBranch
-            )
-            release.map { $0.latest = .release }
-            preRelease.map { $0.latest = .preRelease }
-            defaultBranch.map { $0.latest = .defaultBranch }
-            let updates = [release, preRelease, defaultBranch].compactMap { $0 }
-
-            // reset versions that aren't being updated
-            let resets = previous
-                .filter { !updates.map(\.id).contains($0.id) }
-                .map { version -> Version in
-                    version.latest = nil
-                    return version
-                }
-
-            // save changes
-            return (updates + resets)
-                .map { $0.save(on: database) }
-                .flatten(on: database.eventLoop)
         }
-}
+    }
 
 
-/// Event hook to run logic when new (tagged) versions have been discovered in an analysis pass. Note that the provided
-/// transaction could potentially be rolled back in case an error occurs before all versions are processed and saved.
-/// - Parameters:
-///   - client: `Client` object for http requests
-///   - logger: `Logger` object
-///   - transaction: database transaction
-///   - packageResults: array of `Package`s with their analysis results of `Version`s and `Manifest`s
-/// - Returns: the packageResults that were passed in, for further processing
-func onNewVersions(client: Client,
-                   logger: Logger,
-                   transaction: Database,
-                   packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
-    packageResults.whenAllComplete(on: transaction.eventLoop) { pkg, versionsAndManifests in
-        let versions = versionsAndManifests.map { $0.0 }
-        return Twitter.postToFirehose(client: client,
-                                      database: transaction,
-                                      package: pkg,
-                                      versions: versions)
+    /// Persist version changes to the database.
+    /// - Parameters:
+    ///   - database: `Database` object
+    ///   - version: version to update
+    ///   - manifest: `Manifest` data
+    /// - Returns: future
+    static func updateVersion(on database: Database,
+                              version: Version,
+                              manifest: Manifest,
+                              resolvedDependencies: [ResolvedDependency]?) -> EventLoopFuture<Void> {
+        version.packageName = manifest.name
+        if let resolvedDependencies = resolvedDependencies {
+            // Don't overwrite information provided by the build system unless it's a non-nil (i.e. valid) value
+            version.resolvedDependencies = resolvedDependencies
+        }
+        version.swiftVersions = manifest.swiftLanguageVersions?.compactMap(SwiftVersion.init) ?? []
+        version.supportedPlatforms = manifest.platforms?.compactMap(Platform.init(from:)) ?? []
+        version.toolsVersion = manifest.toolsVersion?.version
+        return version.save(on: database)
+    }
+
+
+    /// Update (delete and re-create) `Product`s from the `Manifest` data provided in `packageResults`.
+    /// - Parameters:
+    ///   - database: database connection
+    ///   - packageResults: results to process
+    /// - Returns: the input data for further processing, wrapped in a future
+    static func updateProducts(on database: Database,
+                               packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
+        packageResults.whenAllComplete(on: database.eventLoop) { (pkg, versionsAndManifests) in
+            EventLoopFuture.andAllComplete(
+                versionsAndManifests.map { version, manifest in
+                    deleteProducts(on: database, version: version)
+                        .flatMap {
+                            createProducts(on: database, version: version, manifest: manifest)
+                        }
+                },
+                on: database.eventLoop
+            )
+            .transform(to: (pkg, versionsAndManifests))
+        }
+    }
+
+
+    /// Delete `Product`s for a given `versionId`.
+    /// - Parameters:
+    ///   - database: database connection
+    ///   - version: parent model object
+    /// - Returns: future
+    static func deleteProducts(on database: Database, version: Version) -> EventLoopFuture<Void> {
+        guard let versionId = version.id else {
+            return database.eventLoop.future()
+        }
+        return Product.query(on: database)
+            .filter(\.$version.$id == versionId)
+            .delete()
+    }
+
+
+    /// Create and persist `Product`s for a given `Version` according to the given `Manifest`.
+    /// - Parameters:
+    ///   - database: `Database` object
+    ///   - version: version to update
+    ///   - manifest: `Manifest` data
+    /// - Returns: future
+    static func createProducts(on database: Database, version: Version, manifest: Manifest) -> EventLoopFuture<Void> {
+        manifest.products.compactMap { manifestProduct in
+            try? Product(version: version,
+                         type: .init(manifestProductType: manifestProduct.type),
+                         name: manifestProduct.name,
+                         targets: manifestProduct.targets)
+        }
+        .create(on: database)
+    }
+
+
+    /// Update (delete and re-create) `Target`s from the `Manifest` data provided in `packageResults`.
+    /// - Parameters:
+    ///   - database: database connection
+    ///   - packageResults: results to process
+    /// - Returns: the input data for further processing, wrapped in a future
+    static func updateTargets(on database: Database,
+                              packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
+        packageResults.whenAllComplete(on: database.eventLoop) { (pkg, versionsAndManifests) in
+            EventLoopFuture.andAllComplete(
+                versionsAndManifests.map { version, manifest in
+                    deleteTargets(on: database, version: version)
+                        .flatMap {
+                            createTargets(on: database, version: version, manifest: manifest)
+                        }
+                },
+                on: database.eventLoop
+            )
+            .transform(to: (pkg, versionsAndManifests))
+        }
+    }
+
+
+    /// Delete `Target`s for a given `versionId`.
+    /// - Parameters:
+    ///   - database: database connection
+    ///   - version: parent model object
+    /// - Returns: future
+    static func deleteTargets(on database: Database, version: Version) -> EventLoopFuture<Void> {
+        guard let versionId = version.id else {
+            return database.eventLoop.future()
+        }
+        return Target.query(on: database)
+            .filter(\.$version.$id == versionId)
+            .delete()
+    }
+
+
+    /// Create and persist `Target`s for a given `Version` according to the given `Manifest`.
+    /// - Parameters:
+    ///   - database: `Database` object
+    ///   - version: version to update
+    ///   - manifest: `Manifest` data
+    /// - Returns: future
+    static func createTargets(on database: Database, version: Version, manifest: Manifest) -> EventLoopFuture<Void> {
+        manifest.targets.compactMap { manifestTarget in
+            try? Target(version: version, name: manifestTarget.name)
+        }
+        .create(on: database)
+    }
+
+
+    /// Update the significant versions (stable, beta, latest) for an array of `Package`s (contained in `packageResults`).
+    /// - Parameters:
+    ///   - database: `Database` object
+    ///   - packageResults: packages to update
+    /// - Returns: the input data for further processing, wrapped in a future
+    static func updateLatestVersions(on database: Database,
+                              packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
+        packageResults.whenAllComplete(on: database.eventLoop) { pkg, versionsAndManifests in
+            updateLatestVersions(on: database, package: pkg)
+                .map { _ in (pkg, versionsAndManifests) }
+        }
+    }
+
+
+    /// Update the significant versions (stable, beta, latest) for a given `Package`.
+    /// - Parameters:
+    ///   - database: `Database` object
+    ///   - package: package to update
+    /// - Returns: future
+    static func updateLatestVersions(on database: Database, package: Joined<Package, Repository>) -> EventLoopFuture<Void> {
+        package.model
+            .$versions.load(on: database)
+            .flatMap {
+                // find previous markers
+                let previous = package.model.versions
+                    .filter { $0.latest != nil }
+
+                let versions = package.model.$versions.value ?? []
+
+                // find new significant releases
+                let (release, preRelease, defaultBranch) = Package.findSignificantReleases(
+                    versions: versions,
+                    branch: package.repository?.defaultBranch
+                )
+                release.map { $0.latest = .release }
+                preRelease.map { $0.latest = .preRelease }
+                defaultBranch.map { $0.latest = .defaultBranch }
+                let updates = [release, preRelease, defaultBranch].compactMap { $0 }
+
+                // reset versions that aren't being updated
+                let resets = previous
+                    .filter { !updates.map(\.id).contains($0.id) }
+                    .map { version -> Version in
+                        version.latest = nil
+                        return version
+                    }
+
+                // save changes
+                return (updates + resets)
+                    .map { $0.save(on: database) }
+                    .flatten(on: database.eventLoop)
+            }
+    }
+
+
+    /// Event hook to run logic when new (tagged) versions have been discovered in an analysis pass. Note that the provided
+    /// transaction could potentially be rolled back in case an error occurs before all versions are processed and saved.
+    /// - Parameters:
+    ///   - client: `Client` object for http requests
+    ///   - logger: `Logger` object
+    ///   - transaction: database transaction
+    ///   - packageResults: array of `Package`s with their analysis results of `Version`s and `Manifest`s
+    /// - Returns: the packageResults that were passed in, for further processing
+    static func onNewVersions(client: Client,
+                              logger: Logger,
+                              transaction: Database,
+                              packageResults: [Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]) -> EventLoopFuture<[Result<(Joined<Package, Repository>, [(Version, Manifest)]), Error>]> {
+        packageResults.whenAllComplete(on: transaction.eventLoop) { pkg, versionsAndManifests in
+            let versions = versionsAndManifests.map { $0.0 }
+            return Twitter.postToFirehose(client: client,
+                                          database: transaction,
+                                          package: pkg,
+                                          versions: versions)
             .flatMapError { error in
                 logger.warning("Twitter.postToFirehose failed: \(error.localizedDescription)")
                 return client.eventLoop.future()
             }
             .map { (pkg, versionsAndManifests) }
+        }
     }
+
 }
 
 

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -90,11 +90,11 @@ extension API {
                                      mode: .limit(limit))
                     return .init(status: "ok", rows: limit)
                 case .analyze:
-                    return try await analyze(client: req.application.client,
-                                             database: req.application.db,
-                                             logger: req.application.logger,
-                                             threadPool: req.application.threadPool,
-                                             mode: .limit(limit))
+                    return try await Analyze.analyze(client: req.application.client,
+                                                     database: req.application.db,
+                                                     logger: req.application.logger,
+                                                     threadPool: req.application.threadPool,
+                                                     mode: .limit(limit))
                         .map {
                             Command.Response(status: "ok", rows: limit)
                         }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -236,7 +236,7 @@ public func configure(_ app: Application) throws -> String {
         app.migrations.add(UpdateRepositoryAddHomepageUrl())
     }
 
-    app.commands.use(AnalyzeCommand(), as: "analyze")
+    app.commands.use(Analyze.Command(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")
     app.commands.use(DeleteBuildsCommand(), as: "delete-builds")
     app.commands.use(IngestCommand(), as: "ingest")

--- a/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
+++ b/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
@@ -29,7 +29,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", -.hours(1), .branch("main"))
 
         // MUT
-        let res = throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [old])
@@ -45,7 +45,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .branch("main"))
 
         // MUT
-        let res = throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [new])
@@ -61,7 +61,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .tag(2, 0, 0))
 
         // MUT
-        let res = throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [new])
@@ -76,7 +76,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .branch("main"))
 
         // MUT
-        let res = throttle(lastestExistingVersion: nil, incoming: [new])
+        let res = Analyze.throttle(lastestExistingVersion: nil, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [new])
@@ -92,7 +92,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .branch("main"))
 
         // MUT
-        let res = throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [old])
@@ -108,7 +108,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha", .hours(-1), .branch("main-new"))
 
         // MUT
-        let res = throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [old])
@@ -128,8 +128,8 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new2 = try makeVersion(pkg, "sha_new2", .hours(-1), .branch("main"))
 
         // MUT
-        let res = throttle(lastestExistingVersion: old,
-                           incoming: [new0, new1, new2].shuffled())
+        let res = Analyze.throttle(lastestExistingVersion: old,
+                                   incoming: [new0, new1, new2].shuffled())
 
         // validate
         XCTAssertEqual(res, [old])
@@ -149,8 +149,8 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new2 = try makeVersion(pkg, "sha_new2", .hours(-1), .branch("main"))
 
         // MUT
-        let res = throttle(lastestExistingVersion: old,
-                           incoming: [new0, new1, new2].shuffled())
+        let res = Analyze.throttle(lastestExistingVersion: old,
+                                   incoming: [new0, new1, new2].shuffled())
 
         // validate
         XCTAssertEqual(res, [new2])
@@ -174,11 +174,11 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
             }
 
             // MUT
-            let res = try diffVersions(client: app.client,
-                                       logger: app.logger,
-                                       threadPool: app.threadPool,
-                                       transaction: app.db,
-                                       package: jpr).wait()
+            let res = try Analyze.diffVersions(client: app.client,
+                                               logger: app.logger,
+                                               threadPool: app.threadPool,
+                                               transaction: app.db,
+                                               package: jpr).wait()
 
             // validate
             XCTAssertEqual(res.toAdd, [])
@@ -195,11 +195,11 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
             }
 
             // MUT
-            let res = try diffVersions(client: app.client,
-                                       logger: app.logger,
-                                       threadPool: app.threadPool,
-                                       transaction: app.db,
-                                       package: jpr).wait()
+            let res = try Analyze.diffVersions(client: app.client,
+                                               logger: app.logger,
+                                               threadPool: app.threadPool,
+                                               transaction: app.db,
+                                               package: jpr).wait()
 
             // validate
             XCTAssertEqual(res.toAdd.map(\.commit), ["sha_new2"])
@@ -216,13 +216,13 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
 
         // Little helper to simulate minimal version reconciliation
         func runVersionReconciliation() throws -> VersionDelta {
-            let delta = try diffVersions(client: app.client,
-                                         logger: app.logger,
-                                         threadPool: app.threadPool,
-                                         transaction: app.db,
-                                         package: jpr).wait()
+            let delta = try Analyze.diffVersions(client: app.client,
+                                                 logger: app.logger,
+                                                 threadPool: app.threadPool,
+                                                 transaction: app.db,
+                                                 package: jpr).wait()
             // apply the delta to ensure versions are in place for next cycle
-            try applyVersionDelta(on: app.db, delta: delta).wait()
+            try Analyze.applyVersionDelta(on: app.db, delta: delta).wait()
             return delta
         }
 
@@ -297,7 +297,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
             let inc = try makeVersion(pkg, "sha-inc", .hours(-23), .branch("main"))
 
             // MUT
-            let res = throttle(lastestExistingVersion: ex, incoming: [inc])
+            let res = Analyze.throttle(lastestExistingVersion: ex, incoming: [inc])
 
             // validate
             XCTAssertEqual(res, [ex])
@@ -308,7 +308,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
             let inc = try makeVersion(pkg, "sha-inc", .hours(-26), .branch("main"))
 
             // MUT
-            let res = throttle(lastestExistingVersion: ex, incoming: [inc])
+            let res = Analyze.throttle(lastestExistingVersion: ex, incoming: [inc])
 
             // validate
             XCTAssertEqual(res, [ex])
@@ -319,7 +319,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
             let inc = try makeVersion(pkg, "sha-inc", .hours(-28), .branch("main"))
 
             // MUT
-            let res = throttle(lastestExistingVersion: ex, incoming: [inc])
+            let res = Analyze.throttle(lastestExistingVersion: ex, incoming: [inc])
 
             // validate
             XCTAssertEqual(res, [inc])

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -416,7 +416,7 @@ class ApiTests: AppTestCase {
         try Version(package: p, reference: .tag(.init(1, 2, 3))).save(on: app.db).wait()
         let jpr = try Package.fetchCandidate(app.db, id: p.id!).wait()
         // update versions
-        _ = try updateLatestVersions(on: app.db, package: jpr).wait()
+        _ = try Analyze.updateLatestVersions(on: app.db, package: jpr).wait()
 
         let owner = "foo"
         let repo = "bar"

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -81,11 +81,11 @@ class ErrorReportingTests: AppTestCase {
         }
         
         // MUT
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try Analyze.analyze(client: app.client,
+                            database: app.db,
+                            logger: app.logger,
+                            threadPool: app.threadPool,
+                            mode: .limit(10)).wait()
         
         // validation
         XCTAssertNotNil(reportedError)
@@ -97,11 +97,11 @@ class ErrorReportingTests: AppTestCase {
         try savePackages(on: app.db, ["1", "2"], processingStage: .ingestion)
         
         // MUT
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try Analyze.analyze(client: app.client,
+                            database: app.db,
+                            logger: app.logger,
+                            threadPool: app.threadPool,
+                            mode: .limit(10)).wait()
         
         // validation
         let packages = try Package.query(on: app.db).sort(\.$url).all().wait()

--- a/Tests/AppTests/MetricsTests.swift
+++ b/Tests/AppTests/MetricsTests.swift
@@ -72,7 +72,7 @@ class MetricsTests: AppTestCase {
         try del.save(on: app.db).wait()
 
         // MUT
-        try applyVersionDelta(on: app.db, delta: .init(toAdd: new, toDelete: del)).wait()
+        try Analyze.applyVersionDelta(on: app.db, delta: .init(toAdd: new, toDelete: del)).wait()
 
         // validation
         XCTAssertEqual(AppMetrics.analyzeVersionsAddedCount?.get(.init("branch")),
@@ -115,7 +115,7 @@ class MetricsTests: AppTestCase {
         let pkg = try savePackage(on: app.db, "1")
 
         // MUT
-        try analyze(client: app.client, database: app.db, logger: app.logger, threadPool: app.threadPool, mode: .id(pkg.id!)).wait()
+        try Analyze.analyze(client: app.client, database: app.db, logger: app.logger, threadPool: app.threadPool, mode: .id(pkg.id!)).wait()
 
         // validation
         XCTAssert((AppMetrics.analyzeDurationSeconds?.get()) ?? 0 > 0)

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -308,11 +308,11 @@ final class PackageTests: AppTestCase {
         }
 
         // run analysis to progress package through pipeline
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try Analyze.analyze(client: app.client,
+                            database: app.db,
+                            logger: app.logger,
+                            threadPool: app.threadPool,
+                            mode: .limit(10)).wait()
 
         // MUT & validate
         do {
@@ -335,11 +335,11 @@ final class PackageTests: AppTestCase {
             XCTAssertFalse(pkg.isNew)
         }
 
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try Analyze.analyze(client: app.client,
+                            database: app.db,
+                            logger: app.logger,
+                            threadPool: app.threadPool,
+                            mode: .limit(10)).wait()
         do {
             let pkg = try XCTUnwrap(Package.query(on: app.db).first().wait())
             XCTAssertFalse(pkg.isNew)

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -175,11 +175,11 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - third stage
-        try await analyze(client: app.client,
-                          database: app.db,
-                          logger: app.logger,
-                          threadPool: app.threadPool,
-                          mode: .limit(10)).get()
+        try await Analyze.analyze(client: app.client,
+                                  database: app.db,
+                                  logger: app.logger,
+                                  threadPool: app.threadPool,
+                                  mode: .limit(10)).get()
         
         do { // validate
             let packages = try await Package.query(on: app.db).sort(\.$url).all()
@@ -216,11 +216,11 @@ class PipelineTests: AppTestCase {
         
         // MUT - analyze again
         let lastAnalysis = Current.date()
-        try await analyze(client: app.client,
-                          database: app.db,
-                          logger: app.logger,
-                          threadPool: app.threadPool,
-                          mode: .limit(10)).get()
+        try await Analyze.analyze(client: app.client,
+                                  database: app.db,
+                                  logger: app.logger,
+                                  threadPool: app.threadPool,
+                                  mode: .limit(10)).get()
         
         do {  // validate - only new package moves to .ingestion stage
             let packages = try await Package.query(on: app.db).sort(\.$url).all()
@@ -246,11 +246,11 @@ class PipelineTests: AppTestCase {
         }
         
         // MUT - re-run analysis to complete the sequence
-        try await analyze(client: app.client,
-                          database: app.db,
-                          logger: app.logger,
-                          threadPool: app.threadPool,
-                          mode: .limit(10)).get()
+        try await Analyze.analyze(client: app.client,
+                                  database: app.db,
+                                  logger: app.logger,
+                                  threadPool: app.threadPool,
+                                  mode: .limit(10)).get()
         
         do {  // validate - only new package moves to .ingestion stage
             let packages = try await Package.query(on: app.db).sort(\.$url).all()

--- a/Tests/AppTests/ReAnalyzeVersionsTests.swift
+++ b/Tests/AppTests/ReAnalyzeVersionsTests.swift
@@ -61,11 +61,11 @@ class ReAnalyzeVersionsTests: AppTestCase {
         }
         do {
             // run initial analysis and assert initial state for versions
-            try analyze(client: app.client,
-                        database: app.db,
-                        logger: app.logger,
-                        threadPool: app.threadPool,
-                        mode: .limit(10)).wait()
+            try Analyze.analyze(client: app.client,
+                                database: app.db,
+                                logger: app.logger,
+                                threadPool: app.threadPool,
+                                mode: .limit(10)).wait()
             let versions = try Version.query(on: app.db)
                 .with(\.$targets)
                 .all().wait()
@@ -93,11 +93,11 @@ class ReAnalyzeVersionsTests: AppTestCase {
             try r.save(on: app.db).wait()
         }
         do {  // assert running analysis again does not update existing versions
-            try analyze(client: app.client,
-                        database: app.db,
-                        logger: app.logger,
-                        threadPool: app.threadPool,
-                        mode: .limit(10)).wait()
+            try Analyze.analyze(client: app.client,
+                                database: app.db,
+                                logger: app.logger,
+                                threadPool: app.threadPool,
+                                mode: .limit(10)).wait()
             let versions = try Version.query(on: app.db)
                 .with(\.$targets)
                 .all().wait()
@@ -179,11 +179,11 @@ class ReAnalyzeVersionsTests: AppTestCase {
             }
             return ""
         }
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try Analyze.analyze(client: app.client,
+                            database: app.db,
+                            logger: app.logger,
+                            threadPool: app.threadPool,
+                            mode: .limit(10)).wait()
         try setAllVersionsUpdatedAt(app.db, updatedAt: .t0)
         do {
             let candidates = try Package

--- a/Tests/AppTests/ScoreTests.swift
+++ b/Tests/AppTests/ScoreTests.swift
@@ -117,7 +117,7 @@ class ScoreTests: AppTestCase {
         }
         let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
         // update versions
-        try updateLatestVersions(on: app.db, package: jpr).wait()
+        try Analyze.updateLatestVersions(on: app.db, package: jpr).wait()
         let versions = try pkg.$versions.load(on: app.db)
             .map { pkg.versions }
             .wait()

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -178,7 +178,7 @@ class TwitterTests: AppTestCase {
         let v3 = try Version(package: pkg, packageName: "MyPackage", reference: .branch("main"))
         try v3.save(on: app.db).wait()
         let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
-        try updateLatestVersions(on: app.db, package: jpr).wait()
+        try Analyze.updateLatestVersions(on: app.db, package: jpr).wait()
 
         Current.twitterCredentials = {
             .init(apiKey: ("key", "secret"), accessToken: ("key", "secret"))
@@ -213,7 +213,7 @@ class TwitterTests: AppTestCase {
         let v2 = try Version(package: pkg, packageName: "MyPackage", reference: .tag(2, 0, 0))
         try v2.save(on: app.db).wait()
         let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
-        try updateLatestVersions(on: app.db, package: jpr).wait()
+        try Analyze.updateLatestVersions(on: app.db, package: jpr).wait()
 
         Current.twitterCredentials = {
             .init(apiKey: ("key", "secret"), accessToken: ("key", "secret"))
@@ -278,11 +278,11 @@ class TwitterTests: AppTestCase {
         try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT - analyze, triggering the tweet
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try Analyze.analyze(client: app.client,
+                            database: app.db,
+                            logger: app.logger,
+                            threadPool: app.threadPool,
+                            mode: .limit(10)).wait()
         do {
             let msg = try XCTUnwrap(message)
             XCTAssertTrue(msg.hasPrefix("📦 foo just added a new package, Mock"), "was \(msg)")
@@ -295,11 +295,11 @@ class TwitterTests: AppTestCase {
         try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT - analyze, triggering tweets if any
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try Analyze.analyze(client: app.client,
+                            database: app.db,
+                            logger: app.logger,
+                            threadPool: app.threadPool,
+                            mode: .limit(10)).wait()
 
         // validate - there are no new tweets to send
         XCTAssertNil(message)
@@ -311,11 +311,11 @@ class TwitterTests: AppTestCase {
         try await ingest(client: app.client, database: app.db, logger: app.logger, mode: .limit(10))
 
         // MUT - analyze again
-        try analyze(client: app.client,
-                    database: app.db,
-                    logger: app.logger,
-                    threadPool: app.threadPool,
-                    mode: .limit(10)).wait()
+        try Analyze.analyze(client: app.client,
+                            database: app.db,
+                            logger: app.logger,
+                            threadPool: app.threadPool,
+                            mode: .limit(10)).wait()
 
         // validate
         let msg = try XCTUnwrap(message)


### PR DESCRIPTION
It's been bothering me for quite a while that all our analysis (and reconciliation, ingestion, etc) code are free, top-level functions and types. (I've actually had a branch that "fixes" this for reconciliation and ingestion on the side.)

When I wanted to add a new type `PackageInfo` to `Analyze.swift` for the documentation targets just now it conflicted with the same type in `Views`.

This looks like a big diff but is structurally pretty simple. Everything moves inside `enum Analyze { ... }` and all `func`s become `static func` to preserve semantics.