### PR TITLE
Revert "Drive documentation url from S3 doc archives"

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -117,7 +117,16 @@ extension PackageShow {
                 let packageId = result.package.id
             else { return nil }
 
-            let defaulDocTarget = result.defaultBranchVersion.docArchives?.first?.title
+            #warning("temporary hotfix until #1770 is properly addressed")
+            let docTargetOverrides = [
+                "https://github.com/apple/swift-docc.git".lowercased() : "DocC",
+                "https://github.com/apple/swift-markdown.git".lowercased() : "Markdown",
+                "https://github.com/parse-community/Parse-Swift.git".lowercased() : "ParseSwift",
+            ]
+            let defaulDocTarget = docTargetOverrides[result.package.url.lowercased()]
+            ?? result.defaultBranchVersion.spiManifest?
+                .allDocumentationTargets()?
+                .first
 
             self.init(
                 packageId: packageId,


### PR DESCRIPTION
This reverts commit ad8898684db20835bd5d36f3c00de4e74df1b333.

It looks like this change is a source of 404s. Let's revert this to see if that fixes it. (Unfortunately our logging doesn't show which urls 404 - that needs fixing separately.)

<img width="580" alt="CleanShot 2022-07-05 at 14 21 17@2x" src="https://user-images.githubusercontent.com/65520/177326191-00a2598d-9cbd-40c3-a543-a64785b22b04.png">

