### PR TITLE
Add pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@
 name: Continuous Integration
 
 on:
-  workflow_dispatch:
+  pull_request_target:
   push:
+  workflow_dispatch:
 
 jobs:
   test-linux:


### PR DESCRIPTION
This should allow us to approve and run CI on forks https://docs.github.com/en/actions/managing-workflow-runs/approving-workflow-runs-from-public-forks