### PR TITLE
typo fix: st -> set

### DIFF
--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -150,7 +150,7 @@ Sometimes you need to run tests or even the server on the target platform, Linux
 
 The trickiest part of this is to ensure the test or app container can connect to the database, which is also running in docker. To do so, requires the following setup:
 
-- in your `.env` file - `development` or `testing`, depending on whether you are running the server or the tests, st `DATABASE_HOST` to `host.docker.internal`
+- in your `.env` file - `development` or `testing`, depending on whether you are running the server or the tests, set `DATABASE_HOST` to `host.docker.internal`
 - on macOS, that's all you need to to. On Linux, you need to tell your `docker run` command to make the host accessible on the network via `--add-host=host.docker.internal:host-gateway`. (This works on macOS as well but is redundant.)
 
 So, in order to run the tests in a Linux container run:


### PR DESCRIPTION
tiny typo fix - ran across it while reading through and setting up a local replica of the server env