### PR TITLE
Docc 404

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -91,7 +91,9 @@ struct PackageController {
         let res = try await Current.fetchDocumentation(req.client, url)
         guard (200..<399).contains(res.status.code) else {
             // Convert anything that isn't a 2xx or 3xx into a 404
-            throw Abort(.notFound)
+            return DocumentationErrorPage.View(path: req.url.path, error: Abort(res.status))
+                .document()
+                .encodeResponse(for: req, status: .notFound)
         }
 
         switch fragment {

--- a/Sources/App/Views/Error/DocumentationErrorPage.swift
+++ b/Sources/App/Views/Error/DocumentationErrorPage.swift
@@ -20,7 +20,6 @@ enum DocumentationErrorPage {
     final class View: PublicPage {
         let error: AbortError
 
-
         init(path: String, error: AbortError) {
             self.error = error
             super.init(path: path)

--- a/Sources/App/Views/Error/DocumentationErrorPage.swift
+++ b/Sources/App/Views/Error/DocumentationErrorPage.swift
@@ -1,0 +1,64 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Plot
+import Vapor
+
+enum DocumentationErrorPage {
+
+    final class View: PublicPage {
+        let error: AbortError
+
+
+        init(path: String, error: AbortError) {
+            self.error = error
+            super.init(path: path)
+        }
+
+        override func pageTitle() -> String? {
+            "Documentation Error"
+        }
+
+        override func content() -> Node<HTML.BodyContext> {
+            .section(
+                .class("error_message"),
+                .h4(.text("Documentation for this package is not yet available")),
+                .p("For newly added packages or packages which have only just started to adopt DocC documentation, it can take a short while for documentation to be generated and available."),
+                .p(
+                    .text("If this error persists, please "),
+                    .a(
+                        .href(ExternalURL.raiseNewIssue),
+                        "raise an issue"
+                    ),
+                    .text(".")
+                ),
+                .p(
+                    .text("From here, you'll want to "),
+                    .a(
+                        .href(SiteURL.home.relativeURL()),
+                        "go to the home page"
+                    ),
+                    .text(" or "),
+                    .a(
+                        .href(SiteURL.search.relativeURL()),
+                        "search for a package"
+                    ),
+                    .text(".")
+                )
+            )
+        }
+
+    }
+
+}

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -264,7 +264,7 @@ class PackageController_routesTests: AppTestCase {
     }
 
     func test_documentation_404() throws {
-        // Test conversion of any doc fetching errors into 404s
+        // Test conversion of any doc fetching errors into 404s and ensure missing/bad documentation shows our documentation specific error page.
         // setup
         Current.fetchDocumentation = { _, uri in .init(status: .badRequest) }
         let pkg = try savePackage(on: app.db, "1")
@@ -277,11 +277,13 @@ class PackageController_routesTests: AppTestCase {
         // test base url
         try app.test(.GET, "/owner/package/1.2.3/documentation") {
             XCTAssertEqual($0.status, .notFound)
+            XCTAssert($0.body.asString().contains("Documentation for this package is not yet available"))
         }
 
         // test path a/b
         try app.test(.GET, "/owner/package/1.2.3/documentation/a/b") {
             XCTAssertEqual($0.status, .notFound)
+            XCTAssert($0.body.asString().contains("Documentation for this package is not yet available"))
         }
     }
 

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -210,7 +210,13 @@ class WebpageSnapshotTests: SnapshotTestCase {
         
         assertSnapshot(matching: page, as: .html)
     }
-    
+
+    func test_DocumentationErrorPageView() throws {
+        let page = { DocumentationErrorPage.View(path: "", error: Abort(.notFound)).document() }
+
+        assertSnapshot(matching: page, as: .html)
+    }
+
     func test_MarkdownPage() throws {
         let page = { MarkdownPage(path: "", "privacy.md").document() }
         

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocumentationErrorPageView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocumentationErrorPageView.1.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en"><!--Version: test--><!--DB Id: db-id-->
+  <head>
+    <meta name="robots" content="noindex"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="UTF-8"/>
+    <meta name="og:site_name" content="The Swift Package Index"/>
+    <link rel="canonical" href="http://localhost:8080/"/>
+    <meta name="twitter:url" content="http://localhost:8080/"/>
+    <meta name="og:url" content="http://localhost:8080/"/>
+    <title>Documentation Error &ndash; Swift Package Index</title>
+    <meta name="twitter:title" content="Documentation Error &ndash; Swift Package Index"/>
+    <meta name="og:title" content="Documentation Error &ndash; Swift Package Index"/>
+    <meta name="description" content="The Swift Package Index is the place to find the best Swift packages."/>
+    <meta name="twitter:description" content="The Swift Package Index is the place to find the best Swift packages."/>
+    <meta name="og:description" content="The Swift Package Index is the place to find the best Swift packages."/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:image" content="http://localhost:8080/images/logo.png"/>
+    <meta name="og:image" content="http://localhost:8080/images/logo.png"/>
+    <link rel="shortcut icon" href="/images/logo-small.png" type="image/png"/>
+    <link rel="stylesheet" href="/main.css?test" data-turbolinks-track="reload"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
+    <script src="/main.js?test" data-turbolinks-track="reload" defer></script>
+  </head>
+  <body>
+    <div class="staging">Staging / Development</div>
+    <header>
+      <div class="inner">
+        <a href="/">
+          <h1>
+            <img alt="The Swift Package Index logo." src="/images/logo.svg"/>Swift Package Index
+          </h1>
+        </a>
+        <nav>
+          <ul>
+            <li class="menu_scta">
+              <a id="menu_scta" href="https://github.com/sponsors/SwiftPackageIndex"></a>
+              <div id="menu_scta_help">
+                <p>The Swift Package Index is an open-source project entirely funded by community donations.</p>
+                <p>Please consider sponsoring this project. 
+                  <strong>Thank you!</strong>
+                </p>
+              </div>
+            </li>
+            <li>
+              <a href="/add-a-package">Add a Package</a>
+            </li>
+            <li>
+              <a href="https://blog.swiftpackageindex.com">Blog</a>
+            </li>
+            <li>
+              <a href="/faq">FAQ</a>
+            </li>
+            <li class="search">
+              <form action="/search">
+                <input id="query" name="query" type="search" placeholder="Search" spellcheck="false" autocomplete="off" data-gramm="false" data-focus="false"/>
+                <button type="submit">
+                  <div title="Search"></div>
+                </button>
+              </form>
+              <a href="/search" title="Search"></a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <main>
+      <div class="inner">
+        <section class="error_message">
+          <h4>Documentation for this package is not yet available</h4>
+          <p>For newly added packages or packages which have only just started to adopt DocC documentation, it can take a short while for documentation to be generated and available.</p>
+          <p>If this error persists, please 
+            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new/choose">raise an issue</a>.
+          </p>
+          <p>From here, you'll want to 
+            <a href="/">go to the home page</a> or 
+            <a href="/search">search for a package</a>.
+          </p>
+        </section>
+      </div>
+    </main>
+    <footer>
+      <div class="inner">
+        <nav>
+          <ul>
+            <li>
+              <a href="https://blog.swiftpackageindex.com">Blog</a>
+            </li>
+            <li>
+              <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a>
+            </li>
+            <li>
+              <a href="/privacy">Privacy and Cookies</a>
+            </li>
+            <li>
+              <a href="https://swiftpackageindex.statuspage.io">Uptime and System Status</a>
+            </li>
+            <li>
+              <a href="/build-monitor">Build System Monitor</a>
+            </li>
+            <li>
+              <a href="https://twitter.com/swiftpackages">Twitter</a>
+            </li>
+          </ul>
+          <small>The Swift Package Index is entirely funded by community sponsorship. Thank you to 
+            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server#funding-and-sponsorship">all our sponsors for their generosity</a>.
+          </small>
+        </nav>
+      </div>
+    </footer>
+    <div class="staging">Staging / Development</div>
+  </body>
+</html>


### PR DESCRIPTION
This adds a doc-specific error page, raised when we encounter any non-`(200..<399)` status code from S3 requests:

<img width="1184" alt="CleanShot 2022-05-24 at 11 26 10@2x" src="https://user-images.githubusercontent.com/65520/170000045-dcc15f07-1abc-412a-9424-3096fe0736bc.png">

Fixes #1751 