### PR TITLE
More tweaks to the Twitter spaces CTA and home page sidebar

### DIFF
--- a/FrontEnd/styles/colors.scss
+++ b/FrontEnd/styles/colors.scss
@@ -47,6 +47,8 @@
   --very-light-grey: #f1f1f1;
   --very-very-light-grey: #f8f8f8;
   --white: #ffffff;
+
+  --twitter-blue: #1d9bf0;
 }
 
 /* Dark mode base color overrides */

--- a/FrontEnd/styles/home.scss
+++ b/FrontEnd/styles/home.scss
@@ -138,8 +138,9 @@
 .twitter_spaces {
   position: relative;
   padding: 15px;
-  margin: 20px 0;
+  margin: 20px 0 60px 0;
   background-color: var(--panel-background);
+  border-bottom: 3px var(--twitter-blue) solid;
 
   &::before {
     content: '';

--- a/FrontEnd/styles/scta.scss
+++ b/FrontEnd/styles/scta.scss
@@ -109,6 +109,7 @@ body.home {
   .scta {
     position: relative;
     border-bottom: 3px var(--pink) solid;
+    margin-bottom: 40px;
 
     &::before {
       content: '';

--- a/Sources/App/Views/Home/HomeIndex+View.swift
+++ b/Sources/App/Views/Home/HomeIndex+View.swift
@@ -85,9 +85,6 @@ enum HomeIndex {
                             )
                         )
                     ),
-                    .hr(
-                        .class("minor")
-                    ),
                     .section(
                         .class("recent"),
                         .div(

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_HomeIndexView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_HomeIndexView.1.html
@@ -80,7 +80,6 @@
                 </small>
               </p>
             </section>
-            <hr class="minor"/>
             <section class="recent">
               <div class="recent_packages">
                 <h3>Recently Added</h3>


### PR DESCRIPTION
* More spacing between the sidebar sponsorship messages
* Added a border to the Twitter Spaces CTA
* Replaced the HR under the Twitter Spaces CTA with a gap

<img width="901" alt="Screenshot 2022-06-21 at 18 56 51@2x" src="https://user-images.githubusercontent.com/5180/174866966-30d4aedb-020c-4ca3-beec-66fba9114ad7.png">
