### PR TITLE
Drive documentation url from S3 doc archives

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -114,16 +114,7 @@ extension PackageShow {
                 let packageId = result.package.id
             else { return nil }
 
-            #warning("temporary hotfix until #1770 is properly addressed")
-            let docTargetOverrides = [
-                "https://github.com/apple/swift-docc.git".lowercased() : "DocC",
-                "https://github.com/apple/swift-markdown.git".lowercased() : "Markdown",
-                "https://github.com/parse-community/Parse-Swift.git".lowercased() : "ParseSwift",
-            ]
-            let defaulDocTarget = docTargetOverrides[result.package.url.lowercased()]
-            ?? result.defaultBranchVersion.spiManifest?
-                .allDocumentationTargets()?
-                .first
+            let defaulDocTarget = result.defaultBranchVersion.docArchives?.first?.title
 
             self.init(
                 packageId: packageId,


### PR DESCRIPTION
Roll out plan:

* [x] final test
	* [x] add doc link change (this PR)
	* [x] deploy branch to staging
	* [x] check that doc urls are working, in particular
		* [x] apple/swift-docc
		* [x] apple/swift-markdown
		* [x] parse-community/Parse-Swift
	* [x] **Next:** remove S3 ingestion gating and deploy to prod for ingestion (PR #1800)
	* [x] remove `spi-prod-docs`  overrides in this (`update-doc-url-source-to-s3`) branch / PR
	* [x] merge **only after prod has seen `doc_archives` populated**
	* [x] deploy to prod
* [x] remove gating around S3 ingestion and deploy to prod (#1800)
	* [ ] wait for full doc archive ingestion
