### PR TITLE
Amended Snapshots workflow with context sensitive comparison

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -31,10 +31,20 @@ jobs:
         run: make build-front-end
       - name: Copy Front-End
         run: cp -a ./Public/* ./Tests/AppTests/__Snapshots__/WebpageSnapshotTests
+      - name: Determine Comparison Git Reference
+        id: determine-comparison-ref
+        run: |
+          branch=$(git branch --show-current)
+          echo $branch
+          if [ $branch == "main" ]; then
+            echo "::set-output name=comparison-ref::HEAD^"
+          else
+            echo "::set-output name=comparison-ref::origin/main"
+          fi
       - name: Diff for Front-End Changes
         id: front-end-changes
         run: |
-          filecount=$(git diff origin/main --shortstat "**.html" "**.scss" "**.js" ".percy.yml" ".github/workflows/snapshots.yml" | awk '{print $1}')
+          filecount=$(git diff ${{steps.determine-comparison-ref.outputs.comparison-ref}} --shortstat "**.html" "**.scss" "**.js" ".percy.yml" ".github/workflows/snapshots.yml" | awk '{print $1}')
           echo "::set-output name=matching-files::${filecount:-0}"
       - name: Run Percy
         if: steps.front-end-changes.outputs.matching-files != '0'

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -35,7 +35,6 @@ jobs:
         id: determine-comparison-ref
         run: |
           branch=$(git branch --show-current)
-          echo $branch
           if [ $branch == "main" ]; then
             echo "::set-output name=comparison-ref::HEAD^"
           else
@@ -44,8 +43,8 @@ jobs:
       - name: Diff for Front-End Changes
         id: front-end-changes
         run: |
-          filecount=$(git diff ${{steps.determine-comparison-ref.outputs.comparison-ref}} --shortstat "**.html" "**.scss" "**.js" ".percy.yml" ".github/workflows/snapshots.yml" | awk '{print $1}')
-          echo "::set-output name=matching-files::${filecount:-0}"
+          filecount=$(git diff ${{ steps.determine-comparison-ref.outputs.comparison-ref }} --shortstat "**.html" "**.scss" "**.js" ".percy.yml" ".github/workflows/snapshots.yml" | awk '{print $1}')
+          echo "::set-output name=matching-files::${ filecount:-0 }"
       - name: Run Percy
         if: steps.front-end-changes.outputs.matching-files != '0'
         run: npx @percy/cli snapshot --verbose ./Tests/AppTests/__Snapshots__/WebpageSnapshotTests

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Diff for Front-End Changes
         id: front-end-changes
         run: |
-          filecount=$(git diff ${{ steps.determine-comparison-ref.outputs.comparison-ref }} --shortstat "**.html" "**.scss" "**.js" ".percy.yml" ".github/workflows/snapshots.yml" | awk '{print $1}')
-          echo "::set-output name=matching-files::${ filecount:-0 }"
+          filecount=$(git diff ${{steps.determine-comparison-ref.outputs.comparison-ref}} --shortstat "**.html" "**.scss" "**.js" ".percy.yml" ".github/workflows/snapshots.yml" | awk '{print $1}')
+          echo "::set-output name=matching-files::${filecount:-0}"
       - name: Run Percy
         if: steps.front-end-changes.outputs.matching-files != '0'
         run: npx @percy/cli snapshot --verbose ./Tests/AppTests/__Snapshots__/WebpageSnapshotTests


### PR DESCRIPTION
From https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/1726#issuecomment-1117300136.

The Snapshots workflow now looks for snapshot-affecting files against `origin/main` when on a feature branch and `HEAD^` when running on `main`.

The effect of this is to run Percy if any snapshot-affecting files have been modified in *any* commit on a feature branch, but when merging into main, only run Percy if the merge commit contains snapshot-affecting files.

This still needs testing on `main` but needs merging for that to happen!