### PR TITLE
Eliminate parsing of dependency code snippet from release url

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -101,14 +101,14 @@ enum PackageShow {
                         .h4("When working with an Xcode project:"),
                         model.xcodeprojDependencyForm(packageUrl: model.url),
                         .h4("When working with a Swift Package Manager manifest:"),
-                        .unwrap(model.releases.stable, {
-                            model.spmDependencyForm(releaseLink: $0.link, cssClass: "stable")
+                        .unwrap(model.dependencyCodeSnippets[.release], {
+                            model.spmDependencyForm(link: $0, cssClass: "stable")
                         }),
-                        .unwrap(model.releases.beta, {
-                            model.spmDependencyForm(releaseLink: $0.link, cssClass: "beta")
+                        .unwrap(model.dependencyCodeSnippets[.preRelease], {
+                            model.spmDependencyForm(link: $0, cssClass: "beta")
                         }),
-                        .unwrap(model.releases.latest, {
-                            model.spmDependencyForm(releaseLink: $0.link, cssClass: "branch")
+                        .unwrap(model.dependencyCodeSnippets[.defaultBranch], {
+                            model.spmDependencyForm(link: $0, cssClass: "branch")
                         })
                     )
                 ),

--- a/Tests/AppTests/Mocks/PackageShowModel+mock.swift
+++ b/Tests/AppTests/Mocks/PackageShowModel+mock.swift
@@ -126,7 +126,13 @@ extension PackageShow.Model {
             title: "Alamofire",
             url: "https://github.com/Alamofire/Alamofire.git",
             score: 10,
-            isArchived: false
+            isArchived: false,
+            dependencyCodeSnippets: Self.packageDependencyCodeSnippets(
+                packageURL: "https://github.com/Alamofire/Alamofire.git",
+                defaultBranchReference: .branch("main"),
+                releaseReference: .tag(5, 2, 0),
+                preReleaseReference: .tag(5, 3, 0, "beta.1")
+            )
         )
     }
 }

--- a/Tests/AppTests/PackageShowModelTests.swift
+++ b/Tests/AppTests/PackageShowModelTests.swift
@@ -327,19 +327,41 @@ class PackageShowModelTests: SnapshotTestCase {
     func test_packageDependencyCodeSnippet() {
         XCTAssertEqual(
             PackageShow.Model.packageDependencyCodeSnippet(
-                ref: "6.0.0-b1",
-                url: "https://github.com/Alamofire/Alamofire/releases/tag/6.0.0-b1"),
+                ref: .tag(.init("6.0.0-b1")!),
+                packageURL: "https://github.com/Alamofire/Alamofire.git"
+            ),
             ".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, from: &quot;6.0.0-b1&quot;)")
         XCTAssertEqual(
             PackageShow.Model.packageDependencyCodeSnippet(
-                ref: "5.5.0",
-                url: "https://github.com/Alamofire/Alamofire/releases/tag/5.5.0"),
-            ".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, from: &quot;5.5.0&quot;)")
+                ref: .tag(.init("5.5.0")!),
+                packageURL: "https://github.com/Alamofire/Alamofire.git"
+            ),
+            ".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, from: &quot;5.5.0&quot;)"
+        )
         XCTAssertEqual(
             PackageShow.Model.packageDependencyCodeSnippet(
-                ref: "master",
-                url: "https://github.com/Alamofire/Alamofire.git"),
-            ".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;master&quot;)")
+                ref: .branch("main"),
+                packageURL: "https://github.com/Alamofire/Alamofire.git"
+            ),
+            ".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)"
+        )
+    }
+
+    func test_packageDependencyCodeSnippets() {
+        XCTAssertEqual(
+            PackageShow.Model.packageDependencyCodeSnippets(
+                packageURL: "https://github.com/Alamofire/Alamofire.git",
+                defaultBranchReference: .branch("main"),
+                releaseReference: .tag(1, 2, 3),
+                preReleaseReference: nil
+            ),
+            [
+                .defaultBranch: .init(label: "main",
+                                      url:".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)"),
+                .release: .init(label: "1.2.3",
+                                url: ".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, from: &quot;1.2.3&quot;)")
+            ]
+        )
     }
 
     func test_relativeDocumentationURL() throws {

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
@@ -118,7 +118,7 @@
                 <span class="branch">main</span>
               </p>
               <form class="copyable_input">
-                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire&quot;, branch: &quot;main&quot;)" readonly/>
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
               </form>
             </section>
           </div>


### PR DESCRIPTION
Fixes #1565 

Instead of prying apart a release URL to come up with the correct code snippet we're constructing it up front from the available data without parsing.

This should also make it easier to support multiple products at some point.