### PR TITLE
Add more obvious way to log SQL queries

### DIFF
--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -65,7 +65,9 @@ public func configure(_ app: Application) throws -> String {
                                 password: password,
                                 database: database,
                                 tlsConfiguration: tlsConfig,
-                                maxConnectionsPerEventLoop: maxConnectionsPerEventLoop),
+                                maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
+                                // Set this to .info to log SQL queries with the default log level.
+                                sqlLogLevel: .debug),
                       as: .psql)
     
     do {  // Migration 001 - schema 1.0


### PR DESCRIPTION
Via https://blog.vapor.codes/posts/enable-db-query-logging/

No actual change, just exposing a more obvious way to log SQL queries. (Previously you had to know that setting the `LOG_LEVEL` env variable to `debug` would log SQL - along with all sort of other debug messages.)