### PR TITLE
Upgrade build machines to use Xcode 13.4.0/Swift 5.6

### DIFF
--- a/Sources/App/Core/SwiftVersion+Build.swift
+++ b/Sources/App/Core/SwiftVersion+Build.swift
@@ -19,7 +19,7 @@ extension SwiftVersion {
     static let v5_3: Self = .init(5, 3, 3)
     static let v5_4: Self = .init(5, 4, 0)
     static let v5_5: Self = .init(5, 5, 2)
-    static let v5_6: Self = .init(5, 6, 0)
+    static let v5_6: Self = .init(5, 6, 1)
 
     /// Currently supported swift versions for building
     static var allActive: [Self] {
@@ -37,7 +37,7 @@ extension SwiftVersion {
             case .v5_5:
                 return "Xcode 13.2.1"
             case .v5_6:
-                return "Xcode 13.3.0"
+                return "Xcode 13.3.1"
             default:
                 return nil
         }

--- a/Sources/App/Core/SwiftVersion+Build.swift
+++ b/Sources/App/Core/SwiftVersion+Build.swift
@@ -36,7 +36,7 @@ extension SwiftVersion {
             case .v5_5:
                 return "Xcode 13.2.1"
             case .v5_6:
-                return "Xcode 13.3.1"
+                return "Xcode 13.4.0"
             default:
                 return nil
         }

--- a/Sources/App/Core/SwiftVersion+Build.swift
+++ b/Sources/App/Core/SwiftVersion+Build.swift
@@ -36,7 +36,7 @@ extension SwiftVersion {
             case .v5_5:
                 return "Xcode 13.2.1"
             case .v5_6:
-                return "Xcode 13.4.0"
+                return "Xcode 13.4.1"
             default:
                 return nil
         }

--- a/Sources/App/Core/SwiftVersion+Build.swift
+++ b/Sources/App/Core/SwiftVersion+Build.swift
@@ -27,7 +27,6 @@ extension SwiftVersion {
     }
 
     var xcodeVersion: String? {
-        // Match with https://gitlab.com/finestructure/swiftpackageindex-builder/-/blob/main/Sources/BuilderCore/SwiftVersion.swift#L41
         // NB: this is used for display purposes and not critical for compiler selection
         switch self {
             case .v5_3:

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.html
@@ -99,7 +99,7 @@
             <a href="/foo/bar">Bar</a> with 
             <strong>Swift 5.6</strong> for 
             <strong>iOS</strong> using 
-            <strong>Xcode 13.3.0</strong>.
+            <strong>Xcode 13.4.0</strong>.
           </p>
           <h3>Build Command</h3>
           <pre>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.html
@@ -99,7 +99,7 @@
             <a href="/foo/bar">Bar</a> with 
             <strong>Swift 5.6</strong> for 
             <strong>iOS</strong> using 
-            <strong>Xcode 13.4.0</strong>.
+            <strong>Xcode 13.4.1</strong>.
           </p>
           <h3>Build Command</h3>
           <pre>


### PR DESCRIPTION
Fixes #1749

We should upgrade our build infrastructure to match the latest Xcode and Swift patch.

This change is not urgent at all and probably shouldn't be done until we're fully deployed with DocC, but I was doing builder maintenance this morning and got a start on it by installing 13.3.1 on all Mac build machines.

Checklist:

- [x] Mac build machines have Xcode 13.4.0 installed
- [x] Builder upgraded to target Xcode 13.4.0 on Mac and 5.6.1 on Linux ([MR!116](https://gitlab.com/finestructure/swiftpackageindex-builder/-/merge_requests/116))
- [ ] Xcode 13.3.0 removed from Mac build machines (post-deploy)
- [ ] More?

We won't need to delete build records as we certainly shouldn't re-process everything 5.6 for this. I'll need your input @finestructure on whether anything needs changing with the DB as the `swift_version` field on existing records specifically refers to Swift 5.6.0, and I believe the change in `SwiftVersion+Build.swift` will change that.