### PR TITLE
Add option to refresh checkouts before re-analysing

### DIFF
--- a/Tests/AppTests/ReAnalyzeVersionsTests.swift
+++ b/Tests/AppTests/ReAnalyzeVersionsTests.swift
@@ -124,6 +124,7 @@ class ReAnalyzeVersionsTests: AppTestCase {
                                                       database: app.db,
                                                       logger: app.logger,
                                                       before: Current.date(),
+                                                      refreshCheckouts: false,
                                                       limit: 10)
 
         // validate that re-analysis has now updated existing versions
@@ -210,6 +211,7 @@ class ReAnalyzeVersionsTests: AppTestCase {
                                                       database: app.db,
                                                       logger: app.logger,
                                                       before: Current.date(),
+                                                      refreshCheckouts: false,
                                                       limit: 10)
 
         // validate


### PR DESCRIPTION
Re-analysis sometimes gets stuck and what appear to be "stale" checkouts on a certain node. The failure mode is that is simply doesn't process versions for the package and they soon start piling up the queue. The current workaround is to delete the checkout directory to force an refresh but that's awkward when it happens a lot.