### PR TITLE
Make a globally available representation of our significant release kinds

### DIFF
--- a/Sources/App/Models/Release.swift
+++ b/Sources/App/Models/Release.swift
@@ -35,3 +35,9 @@ extension Release {
         url = node.url
     }
 }
+
+enum SignificantReleaseKind: String {
+    case defaultBranch
+    case preRelease
+    case release
+}

--- a/Sources/App/Models/Release.swift
+++ b/Sources/App/Models/Release.swift
@@ -24,6 +24,13 @@ struct Release: Codable, Equatable {
     var url: String
 }
 
+extension Release {
+    enum Kind: String {
+        case defaultBranch
+        case preRelease
+        case release
+    }
+}
 
 extension Release {
     init(from node: Github.Metadata.ReleaseNodes.ReleaseNode) {
@@ -34,10 +41,4 @@ extension Release {
         tagName = node.tagName
         url = node.url
     }
-}
-
-enum SignificantReleaseKind: String {
-    case defaultBranch
-    case preRelease
-    case release
 }

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -46,7 +46,7 @@ extension PackageShow {
         var isArchived: Bool
         var homepageUrl: String?
         var documentationMetadata: DocumentationMetadata?
-        var dependencyCodeSnippets: [SignificantReleases: Link]
+        var dependencyCodeSnippets: [SignificantReleaseKind: Link]
         
         internal init(packageId: Package.Id,
                       repositoryOwner: String,
@@ -72,7 +72,7 @@ extension PackageShow {
                       isArchived: Bool,
                       homepageUrl: String? = nil,
                       documentationMetadata: DocumentationMetadata? = nil,
-                      dependencyCodeSnippets: [SignificantReleases: Link]) {
+                      dependencyCodeSnippets: [SignificantReleaseKind: Link]) {
             self.packageId = packageId
             self.repositoryOwner = repositoryOwner
             self.repositoryOwnerName = repositoryOwnerName
@@ -508,12 +508,6 @@ extension PackageShow.Model {
         )
     }
 
-    enum SignificantReleases: String {
-        case defaultBranch
-        case preRelease
-        case release
-    }
-
     static func packageDependencyCodeSnippet(ref: App.Reference, packageURL: String) -> String {
         switch ref {
             case let .branch(branch):
@@ -527,8 +521,8 @@ extension PackageShow.Model {
     static func packageDependencyCodeSnippets(packageURL: String,
                                               defaultBranchReference: App.Reference?,
                                               releaseReference: App.Reference?,
-                                              preReleaseReference: App.Reference?) -> [SignificantReleases: Link] {
-        var snippets = [SignificantReleases: Link]()
+                                              preReleaseReference: App.Reference?) -> [SignificantReleaseKind: Link] {
+        var snippets = [SignificantReleaseKind: Link]()
         if let ref = defaultBranchReference {
             snippets[.defaultBranch] = Link(label: "\(ref)",
                                             url: packageDependencyCodeSnippet(ref: ref,

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -46,7 +46,7 @@ extension PackageShow {
         var isArchived: Bool
         var homepageUrl: String?
         var documentationMetadata: DocumentationMetadata?
-        var dependencyCodeSnippets: [SignificantReleaseKind: Link]
+        var dependencyCodeSnippets: [Release.Kind: Link]
         
         internal init(packageId: Package.Id,
                       repositoryOwner: String,
@@ -72,7 +72,7 @@ extension PackageShow {
                       isArchived: Bool,
                       homepageUrl: String? = nil,
                       documentationMetadata: DocumentationMetadata? = nil,
-                      dependencyCodeSnippets: [SignificantReleaseKind: Link]) {
+                      dependencyCodeSnippets: [Release.Kind: Link]) {
             self.packageId = packageId
             self.repositoryOwner = repositoryOwner
             self.repositoryOwnerName = repositoryOwnerName
@@ -521,8 +521,8 @@ extension PackageShow.Model {
     static func packageDependencyCodeSnippets(packageURL: String,
                                               defaultBranchReference: App.Reference?,
                                               releaseReference: App.Reference?,
-                                              preReleaseReference: App.Reference?) -> [SignificantReleaseKind: Link] {
-        var snippets = [SignificantReleaseKind: Link]()
+                                              preReleaseReference: App.Reference?) -> [Release.Kind: Link] {
+        var snippets = [Release.Kind: Link]()
         if let ref = defaultBranchReference {
             snippets[.defaultBranch] = Link(label: "\(ref)",
                                             url: packageDependencyCodeSnippet(ref: ref,


### PR DESCRIPTION
Merge after #1843 
More prep for #1834 