### PR TITLE
Remove "Versions" sidebar heading

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -260,6 +260,7 @@ enum PackageShow {
         func sidebarVersions() -> Node<HTML.BodyContext> {
             .section(
                 .class("sidebar_versions"),
+                .ariaLabel("Versions"),
                 .ul(
                     model.stableReleaseMetadata(),
                     model.betaReleaseMetadata(),

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -260,7 +260,6 @@ enum PackageShow {
         func sidebarVersions() -> Node<HTML.BodyContext> {
             .section(
                 .class("sidebar_versions"),
-                .h3("Versions"),
                 .ul(
                     model.stableReleaseMetadata(),
                     model.betaReleaseMetadata(),

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -285,7 +285,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -286,7 +286,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -285,7 +285,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -286,7 +286,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -282,7 +282,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -283,7 +283,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -315,7 +315,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -316,7 +316,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -409,7 +409,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -408,7 +408,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -278,7 +278,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -279,7 +279,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -175,7 +175,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -176,7 +176,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -285,7 +285,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -286,7 +286,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -285,7 +285,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -284,7 +284,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -285,7 +285,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -286,7 +286,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -225,7 +225,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -224,7 +224,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
@@ -285,7 +285,7 @@
               </ul>
             </section>
             <hr class="minor"/>
-            <section class="sidebar_versions">
+            <section class="sidebar_versions" aria-label="Versions">
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
@@ -286,7 +286,6 @@
             </section>
             <hr class="minor"/>
             <section class="sidebar_versions">
-              <h3>Versions</h3>
               <ul>
                 <li class="stable">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">


### PR DESCRIPTION
Merge after #1756

As discussed, removes the "Versions" header that wasn't doing enough!