### PR TITLE
Fix fetch doc archives

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -301,8 +301,13 @@ func ingestFromS3(database: Database,
         logger.debug("ingestFromS3 versions with doc targets: \(versions.count)")
         guard !versions.isEmpty else { continue }
 
-        guard let owner = pkg.repository?.owner,
-              let repository = pkg.repository?.name else { continue }
+        let repo = try await Repository.query(on: database)
+            .filter(\.$package.$id == pkg.model.id!)
+            .field(\.$owner)
+            .field(\.$name)
+            .first()
+        guard let owner = repo?.owner,
+              let repository = repo?.name else { continue }
 
         let prefix = "\(owner)/\(repository)".lowercased()
 

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -128,7 +128,9 @@ func ingest(client: Client,
 #warning("ingestFromS3 temporarily excluded from production")
     if Environment.current != .production {
         logger.debug("Ingesting from S3 ...")
-        try await ingestFromS3(database: database, logger: logger, packages: packages)
+        try await ingestFromS3(database: database,
+                               logger: logger,
+                               packageIDs: packages.compactMap(\.model.id))
     }
 }
 
@@ -277,7 +279,7 @@ func insertOrUpdateRepository(on database: Database,
 ///   - packages: packages to be checked
 func ingestFromS3(database: Database,
                   logger: Logger,
-                  packages: [Joined<Package, Repository>]) async throws {
+                  packageIDs: [Package.Id]) async throws {
 #warning("FIXME: temporary bucket override to point ingestion at prod bucket")
     let awsBucketName = "spi-prod-docs"
 
@@ -292,17 +294,17 @@ func ingestFromS3(database: Database,
     defer { AppMetrics.ingestDurationSeconds?.time(.init(stage: .s3), since: start) }
 
     let versions = try await fetchDocArchiveCandidates(database: database,
-                                                       packageIDs: packages.compactMap(\.model.id))
+                                                       packageIDs: packageIDs)
     logger.debug("ingestFromS3 version candidates: \(versions.count)")
 
-    for pkg in packages {
+    for pkgID in packageIDs {
         let versions = versions
-            .filter { $0.$package.id == pkg.model.id && $0.hasDocumentationTargets }
+            .filter { $0.$package.id == pkgID && $0.hasDocumentationTargets }
         logger.debug("ingestFromS3 versions with doc targets: \(versions.count)")
         guard !versions.isEmpty else { continue }
 
         let repo = try await Repository.query(on: database)
-            .filter(\.$package.$id == pkg.model.id!)
+            .filter(\.$package.$id == pkgID)
             .field(\.$owner)
             .field(\.$name)
             .first()

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -175,7 +175,8 @@ class IngestorTests: AppTestCase {
         }
         let pkg1 = Package(id: .id0, url: "https://github.com/foo/bar1", processingStage: .reconciliation)
         try await pkg1.save(on: app.db)
-        try await Repository(package: pkg1, name: "bar1", owner: "foo").save(on: app.db)
+        // upper case owner to ensure we properly downcase the prefix
+        try await Repository(package: pkg1, name: "bar1", owner: "Foo").save(on: app.db)
         do {
             // first version has a manifest but no doc archives (should be updated)
             try await Version(id: .id2,

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -28,11 +28,19 @@ class IngestorTests: AppTestCase {
         // High level ingest test
         // setup
         Current.fetchMetadata = { _, pkg in .mock(for: pkg) }
-        let packages = ["https://github.com/finestructure/Gala",
-                        "https://github.com/finestructure/Rester",
-                        "https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server"]
-            .map { Package(url: $0, processingStage: .reconciliation) }
+        Current.fetchS3DocArchives = { _, _, _, _ in [.mock("foo", "bar", "main", "p1", "P1")] }
+        let packages = [(UUID.id0, "https://github.com/finestructure/Gala"),
+                        (.id1, "https://github.com/finestructure/Rester"),
+                        (.id2, "https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server")]
+            .map { Package(id: $0, url: $1, processingStage: .reconciliation) }
         try await packages.save(on: app.db)
+        try await Version(id: .id1,
+                          package: packages[2],
+                          commit: "commit",
+                          commitDate: .t0,
+                          docArchives: nil,
+                          reference: .branch("main"),
+                          spiManifest: .init(documentationTargets: ["target"])).save(on: app.db)
         let lastUpdate = Date()
 
         // MUT

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -220,10 +220,9 @@ class IngestorTests: AppTestCase {
             .save(on: app.db)
         }
         let lastUpdate = Date()
-        let packages = try await Package.fetchCandidates(app.db, for: .ingestion, limit: 10).get()
 
         // MUT
-        try await ingestFromS3(database: app.db, logger: app.logger, packages: packages)
+        try await ingestFromS3(database: app.db, logger: app.logger, packageIDs: [.id0, .id1])
 
         // validate
         let v2 = try await Version.find(.id2, on: app.db).unwrap()
@@ -260,11 +259,8 @@ class IngestorTests: AppTestCase {
         }
         var lastUpdate = Date()
 
-        do {  // MUT
-            let packages = try await Package.fetchCandidates(app.db, for: .ingestion, limit: 10)
-                .get()
-            try await ingestFromS3(database: app.db, logger: app.logger, packages: packages)
-        }
+        // MUT
+        try await ingestFromS3(database: app.db, logger: app.logger, packageIDs: [.id0])
 
         do {  // validate
             let v = try await Version.find(.id1, on: app.db).unwrap()
@@ -279,11 +275,8 @@ class IngestorTests: AppTestCase {
         }
         lastUpdate = Date()
 
-        do {  // MUT
-            let packages = try await Package.fetchCandidates(app.db, for: .ingestion, limit: 10)
-                .get()
-            try await ingestFromS3(database: app.db, logger: app.logger, packages: packages)
-        }
+        // MUT
+        try await ingestFromS3(database: app.db, logger: app.logger, packageIDs: [.id0])
 
         do {  // validate
             let v = try await Version.find(.id1, on: app.db).unwrap()


### PR DESCRIPTION
We were tripping over accessing the owner/repo fields on Repository:

```
[ INFO ] Ingesting (id: 38D534BF-4BE1-498E-B973-E7E885FC3A4E) ... [component: ingest] (App/Commands/Ingest.swift:91)
[ DEBUG ] Ingesting [38D534BF-4BE1-498E-B973-E7E885FC3A4E] [component: ingest] (App/Commands/Ingest.swift:119)
[ DEBUG ] Ingesting from Github ... [component: ingest] (App/Commands/Ingest.swift:122)
[ DEBUG ] updateStatus ops: 1 [component: ingest] (App/Commands/Common.swift:57)
[ DEBUG ] Ingesting from S3 ... [component: ingest] (App/Commands/Ingest.swift:130)
[ DEBUG ] ingestFromS3 version candidates: 4 [component: ingest] (App/Commands/Ingest.swift:296)
[ DEBUG ] ingestFromS3 versions with doc targets: 3 [component: ingest] (App/Commands/Ingest.swift:301)
FluentKit/Field.swift:23: Fatal error: Cannot access field before it is initialized or fetched: owner
```

The problem is that the Github ingestion pass saving the model apparently invalidates the relation to Repository. The fix is to refetch the two fields we need.

I've changed the entire `ingestFromS3` function back to just using `[Package.ID]` as its input to avoid any future temptation to access fields on `Joined<Package, Repository>`.