### PR TITLE
Extend trigger-builds to trigger for a particular version-id + platfo…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,6 @@ COPY . .
 
 # Compile with optimizations
 RUN swift build \
-    --enable-test-discovery \
     -c release \
     -Xswiftc -g
 

--- a/Sources/App/Models/Build+Platform.swift
+++ b/Sources/App/Models/Build+Platform.swift
@@ -73,3 +73,14 @@ extension Build.Platform: Comparable {
         }
     }
 }
+
+
+extension Build.Platform: LosslessStringConvertible {
+    init?(_ description: String) {
+        self.init(rawValue: description)
+    }
+
+    var description: String {
+        rawValue
+    }
+}

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -56,7 +56,7 @@ final class Build: Model, Content {
     var runnerId: String?
     
     @Field(key: "status")
-    var status: Build.Status
+    var status: Status
     
     @Field(key: "swift_version")
     var swiftVersion: SwiftVersion


### PR DESCRIPTION
…rm + swift-version

This will make it easier to re-generate docs for a particular package by running only the required build:

```
swift run Run trigger-builds -v 5a089d54-faa7-4a20-8715-f15b87214aa4 -p macos-spm -s 5.6
```

This is will ignore any downscaling settings, too, and send a direct trigger.