### PR TITLE
Revert "Drive documentation url from S3 doc archives"

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -114,7 +114,16 @@ extension PackageShow {
                 let packageId = result.package.id
             else { return nil }
 
-            let defaulDocTarget = result.defaultBranchVersion.docArchives?.first?.title
+            #warning("temporary hotfix until #1770 is properly addressed")
+            let docTargetOverrides = [
+                "https://github.com/apple/swift-docc.git".lowercased() : "DocC",
+                "https://github.com/apple/swift-markdown.git".lowercased() : "Markdown",
+                "https://github.com/parse-community/Parse-Swift.git".lowercased() : "ParseSwift",
+            ]
+            let defaulDocTarget = docTargetOverrides[result.package.url.lowercased()]
+            ?? result.defaultBranchVersion.spiManifest?
+                .allDocumentationTargets()?
+                .first
 
             self.init(
                 packageId: packageId,


### PR DESCRIPTION
This reverts commit ad8898684db20835bd5d36f3c00de4e74df1b333.

I believe this broke almost half of our doc urls. Need to investigate why the urls aren't working as expected.