### PR TITLE
Show a "Targets" bar as part of the DocC generated header

### DIFF
--- a/FrontEnd/docc.scss
+++ b/FrontEnd/docc.scss
@@ -32,7 +32,7 @@ footer.spi {
   .inner {
     margin: 0 auto;
     max-width: 980px;
-    padding: 20px 10px;
+    padding: 10px 10px;
   }
 
   a {
@@ -47,69 +47,65 @@ footer.spi {
 }
 
 header.spi .inner {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px;
-
-  @media screen and (max-width: $mobile-breakpoint) {
-    grid-template-columns: 1fr;
-
-    a {
-      margin: 0 auto;
-    }
-  }
-
-  h1 {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    font-size: 23px;
-    color: inherit;
-
-    img {
-      margin-right: 10px;
-      max-width: 64px;
-    }
-  }
-
-  .menu {
-    display: flex;
-    align-items: center;
-    justify-self: end;
+  &.branding_and_menu {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
 
     @media screen and (max-width: $mobile-breakpoint) {
-      justify-self: center;
+      grid-template-columns: 1fr;
+
+      a {
+        margin: 0 auto;
+      }
     }
 
-    a {
-      padding: 3px;
-      font-size: 15px;
-      font-weight: 600;
-    }
-
-    ul {
-      margin: 0;
-      padding: 0;
+    h1 {
       display: flex;
       flex-direction: row;
-      flex-wrap: wrap;
-      justify-content: center;
       align-items: center;
+      font-size: 23px;
+      color: inherit;
 
-      li {
-        margin: 0 3px;
-        list-style: none;
+      img {
+        margin-right: 10px;
+        max-width: 64px;
+      }
+    }
+
+    .menu {
+      display: flex;
+      align-items: center;
+      justify-self: end;
+
+      @media screen and (max-width: $mobile-breakpoint) {
+        justify-self: center;
+      }
+
+      a {
+        padding: 3px;
+        font-size: 15px;
+        font-weight: 600;
+      }
+
+      ul {
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: row;
+        flex-wrap: wrap;
+        justify-content: center;
+        align-items: center;
+
+        li {
+          margin: 0 3px;
+          list-style: none;
+        }
       }
     }
   }
 
-  .breadcrumbs {
-    grid-column-start: span 2;
-
-    @media screen and (max-width: $mobile-breakpoint) {
-      grid-column-start: unset;
-    }
-
+  &.breadcrumbs {
     ul {
       display: flex;
       gap: 20px;
@@ -146,6 +142,44 @@ header.spi .inner {
             margin-left: 20px;
           }
         }
+      }
+    }
+  }
+
+  &.targets {
+    position: relative;
+
+    &::before {
+      content: '';
+      background-color: rgba(255, 255, 255, 0.15);
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      left: 0;
+      width: 100vw;
+      margin-left: 50%;
+      transform: translateX(-50%);
+      z-index: -1;
+
+      @media (prefers-color-scheme: dark) {
+        background-color: rgba(0, 0, 0, 0.25);
+      }
+    }
+
+    ul {
+      display: flex;
+      gap: 20px;
+      padding: 0;
+      list-style: none;
+
+      @media screen and (max-width: $mobile-breakpoint) {
+        flex-direction: column;
+        gap: 0;
+      }
+
+      li:first-of-type {
+        font-weight: bold;
       }
     }
   }

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -110,8 +110,8 @@ struct PackageController {
                                                                  repositoryOwnerName: queryResult.repository.ownerName ?? owner,
                                                                  repositoryName: repository,
                                                                  packageName: queryResult.version.packageName ?? repository,
-                                                                 targets: queryResult.version.spiManifest?.allDocumentationTargets() ?? [],
                                                                  reference: reference,
+                                                                 targets: queryResult.version.spiManifest?.allDocumentationTargets() ?? [],
                                                                  rawHtml: body.asString())
                 else {
                     return try await res.encodeResponse(

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -102,6 +102,7 @@ struct PackageController {
                 guard let queryResult = try await Joined3<Package, Repository, Version>
                     .query(on: req.db, owner: owner, repository: repository, version: .defaultBranch)
                     .field(Version.self, \.$packageName)
+                    .field(Version.self, \.$spiManifest)
                     .field(Repository.self, \.$ownerName)
                     .first(),
                       let body = res.body,
@@ -109,6 +110,8 @@ struct PackageController {
                                                                  repositoryOwnerName: queryResult.repository.ownerName ?? owner,
                                                                  repositoryName: repository,
                                                                  packageName: queryResult.version.packageName ?? repository,
+                                                                 targets: queryResult.version.spiManifest?.allDocumentationTargets() ?? [],
+                                                                 reference: reference,
                                                                  rawHtml: body.asString())
                 else {
                     return try await res.encodeResponse(

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -22,16 +22,22 @@ struct DocumentationPageProcessor {
     let repositoryOwnerName: String
     let repositoryName: String
     let packageName: String
+    let reference: String
+    let targets: [String]
 
     init?(repositoryOwner: String,
           repositoryOwnerName: String,
           repositoryName: String,
           packageName: String,
+          targets: [String],
+          reference: String,
           rawHtml: String) {
         self.repositoryOwner = repositoryOwner
         self.repositoryOwnerName = repositoryOwnerName
         self.repositoryName = repositoryName
         self.packageName = packageName
+        self.reference = reference
+        self.targets = targets
 
         do {
             document = try SwiftSoup.parse(rawHtml)
@@ -72,7 +78,7 @@ struct DocumentationPageProcessor {
             .header(
                 .class("spi"),
                 .div(
-                    .class("inner"),
+                    .class("inner branding_and_menu"),
                     .a(
                         .href("/"),
                         .h1(
@@ -88,13 +94,33 @@ struct DocumentationPageProcessor {
                         .ul(
                             .group(navMenuItems.map { $0.listNode() })
                         )
-                    ),
+                    )
+                ),
+                .div(
+                    .class("inner breadcrumbs"),
                     .nav(
-                        .class("breadcrumbs"),
                         .ul(
                             .group(breadcrumbs.map { $0.listNode() })
                         )
                     )
+                ),
+                .if(targets.count > 1, .div(
+                    .class("inner targets"),
+                    .nav(
+                        .ul(
+                            .li(
+                                .text("Documentation for:")
+                            ),
+                            .forEach(targets, { target in
+                                    .li(
+                                        .a(
+                                            .href(relativeDocumentationURL(target: target)),
+                                            .text(target)
+                                        )
+                                    )
+                            })
+                        )
+                    ))
                 )
             )
         ).render()
@@ -157,5 +183,10 @@ struct DocumentationPageProcessor {
         } catch {
             return "An error occurred while rendering processed documentation."
         }
+    }
+
+    // Note: When this gets merged back with the refactored SiteURL, note that it's duplicated in `PackageShow.Model`.
+    func relativeDocumentationURL(target: String) -> String {
+        "/\(repositoryOwner)/\(repositoryName)/\(reference)/documentation/\(target.lowercased())"
     }
 }

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -29,8 +29,8 @@ struct DocumentationPageProcessor {
           repositoryOwnerName: String,
           repositoryName: String,
           packageName: String,
-          targets: [String],
           reference: String,
+          targets: [String],
           rawHtml: String) {
         self.repositoryOwner = repositoryOwner
         self.repositoryOwnerName = repositoryOwnerName

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -176,6 +176,7 @@ extension PackageShow.Model {
         "https://github.com/\(repositoryOwner)/\(repositoryName)"
     }
 
+    // Note: When this gets merged back with the refactored SiteURL, note that it's duplicated in `DocumentationPageProcessor`.
     func relativeDocumentationURL(reference: String, target: String) -> String {
         "/\(repositoryOwner)/\(repositoryName)/\(reference)/documentation/\(target.lowercased())"
     }

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -354,8 +354,8 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  repositoryOwnerName: "Owner Name",
                                                                  repositoryName: "package",
                                                                  packageName: "Package Name",
-                                                                 targets: [],
                                                                  reference: "main",
+                                                                 targets: [],
                                                                  rawHtml: doccHtml))
 
         assertSnapshot(matching: processor.processedPage, as: .html)
@@ -368,8 +368,8 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  repositoryOwnerName: "Owner Name",
                                                                  repositoryName: "package",
                                                                  packageName: "Package Name",
-                                                                 targets: ["Target1", "Target2"],
                                                                  reference: "main",
+                                                                 targets: ["Target1", "Target2"],
                                                                  rawHtml: doccHtml))
 
         assertSnapshot(matching: processor.processedPage, as: .html)

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -347,7 +347,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         assertSnapshot(matching: page, as: .html)
     }
 
-    func test_DocC_Template() throws {
+    func test_DocCTemplate() throws {
         let doccTemplatePath = fixturesDirectory().appendingPathComponent("docc-template.html").path
         let doccHtml = try String(contentsOfFile: doccTemplatePath)
         let processor = try XCTUnwrap(DocumentationPageProcessor(repositoryOwner: "owner",

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -354,6 +354,8 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  repositoryOwnerName: "Owner Name",
                                                                  repositoryName: "package",
                                                                  packageName: "Package Name",
+                                                                 targets: [],
+                                                                 reference: "main",
                                                                  rawHtml: doccHtml))
 
         assertSnapshot(matching: processor.processedPage, as: .html)

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -360,4 +360,18 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
         assertSnapshot(matching: processor.processedPage, as: .html)
     }
+
+    func test_DocCTemplate_multipleTargets() throws {
+        let doccTemplatePath = fixturesDirectory().appendingPathComponent("docc-template.html").path
+        let doccHtml = try String(contentsOfFile: doccTemplatePath)
+        let processor = try XCTUnwrap(DocumentationPageProcessor(repositoryOwner: "owner",
+                                                                 repositoryOwnerName: "Owner Name",
+                                                                 repositoryName: "package",
+                                                                 packageName: "Package Name",
+                                                                 targets: ["Target1", "Target2"],
+                                                                 reference: "main",
+                                                                 rawHtml: doccHtml))
+
+        assertSnapshot(matching: processor.processedPage, as: .html)
+    }
 }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
@@ -10,7 +10,7 @@
  </head> 
  <body>
   <header class="spi">
-   <div class="inner">
+   <div class="inner branding_and_menu">
     <a href="/"><h1><img src="/images/logo.svg" alt="Swift Package Index Logo">Swift Package Index</h1></a>
     <nav class="menu">
      <ul>
@@ -20,7 +20,9 @@
       <li><a href="/search">Package Search</a></li>
      </ul>
     </nav>
-    <nav class="breadcrumbs">
+   </div>
+   <div class="inner breadcrumbs">
+    <nav>
      <ul>
       <li><a href="/">Home</a></li>
       <li><a href="/owner">Owner Name</a></li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleTargets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleTargets.1.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+ <head> 
+  <meta charset="UTF-8"> 
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
+  <title>DocC Template Page</title> 
+  <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
+  <script src="/path/to/some/script.js?12345" defer></script> 
+  <link rel="stylesheet" href="/docc.css?test">
+ </head> 
+ <body>
+  <header class="spi">
+   <div class="inner branding_and_menu">
+    <a href="/"><h1><img src="/images/logo.svg" alt="Swift Package Index Logo">Swift Package Index</h1></a>
+    <nav class="menu">
+     <ul>
+      <li><a href="/add-a-package">Add a Package</a></li>
+      <li><a href="https://blog.swiftpackageindex.com">Blog</a></li>
+      <li><a href="/faq">FAQ</a></li>
+      <li><a href="/search">Package Search</a></li>
+     </ul>
+    </nav>
+   </div>
+   <div class="inner breadcrumbs">
+    <nav>
+     <ul>
+      <li><a href="/">Home</a></li>
+      <li><a href="/owner">Owner Name</a></li>
+      <li><a href="/owner/package">Package Name</a></li>
+      <li>Documentation</li>
+     </ul>
+    </nav>
+   </div>
+   <div class="inner targets">
+    <nav>
+     <ul>
+      <li>Documentation for:</li>
+      <li><a href="/owner/package/main/documentation/target1">Target1</a></li>
+      <li><a href="/owner/package/main/documentation/target2">Target2</a></li>
+     </ul>
+    </nav>
+   </div>
+  </header> 
+  <p>This is DocC content.</p>   
+  <footer class="spi">
+   <div class="inner">
+    <nav>
+     <ul>
+      <li><a href="https://blog.swiftpackageindex.com">Blog</a></li>
+      <li><a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a></li>
+      <li><a href="/privacy">Privacy and Cookies</a></li>
+      <li><a href="https://swiftpackageindex.statuspage.io">Uptime and System Status</a></li>
+      <li><a href="https://twitter.com/swiftpackages">Twitter</a></li>
+     </ul>
+     <small>The Swift Package Index is entirely funded by sponsorship. Thank you to <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server#funding-and-sponsorship">all our sponsors for their generosity</a>.</small>
+    </nav>
+   </div>
+  </footer>
+ </body>
+</html>


### PR DESCRIPTION
Fixes #1743 

When there is > 1 documentation target:

<img width="1040" alt="Screenshot 2022-05-24 at 20 37 18@2x" src="https://user-images.githubusercontent.com/5180/170118865-a5d401ff-a1a8-4466-aa97-eaf16c5d88b5.png">
<img width="1040" alt="Screenshot 2022-05-24 at 20 37 44@2x" src="https://user-images.githubusercontent.com/5180/170118872-39bdcf51-5aaf-4b1e-8f18-bc3e5f4b5919.png">

When there is exactly 1 documentation target:

<img width="1040" alt="Screenshot 2022-05-24 at 20 38 23@2x" src="https://user-images.githubusercontent.com/5180/170118875-64c21f5b-1369-4bb2-9236-6cfcbcf7a198.png">
<img width="1040" alt="Screenshot 2022-05-24 at 20 38 32@2x" src="https://user-images.githubusercontent.com/5180/170118879-1382a745-a2a5-426e-b9aa-6a9a53085a8a.png">
