### PR TITLE
Disable Turbolinks on links to the DocC documentation

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -260,6 +260,7 @@ enum PackageShow {
                                     .li(
                                         .a(
                                             .href(model.relativeDocumentationURL(reference: metadata.reference, target: target)),
+                                            .data(named: "turbo", value: String(false)),
                                             .text(target)
                                         )
                                     )

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_multiple_documentation_links.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_multiple_documentation_links.1.html
@@ -284,10 +284,10 @@
             <h6>Documentation</h6>
             <ul>
               <li>
-                <a href="/Alamo/Alamofire/main/documentation/target1">Target1</a>
+                <a href="/Alamo/Alamofire/main/documentation/target1" data-turbo="false">Target1</a>
               </li>
               <li>
-                <a href="/Alamo/Alamofire/main/documentation/target2">Target2</a>
+                <a href="/Alamo/Alamofire/main/documentation/target2" data-turbo="false">Target2</a>
               </li>
             </ul>
             <hr class="minor"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
@@ -284,7 +284,7 @@
             <h6>Documentation</h6>
             <ul>
               <li>
-                <a href="/Alamo/Alamofire/main/documentation/target1">Target1</a>
+                <a href="/Alamo/Alamofire/main/documentation/target1" data-turbo="false">Target1</a>
               </li>
             </ul>
             <hr class="minor"/>


### PR DESCRIPTION
Fixes #1741
Fixes #1742

Turbo was fighting with Vue. One JavaScript framework at a time, please!

This may also be the best one-line bug fix ever!