### PR TITLE
Uses the correct make command

### DIFF
--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -84,7 +84,7 @@ There are three main background processes responsible for adding/removing packag
 The `ingest-loop.sh` script can serve as a simple way to run a full ingestion cycle:
 
 ```
-make reset                # Delete and re-creating the development and test databases.
+make db-reset                # Delete and re-creating the development and test databases.
 make reconcile            # Import all packages in the package list.
 ./scripts/ingest-loop.sh  # Ingest metadata for 100 packages, pause for 10 sec, and repeat.
 ```


### PR DESCRIPTION
The instruction how to reset the database uses incorrectly "make reset" while in the Makefile it's "db-reset". This PR just updates the instructions with the right command.