### PR TITLE
Update perf cost expectation for test_Search_refresh

### DIFF
--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -145,7 +145,7 @@ class QueryPerformanceTests: XCTestCase {
               JOIN versions v ON v.package_id = p.id
             WHERE v.reference ->> 'branch' = r.default_branch
             """)
-        try await assertQueryPerformance(query, expectedCost: 15_000, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 19_340, variation: 200)
     }
 
 }


### PR DESCRIPTION
Fixes #1893 

I've had a look at the query plan details but there's nothing dramatic that I can see. One notable thing we might want to change is the `WHERE` clause:

```sql
            WHERE v.reference ->> 'branch' = r.default_branch
```

It'd make more sense logically to write

```sql
            WHERE v.latest = 'default_branch'
```

I've compared the results and they are identical (as they should be).

Interestingly, this change reduces the overall _time_ of the query noticeably (from 500ms to 270ms, on staging, 380ms to 230ms on prod) but it also increases the _cost_ dramatically (to 100k). 

Now cost probably isn't the be all metric, but it's one that's been pretty stable and a good indicator for perf regressions. In the absence of time being massively different (say 10x) and fully understanding the implications it's probably not worth making this change. We can afford the search refresh taking ~500ms. It'd be worse if it ran faster but actually caused more load (which the cost might be an indication of).