### PR TITLE
Re-enable tests (passing on macOS 12.4, Xcode 13.4, arm64)

### DIFF
--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -38,9 +38,6 @@ class ErrorReportingTests: AppTestCase {
     }
     
     func test_Ingestor_error_reporting() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // setup
         try savePackages(on: app.db, ["1", "2"], processingStage: .reconciliation)
         Current.fetchMetadata = { _, _ in throw AppError.invalidPackageUrl(nil, "foo") }

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -22,9 +22,6 @@ import XCTest
 class IngestorTests: AppTestCase {
     
     func test_ingest_basic() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // setup
         Current.fetchMetadata = { _, pkg in .mock(for: pkg) }
         let packages = ["https://github.com/finestructure/Gala",
@@ -59,9 +56,6 @@ class IngestorTests: AppTestCase {
     }
     
     func test_fetchMetadata() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // Test completion of all fetches despite early error
         // setup
         enum TestError: Error, Equatable {
@@ -311,9 +305,6 @@ class IngestorTests: AppTestCase {
     }
     
     func test_partial_save_issue() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // Test to ensure futures are properly waited for and get flushed to the db in full
         // setup
         Current.fetchMetadata = { _, pkg in .mock(for: pkg) }
@@ -330,9 +321,6 @@ class IngestorTests: AppTestCase {
     }
     
     func test_ingest_badMetadata() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // setup
         let urls = ["https://github.com/foo/1",
                     "https://github.com/foo/2",
@@ -368,9 +356,6 @@ class IngestorTests: AppTestCase {
     }
     
     func test_ingest_unique_owner_name_violation() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // Test error behaviour when two packages resolving to the same owner/name are ingested:
         //   - don't update package
         //   - don't create repository records
@@ -437,9 +422,6 @@ class IngestorTests: AppTestCase {
     }
     
     func test_issue_761_no_license() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/761
         // setup
         let packages = try await savePackagesAsync(on: app.db, ["https://github.com/foo/1"])

--- a/Tests/AppTests/MetricsTests.swift
+++ b/Tests/AppTests/MetricsTests.swift
@@ -97,9 +97,6 @@ class MetricsTests: AppTestCase {
     }
 
     func test_ingestDurationSeconds() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // setup
         let pkg = try savePackage(on: app.db, "1")
 

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -267,9 +267,6 @@ final class PackageTests: AppTestCase {
     }
 
     func test_isNew() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // setup
         let url = "1".asGithubUrl
         Current.fetchMetadata = { _, pkg in .mock(for: pkg) }

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -130,9 +130,6 @@ class PipelineTests: AppTestCase {
     }
     
     func test_processing_pipeline() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // Test pipeline pick-up end to end
         // setup
         let urls = ["1", "2", "3"].asGithubUrls

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -239,9 +239,6 @@ class TwitterTests: AppTestCase {
     }
 
     func test_endToEnd() async throws {
-        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1623
-        try XCTSkipIf(true)
-
         // setup
         Current.twitterCredentials = {
             .init(apiKey: ("key", "secret"), accessToken: ("key", "secret"))


### PR DESCRIPTION
Just noticed these were still disabled and are now working, at least on macOS - let's see what the pipeline say about Linux.