### PR TITLE
Include a reference to the default branch in the documentation URLs

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -16,6 +16,7 @@ import Foundation
 import Plot
 import Vapor
 import DependencyResolution
+import SPIManifest
 
 
 extension PackageShow {
@@ -44,7 +45,7 @@ extension PackageShow {
         var score: Int?
         var isArchived: Bool
         var homepageUrl: String?
-        var documentationTargets: [String]?
+        var documentationMetadata: DocumentationMetadata?
         
         internal init(packageId: Package.Id,
                       repositoryOwner: String,
@@ -69,7 +70,7 @@ extension PackageShow {
                       score: Int? = nil,
                       isArchived: Bool,
                       homepageUrl: String? = nil,
-                      documentationTargets: [String]? = nil) {
+                      documentationMetadata: DocumentationMetadata? = nil) {
             self.packageId = packageId
             self.repositoryOwner = repositoryOwner
             self.repositoryOwnerName = repositoryOwnerName
@@ -93,7 +94,7 @@ extension PackageShow {
             self.score = score
             self.isArchived = isArchived
             self.homepageUrl = homepageUrl
-            self.documentationTargets = documentationTargets
+            self.documentationMetadata = documentationMetadata
         }
         
         init?(result: PackageController.PackageResult,
@@ -142,9 +143,25 @@ extension PackageShow {
                 score: result.package.score,
                 isArchived: repository.isArchived,
                 homepageUrl: repository.homepageUrl,
-                documentationTargets: result.defaultBranchVersion.spiManifest?.allDocumentationTargets()
+                documentationMetadata: DocumentationMetadata(reference: result.repository.defaultBranch,
+                                                             targets: result.defaultBranchVersion.spiManifest?.allDocumentationTargets())
             )
 
+        }
+    }
+
+    struct DocumentationMetadata: Equatable {
+        let reference: String
+        let targets: [String]
+
+        init?(reference: String?, targets: [String]?) {
+            guard
+                let reference = reference,
+                let targets = targets
+            else { return nil }
+
+            self.reference = reference
+            self.targets = targets
         }
     }
     
@@ -159,8 +176,8 @@ extension PackageShow.Model {
         "https://github.com/\(repositoryOwner)/\(repositoryName)"
     }
 
-    func relativeDocumentationURL(target: String) -> String {
-        return "/\(repositoryOwner)/\(repositoryName)/documentation/\(target.lowercased())"
+    func relativeDocumentationURL(reference: String, target: String) -> String {
+        "/\(repositoryOwner)/\(repositoryName)/\(reference)/documentation/\(target.lowercased())"
     }
 }
 

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -252,14 +252,14 @@ enum PackageShow {
         func sidebarDocumentation() -> Node<HTML.BodyContext> {
             guard Environment.current != .production else { return .empty }
 
-            return .unwrap(model.documentationTargets) { targets in
+            return .unwrap(model.documentationMetadata) { metadata in
                     .group(
                         .h6("Documentation"),
                         .ul(
-                            .forEach(targets, { target in
+                            .forEach(metadata.targets, { target in
                                     .li(
                                         .a(
-                                            .href(model.relativeDocumentationURL(target: target)),
+                                            .href(model.relativeDocumentationURL(reference: metadata.reference, target: target)),
                                             .text(target)
                                         )
                                     )

--- a/Tests/AppTests/PackageShowModelTests.swift
+++ b/Tests/AppTests/PackageShowModelTests.swift
@@ -348,15 +348,15 @@ class PackageShowModelTests: SnapshotTestCase {
         model.repositoryName = "bar"
 
         // MUT
-        XCTAssertEqual(model.relativeDocumentationURL(target: "bazqux"),
-                       "/foo/bar/documentation/bazqux")
+        XCTAssertEqual(model.relativeDocumentationURL(reference: "main", target: "bazqux"),
+                       "/foo/bar/main/documentation/bazqux")
 
         model.repositoryOwner = "Foo"
         model.repositoryName = "Bar"
 
         // MUT
-        XCTAssertEqual(model.relativeDocumentationURL(target: "BazQux"),
-                       "/Foo/Bar/documentation/bazqux")
+        XCTAssertEqual(model.relativeDocumentationURL(reference: "Main", target: "BazQux"),
+                       "/Foo/Bar/Main/documentation/bazqux")
     }
 }
 

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -113,7 +113,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     func test_PackageShowView_with_single_documentation_link() throws {
         var model = PackageShow.Model.mock
-        model.documentationTargets = ["Target1"]
+        model.documentationMetadata = .init(reference: "main", targets: ["Target1"])
         let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
 
         assertSnapshot(matching: page, as: .html)
@@ -121,7 +121,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     func test_PackageShowView_with_multiple_documentation_links() throws {
         var model = PackageShow.Model.mock
-        model.documentationTargets = ["Target1", "Target2"]
+        model.documentationMetadata = .init(reference: "main", targets: ["Target1", "Target2"])
         let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
 
         assertSnapshot(matching: page, as: .html)

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_multiple_documentation_links.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_multiple_documentation_links.1.html
@@ -284,10 +284,10 @@
             <h6>Documentation</h6>
             <ul>
               <li>
-                <a href="/Alamo/Alamofire/documentation/target1">Target1</a>
+                <a href="/Alamo/Alamofire/main/documentation/target1">Target1</a>
               </li>
               <li>
-                <a href="/Alamo/Alamofire/documentation/target2">Target2</a>
+                <a href="/Alamo/Alamofire/main/documentation/target2">Target2</a>
               </li>
             </ul>
             <hr class="minor"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
@@ -284,7 +284,7 @@
             <h6>Documentation</h6>
             <ul>
               <li>
-                <a href="/Alamo/Alamofire/documentation/target1">Target1</a>
+                <a href="/Alamo/Alamofire/main/documentation/target1">Target1</a>
               </li>
             </ul>
             <hr class="minor"/>


### PR DESCRIPTION
After today's discussion, we're postponing deciding on the hosting URL, so it makes sense for these links to include a reference.

This needed a new data type, mainly so there was only one thing to unwrap in the view rather than both the default branch name *and* the targets.

Technically the branch name is already in the view model, but it's nested inside a `DatedLink`, and it didn't feel especially good to go digging around in there for it. That also wouldn't solve the double unwrap problem, which is kinda awkward in Plot.

