### PR TITLE
Drive default doc url via first doc archive (again)

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -117,16 +117,7 @@ extension PackageShow {
                 let packageId = result.package.id
             else { return nil }
 
-            #warning("temporary hotfix until #1770 is properly addressed")
-            let docTargetOverrides = [
-                "https://github.com/apple/swift-docc.git".lowercased() : "DocC",
-                "https://github.com/apple/swift-markdown.git".lowercased() : "Markdown",
-                "https://github.com/parse-community/Parse-Swift.git".lowercased() : "ParseSwift",
-            ]
-            let defaulDocTarget = docTargetOverrides[result.package.url.lowercased()]
-            ?? result.defaultBranchVersion.spiManifest?
-                .allDocumentationTargets()?
-                .first
+            let defaulDocTarget = result.defaultBranchVersion.docArchives?.first?.title
 
             self.init(
                 packageId: packageId,


### PR DESCRIPTION
Tested locally by pulling a prod copy after all the doc re-builds were done and pointing the S3 url at the prod bucket.

All doc links are presents as expected and I've manually confirmed the vast majority of them.

One package loses the doc link, and that's ParseSwift, because it's using `macos-xcodebuild` for its doc building platform, which we don't support yet. That's actually a bug I introduced in their `.spi.yml` when they'd shifted away from iOS docs to macos.

PR to correct here: https://github.com/parse-community/Parse-Swift/pull/383