### PR TITLE
Rename `targets` to `doc_archives` in the `DocumentationPageProcessor`

### DIFF
--- a/FrontEnd/docc.scss
+++ b/FrontEnd/docc.scss
@@ -147,7 +147,7 @@ header.spi {
       }
     }
 
-    &.targets {
+    &.doc_archives {
       ul {
         display: flex;
         gap: 20px;
@@ -166,7 +166,7 @@ header.spi {
     }
   }
 
-  .targets_wrap {
+  .doc_archives_wrap {
     background-color: rgba(255, 255, 255, 0.15);
 
     @media (prefers-color-scheme: dark) {

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -116,7 +116,7 @@ struct PackageController {
                                                                  repositoryName: repository,
                                                                  packageName: queryResult.version.packageName ?? repository,
                                                                  reference: reference,
-                                                                 targets: queryResult.version.spiManifest?.allDocumentationTargets() ?? [],
+                                                                 doc_archives: queryResult.version.spiManifest?.allDocumentationTargets() ?? [],
                                                                  rawHtml: body.asString())
                 else {
                     return try await awsResponse.encodeResponse(

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -105,9 +105,9 @@ struct DocumentationPageProcessor {
                     )
                 ),
                 .if(doc_archives.count > 1, .div(
-                    .class("targets_wrap"),
+                    .class("doc_archives_wrap"),
                     .div(
-                        .class("inner targets"),
+                        .class("inner doc_archives"),
                         .nav(
                             .ul(
                                 .li(

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -23,21 +23,21 @@ struct DocumentationPageProcessor {
     let repositoryName: String
     let packageName: String
     let reference: String
-    let targets: [String]
+    let doc_archives: [String]
 
     init?(repositoryOwner: String,
           repositoryOwnerName: String,
           repositoryName: String,
           packageName: String,
           reference: String,
-          targets: [String],
+          doc_archives: [String],
           rawHtml: String) {
         self.repositoryOwner = repositoryOwner
         self.repositoryOwnerName = repositoryOwnerName
         self.repositoryName = repositoryName
         self.packageName = packageName
         self.reference = reference
-        self.targets = targets
+        self.doc_archives = doc_archives
 
         do {
             document = try SwiftSoup.parse(rawHtml)
@@ -104,7 +104,7 @@ struct DocumentationPageProcessor {
                         )
                     )
                 ),
-                .if(targets.count > 1, .div(
+                .if(doc_archives.count > 1, .div(
                     .class("targets_wrap"),
                     .div(
                         .class("inner targets"),
@@ -113,11 +113,11 @@ struct DocumentationPageProcessor {
                                 .li(
                                     .text("Documentation for:")
                                 ),
-                                .forEach(targets, { target in
+                                .forEach(doc_archives, { archive in
                                         .li(
                                             .a(
-                                                .href(relativeDocumentationURL(target: target)),
-                                                .text(target)
+                                                .href(relativeDocumentationURL(doc_archive: archive)),
+                                                .text(archive)
                                             )
                                         )
                                 })
@@ -189,7 +189,7 @@ struct DocumentationPageProcessor {
     }
 
     // Note: When this gets merged back with the refactored SiteURL, note that it's duplicated in `PackageShow.Model`.
-    func relativeDocumentationURL(target: String) -> String {
-        "/\(repositoryOwner)/\(repositoryName)/\(reference)/documentation/\(target.lowercased())"
+    func relativeDocumentationURL(doc_archive: String) -> String {
+        "/\(repositoryOwner)/\(repositoryName)/\(reference)/documentation/\(doc_archive.lowercased())"
     }
 }

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -358,7 +358,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  repositoryName: "package",
                                                                  packageName: "Package Name",
                                                                  reference: "main",
-                                                                 targets: [],
+                                                                 doc_archives: [],
                                                                  rawHtml: doccHtml))
 
         assertSnapshot(matching: processor.processedPage, as: .html)
@@ -372,7 +372,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  repositoryName: "package",
                                                                  packageName: "Package Name",
                                                                  reference: "main",
-                                                                 targets: ["Target1", "Target2"],
+                                                                 doc_archives: ["Archive1", "Archive2"],
                                                                  rawHtml: doccHtml))
 
         assertSnapshot(matching: processor.processedPage, as: .html)

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleTargets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleTargets.1.html
@@ -31,13 +31,13 @@
      </ul>
     </nav>
    </div>
-   <div class="targets_wrap">
-    <div class="inner targets">
+   <div class="doc_archives_wrap">
+    <div class="inner doc_archives">
      <nav>
       <ul>
        <li>Documentation for:</li>
-       <li><a href="/owner/package/main/documentation/target1">Target1</a></li>
-       <li><a href="/owner/package/main/documentation/target2">Target2</a></li>
+       <li><a href="/owner/package/main/documentation/archive1">Archive1</a></li>
+       <li><a href="/owner/package/main/documentation/archive2">Archive2</a></li>
       </ul>
      </nav>
     </div>


### PR DESCRIPTION
In preparation for the changes that will be needed when we switch from `targets` to `doc_archives` across the whole system, I wanted to get these fields renamed now as they are very likely to conflict with other changes I'm about to make for #1834.

There should be no visual difference, and the content is still currently target-based. This is just to reduce the chance of difficult merges later.