### PR TITLE
Run push trigger only on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ name: Continuous Integration
 on:
   pull_request_target:
   push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,11 +15,8 @@
 name: Continuous Integration
 
 on:
-  pull_request_target:
-  push:
-    branches:
-      - main
   workflow_dispatch:
+  push:
 
 jobs:
   test-linux:


### PR DESCRIPTION
This should fix the double runs:

- `pull_request_target` triggers when there are commits on a PR branch
- `push` triggers when there are commis on `main`

The downside is that this doesn't trigger on branches by themselves anymore, only when they're a PR. I do use that quite a bit as a pre-flight check before opening up PRs. I can just open a draft PR but that's noisy.

I wish GH was smart enough not to double trigger...

Also, whatever setting we decide, we'll need to replicate it in the `query-performance.yml` and `snapshots.yml` workflows.