### PR TITLE
Make the announcement banner global across the whole site

### DIFF
--- a/FrontEnd/styles/base.scss
+++ b/FrontEnd/styles/base.scss
@@ -219,7 +219,7 @@ a.big_button {
 
 .announcement {
   margin: 0;
-  padding: 16px 0;
+  padding: 8px 0;
   background-color: var(--announcement-background);
   text-align: center;
 }

--- a/Sources/App/Views/Home/HomeIndex+View.swift
+++ b/Sources/App/Views/Home/HomeIndex+View.swift
@@ -40,24 +40,13 @@ enum HomeIndex {
         }
         
         override func preMain() -> Node<HTML.BodyContext> {
-            .group(
-                .p(
-                    .class("announcement"),
-                    .text("Join us in celebrating "),
-                    .a(
-                        .href("https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/"),
-                        "two years of the Swift Package Index"
-                    ),
-                    .text("! 🎂")
-                ),
-                .section(
-                    .class("search home"),
-                    .div(
-                        .class("inner"),
-                        .h3("The place to find Swift packages."),
-                        .searchForm(),
-                        .unwrap(model.statsClause()) { $0 }
-                    )
+            .section(
+                .class("search home"),
+                .div(
+                    .class("inner"),
+                    .h3("The place to find Swift packages."),
+                    .searchForm(),
+                    .unwrap(model.statsClause()) { $0 }
                 )
             )
         }

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -169,6 +169,7 @@ class PublicPage {
             bodyComments(),
             stagingBanner(),
             header(),
+            announcementBanner(),
             preMain(),
             breadcrumbNode(),
             main(),
@@ -228,6 +229,18 @@ class PublicPage {
     /// - Returns: An array of `NavMenuItem` items used in `header`.
     func navMenuItems() -> [NavMenuItem] {
         [.sponsorCTA, .addPackage, .blog, .faq, .search]
+    }
+
+    func announcementBanner() -> Node<HTML.BodyContext> {
+        .p(
+            .class("announcement"),
+            .text("Join us in celebrating "),
+            .a(
+                .href("https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/"),
+                "two years of the Swift Package Index"
+            ),
+            .text("! 🎂")
+        )
     }
 
     /// Optional content that will be inserted in between the page header and the main content for the page.

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_AuthorShow.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_AuthorShow.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildMonitorIndex.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildMonitorIndex.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocumentationErrorPageView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocumentationErrorPageView.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <main>
       <div class="inner">
         <section class="error_message">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ErrorPageView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ErrorPageView.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <main>
       <div class="inner">
         <section class="error_message">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_KeywordShow.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_KeywordShow.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MaintainerInfoIndex.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MaintainerInfoIndex.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MarkdownPage.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MarkdownPage.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MarkdownPageStyling.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MarkdownPageStyling.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <main>
       <div class="inner"><h1>Header One</h1><h2>Header Two</h2><h3>Header Three</h3><h4>Header Four</h4><h5>Header Five</h5><h6>Header Six</h6><p># Not a Header</p><h2>Basic Formatting</h2><p><em>Italic</em> or <em>Italic</em> <strong>Bold</strong> or <strong>Bold</strong> <s>Strikethrough</s></p><h2>Horizontal Lines</h2><hr><hr><h2>Lists</h2><ul><li>List Item One</li></ul><ul><li>List Item Two</li></ul><ol><li>List Item One</li></ol><ol start="2"><li>List Item Two<ul><li>List Item Two -&gt; Indented<ul><li>List Item Two -&gt; Indented -&gt; Indented</li></ul></li></ul></li></ol><ol start="100"><li>Start with 100</li><li>Continue to 101</li></ol><p>Inline <code>code</code> using backticks.</p><h2>Code</h2><pre><code>$ spi search Markdown
 </code></pre><pre><code class="language-swift">class SyntaxHighlighter {

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_missingPackage.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_missingPackage.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <main>
       <div class="inner">
         <h2>Package not found</h2>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
@@ -68,6 +68,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow.1.html
@@ -59,6 +59,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow_withFilters.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_SearchShow_withFilters.1.html
@@ -59,6 +59,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">Join us in celebrating 
+      <a href="https://blog.swiftpackageindex.com/posts/two-years-of-the-swift-package-index/">two years of the Swift Package Index</a>! 🎂
+    </p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>


### PR DESCRIPTION
As discussed.

This PR can be merged any time. The next PR changes the banner to the DocC announcement, so shouldn't be merged until tomorrow.

<img width="1004" alt="Screenshot 2022-06-02 at 16 45 33@2x" src="https://user-images.githubusercontent.com/5180/171669117-263e8810-1477-4934-89db-7f852aed81df.png">

<img width="1004" alt="Screenshot 2022-06-02 at 16 45 49@2x" src="https://user-images.githubusercontent.com/5180/171669142-dcb0c3ae-2caf-458a-9023-ae2c24678b6e.png">