### PR TITLE
revised search - ranking results using ts_vector and ts_rank from Postgres on english-only word vectors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
     name: "SPI-Server",
     platforms: [
-        .macOS(.v12)
+        .macOS(.v12),
     ],
     products: [
         .library(name: "DependencyResolution", targets: ["DependencyResolution"]),
@@ -40,7 +40,7 @@ let package = Package(
         .package(url: "https://github.com/handya/OhhAuth.git", from: "1.4.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
         .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git",
-                 .branch("release/5.6"))
+                 .branch("release/5.6")),
     ],
     targets: [
         .executableTarget(name: "Run", dependencies: ["App"]),

--- a/Sources/App/Core/Extensions/SQLKit+functions.swift
+++ b/Sources/App/Core/Extensions/SQLKit+functions.swift
@@ -49,11 +49,65 @@ func lower(_ arg: SQLExpression) -> SQLFunction {
     SQLFunction("LOWER", args: arg)
 }
 
-
 func unnest(_ array: SQLExpression) -> SQLFunction {
     SQLFunction("UNNEST", args: array)
 }
 
+func to_tsvector(_ array: SQLExpression) -> SQLFunction {
+    // The argument is meant to be a string, which this wraps and converts
+    // first into a tsvector internal type, and then applies weighting
+    // for query ranking purposes.
+    // The default weight class ('D') results in a  0.1 multiplier on the rank.
+    SQLFunction("to_tsvector", args: array)
+}
+
+func to_tsvectorA(_ array: SQLExpression) -> SQLFunction {
+    // The argument is meant to be a string, which this wraps and converts
+    // first into a tsvector internal type, and then applies weighting
+    // for query ranking purposes.
+    // Details of the setweight function (and to_tsvector) are available
+    // at https://www.postgresql.org/docs/current/textsearch-controls.html
+    // The weight class 'A' results in a 1.0 multiplier on the rank.
+    SQLFunction("setweight", args: [to_tsvector(array), SQLRaw("'A'")])
+}
+
+func to_tsvectorB(_ array: SQLExpression) -> SQLFunction {
+    // The argument is meant to be a string, which this wraps and converts
+    // first into a tsvector internal type, and then applies weighting
+    // for query ranking purposes.
+    // The weight class 'B' results in a 0.4 multiplier on the rank.
+    SQLFunction("setweight", args: [to_tsvector(array), SQLRaw("'B'")])
+}
+
+func to_tsvectorC(_ array: SQLExpression) -> SQLFunction {
+    // The argument is meant to be a string, which this wraps and converts
+    // first into a tsvector internal type, and then applies weighting
+    // for query ranking purposes.
+    // The weight class 'C' results in a 0.2 multiplier on the rank.
+    SQLFunction("setweight", args: [to_tsvector(array), SQLRaw("'C'")])
+}
+
+func plainto_tsquery(_ array: SQLExpression) -> SQLFunction {
+    // generates a simplistic tsquery concatenating all individual words as
+    // 'AND' tokens for the ts_query binary search structure. For example,
+    // an input of 'bezier curve' becomes 'bezier & curve'.
+    SQLFunction("plainto_tsquery", args: array)
+}
+
+func ts_rank(vector: SQLExpression, query: SQLExpression) -> SQLFunction {
+    // returns a ranking value when applying the query to the relevant
+    // tsvector data type. If the query wouldn't match at all, the ranking
+    // returns as `0`. The documentation for the return values is non-specific
+    // about the range, but hints that values can easily exceed 1.0. In
+    // my experimentation, and based on reading the code at
+    // https://github.com/postgres/postgres/blob/master/src/backend/utils/adt/tsrank.c
+    // the returned rank values range from 0 to 1.0, with a single query term
+    // perfectly matching the response returning a ranking of 0.6. Additional
+    // query terms adjust the ranking - OR queries maintain or reduce the value
+    // depending on matches with the vector, and AND queries increase the value
+    // pressing it slowly up towards 1.0.
+    SQLFunction("ts_rank", args: [vector, query])
+}
 
 // MARK: - SQL Binary Expressions
 
@@ -61,8 +115,6 @@ func isNotNull(_ column: SQLIdentifier) -> SQLBinaryExpression {
     SQLBinaryExpression(left: column, op: SQLBinaryOperator.isNot, right: SQLRaw("NULL"))
 }
 
-
 func eq(_ lhs: SQLExpression, _ rhs: SQLExpression) -> SQLBinaryExpression {
     SQLBinaryExpression(left: lhs, op: SQLBinaryOperator.equal, right: rhs)
 }
-

--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -42,7 +42,7 @@ enum Search {
     static let tsvector = SQLIdentifier("tsvector")
     static let tsrankvalue = SQLIdentifier("tsrankvalue")
     
-    static let emptyString = SQLRaw("''")
+    static let emptyString = SQLRaw("")
     static let inVector = SQLRaw("@@")
     static let ilike = SQLRaw("ILIKE")
     static let null = SQLRaw("NULL")

--- a/Sources/App/Migrations/053/UpdateSearchAddProductType.swift
+++ b/Sources/App/Migrations/053/UpdateSearchAddProductType.swift
@@ -24,7 +24,7 @@ struct UpdateSearchAddProductType: AsyncMigration {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
 
-        // Creat an index on products.version_id - this speeds up search view creation
+        // Create an index on products.version_id - this speeds up search view creation
         // dramatically.
         try await db.raw("CREATE INDEX idx_products_version_id ON products (version_id)")
             .run()

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -28,7 +28,7 @@ public func configure(_ app: Application) throws -> String {
     // ---
     // app.http.server.configuration.responseCompression = .enabled
     // app.http.server.configuration.requestDecompression = .enabled
-    
+
     app.middleware.use(FileMiddleware(publicDirectory: app.directory.publicDirectory))
     app.middleware.use(ErrorMiddleware())
 
@@ -41,7 +41,7 @@ public func configure(_ app: Application) throws -> String {
     // the failure mode is exactly the same we have before increasing the limits.
     // This parameter could also be made configurable via an env variable.
     let maxConnectionsPerEventLoop = 3
-    
+
     guard
         let host = Environment.get("DATABASE_HOST"),
         let port = Environment.get("DATABASE_PORT").flatMap(Int.init),
@@ -69,7 +69,7 @@ public func configure(_ app: Application) throws -> String {
                                 // Set sqlLogLevel to .info to log SQL queries with the default log level.
                                 sqlLogLevel: .debug),
                       as: .psql)
-    
+
     do {  // Migration 001 - schema 1.0
         app.migrations.add(CreatePackage())
         app.migrations.add(CreateRepository())
@@ -269,7 +269,7 @@ public func configure(_ app: Application) throws -> String {
     app.commands.use(ReconcileCommand(), as: "reconcile")
     app.commands.use(TriggerBuildsCommand(), as: "trigger-builds")
     app.commands.use(ReAnalyzeVersions.Command(), as: "re-analyze-versions")
-    
+
     // register routes
     try routes(app)
 

--- a/Tests/AppTests/PackageReleasesModelTests.swift
+++ b/Tests/AppTests/PackageReleasesModelTests.swift
@@ -46,6 +46,8 @@ class PackageReleasesModelTests: AppTestCase {
             .init(title: "0.0.1", date: "Released 50 years ago on 1 January 1970",
                   html: nil, link: "some url"),
         ])
+        // NOTE(heckj): test is sensitive to local time zones, breaks when run at GMT-7
+        // resolves as `31 December 1969`
     }
     
     func test_dateFormatting() throws {
@@ -54,6 +56,8 @@ class PackageReleasesModelTests: AppTestCase {
         
         XCTAssertEqual(PackageReleases.Model.formatDate(targetDate, currentDate: currentDate),
                        "Released 8 minutes ago on 1 January 1970")
+        // NOTE(heckj): test is sensitive to local time zones, breaks when run at GMT-7
+        // resolves as `31 December 1969`
         
         XCTAssertNil(PackageReleases.Model.formatDate(nil, currentDate: currentDate))
     }

--- a/Tests/AppTests/PackageReleasesModelTests.swift
+++ b/Tests/AppTests/PackageReleasesModelTests.swift
@@ -21,6 +21,17 @@ class PackageReleasesModelTests: AppTestCase {
 
     func test_initialise() throws {
         // Setup
+        
+        // Work-around to set the local time zone for time sensitive
+        // tests. Sets the explicit default time zone to UTC for the duration
+        // of this test.
+        let explicitGMTTimeZone = TimeZone(identifier: "Etc/UTC")!
+        let oldDefault = NSTimeZone.default
+        NSTimeZone.default = explicitGMTTimeZone
+        defer {
+            NSTimeZone.default = oldDefault
+        }
+        
         Current.date = { .spiBirthday }
         let pkg = Package(id: UUID(), url: "1".asGithubUrl.url)
         try pkg.save(on: app.db).wait()
@@ -51,6 +62,17 @@ class PackageReleasesModelTests: AppTestCase {
     }
     
     func test_dateFormatting() throws {
+        
+        // Work-around to set the local time zone for time sensitive
+        // tests. Sets the explicit default time zone to UTC for the duration
+        // of this test.
+        let explicitGMTTimeZone = TimeZone(identifier: "Etc/UTC")!
+        let oldDefault = NSTimeZone.default
+        NSTimeZone.default = explicitGMTTimeZone
+        defer {
+            NSTimeZone.default = oldDefault
+        }
+
         let currentDate = Date(timeIntervalSince1970: 500)
         let targetDate = Date(timeIntervalSince1970: 0)
         

--- a/Tests/AppTests/SearchTests.swift
+++ b/Tests/AppTests/SearchTests.swift
@@ -38,14 +38,14 @@ class SearchTests: AppTestCase {
 
     func test_packageMatchQuery_single_term() throws {
         let b = Search.packageMatchQueryBuilder(on: app.db, terms: ["a"], filters: [])
-        XCTAssertEqual(renderSQL(b), #"SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL ORDER BY LOWER("package_name") = $2 DESC, "score" DESC, "package_name" ASC"#)
-        XCTAssertEqual(binds(b), ["a", "a"])
+        XCTAssertEqual(renderSQL(b), #"SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL ORDER BY LOWER("package_name") = $3 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC"#)
+        XCTAssertEqual(binds(b), ["a", "a", "a"])
     }
 
     func test_packageMatchQuery_multiple_terms() throws {
         let b = Search.packageMatchQueryBuilder(on: app.db, terms: ["a", "b"], filters: [])
-        XCTAssertEqual(renderSQL(b), #"SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL ORDER BY LOWER("package_name") = $3 DESC, "score" DESC, "package_name" ASC"#)
-        XCTAssertEqual(binds(b), ["a", "b", "a b"])
+        XCTAssertEqual(renderSQL(b), #"SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $3 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL ORDER BY LOWER("package_name") = $4 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC"#)
+        XCTAssertEqual(binds(b), ["a b", "a", "b", "a b"])
     }
 
     func test_packageMatchQuery_AuthorSearchFilter() throws {
@@ -55,9 +55,9 @@ class SearchTests: AppTestCase {
         )
 
         XCTAssertEqual(renderSQL(b), """
-              SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("repo_owner" ILIKE $2) ORDER BY LOWER("package_name") = $3 DESC, "score" DESC, "package_name" ASC
+              SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("repo_owner" ILIKE $3) ORDER BY LOWER("package_name") = $4 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC
               """)
-        XCTAssertEqual(binds(b), ["a", "foo", "a"])
+        XCTAssertEqual(binds(b), ["a", "a", "foo", "a"])
     }
 
     func test_packageMatchQuery_KeywordSearchFilter() throws {
@@ -68,9 +68,9 @@ class SearchTests: AppTestCase {
         )
 
         XCTAssertEqual(renderSQL(b), """
-            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ($2 ILIKE ANY("keywords")) ORDER BY LOWER("package_name") = $3 DESC, "score" DESC, "package_name" ASC
+            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ($3 ILIKE ANY("keywords")) ORDER BY LOWER("package_name") = $4 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC
             """)
-        XCTAssertEqual(binds(b), ["a", "foo", "a"])
+        XCTAssertEqual(binds(b), ["a", "a", "foo", "a"])
     }
 
     func test_packageMatchQuery_LastActivitySearchFilter() throws {
@@ -81,9 +81,9 @@ class SearchTests: AppTestCase {
         )
 
         XCTAssertEqual(renderSQL(b), """
-            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("last_activity_at" > $2) ORDER BY LOWER("package_name") = $3 DESC, "score" DESC, "package_name" ASC
+            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("last_activity_at" > $3) ORDER BY LOWER("package_name") = $4 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC
             """)
-        XCTAssertEqual(binds(b), ["a", "2021-12-01", "a"])
+        XCTAssertEqual(binds(b), ["a", "a", "2021-12-01", "a"])
     }
 
     func test_packageMatchQuery_LastCommitSearchFilter() throws {
@@ -94,9 +94,9 @@ class SearchTests: AppTestCase {
         )
 
         XCTAssertEqual(renderSQL(b), """
-            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("last_commit_date" > $2) ORDER BY LOWER("package_name") = $3 DESC, "score" DESC, "package_name" ASC
+            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("last_commit_date" > $3) ORDER BY LOWER("package_name") = $4 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC
             """)
-        XCTAssertEqual(binds(b), ["a", "2021-12-01", "a"])
+        XCTAssertEqual(binds(b), ["a", "a", "2021-12-01", "a"])
     }
 
     func test_packageMatchQuery_LicenseSearchFilter() throws {
@@ -106,9 +106,9 @@ class SearchTests: AppTestCase {
         )
 
         XCTAssertEqual(renderSQL(b), """
-            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("license" IN ($2)) ORDER BY LOWER("package_name") = $3 DESC, "score" DESC, "package_name" ASC
+            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("license" IN ($3)) ORDER BY LOWER("package_name") = $4 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC
             """)
-        XCTAssertEqual(binds(b), ["a", "mit", "a"])
+        XCTAssertEqual(binds(b), ["a", "a", "mit", "a"])
     }
 
     func test_packageMatchQuery_PlatformSearchFilter() throws {
@@ -118,9 +118,9 @@ class SearchTests: AppTestCase {
         )
 
         XCTAssertEqual(renderSQL(b), """
-        SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("platform_compatibility" @> $2) ORDER BY LOWER("package_name") = $3 DESC, "score" DESC, "package_name" ASC
+        SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("platform_compatibility" @> $3) ORDER BY LOWER("package_name") = $4 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC
         """)
-        XCTAssertEqual(binds(b), ["a", "{ios,macos}", "a"])
+        XCTAssertEqual(binds(b), ["a", "a", "{ios,macos}", "a"])
     }
 
     func test_packageMatchQuery_ProductTypeSearchFilter() throws {
@@ -132,9 +132,9 @@ class SearchTests: AppTestCase {
                 ]
             )
             XCTAssertEqual(renderSQL(b), """
-            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("product_types" @> $2) ORDER BY LOWER("package_name") = $3 DESC, "score" DESC, "package_name" ASC
+            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("product_types" @> $3) ORDER BY LOWER("package_name") = $4 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC
             """)
-            XCTAssertEqual(binds(b), ["a", "{\(type.rawValue)}", "a"])
+            XCTAssertEqual(binds(b), ["a", "a", "{\(type.rawValue)}", "a"])
         }
     }
 
@@ -145,33 +145,33 @@ class SearchTests: AppTestCase {
                                                               value: "500"))])
 
         XCTAssertEqual(renderSQL(b), """
-            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $1 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("stars" > $2) ORDER BY LOWER("package_name") = $3 DESC, "score" DESC, "package_name" ASC
+            SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($1) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $2 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL AND ("stars" > $3) ORDER BY LOWER("package_name") = $4 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC
             """)
-        XCTAssertEqual(binds(b), ["a", "500", "a"])
+        XCTAssertEqual(binds(b), ["a", "a", "500", "a"])
     }
 
     func test_keywordMatchQuery_single_term() throws {
         let b = Search.keywordMatchQueryBuilder(on: app.db, terms: ["a"])
-        XCTAssertEqual(renderSQL(b), #"SELECT DISTINCT 'keyword' AS "match_type", "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", NULL AS "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("keyword", $1) AS "levenshtein_dist" FROM "search", UNNEST("keywords") AS "keyword" WHERE "keyword" ILIKE $2 ORDER BY "levenshtein_dist" LIMIT 50"#)
-        XCTAssertEqual(binds(b), ["a", "%a%"])
+        XCTAssertEqual(renderSQL(b), #"SELECT DISTINCT 'keyword' AS "match_type", "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", NULL AS "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("keyword", $1) AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", UNNEST("keywords") AS "keyword", plainto_tsquery($2) AS "tsquery", setweight(to_tsvector("keyword"), 'B') AS "tsvector" WHERE "keyword" ILIKE $3 ORDER BY "tsrankvalue" LIMIT 50"#)
+        XCTAssertEqual(binds(b), ["a", "a", "%a%"])
     }
 
     func test_keywordMatchQuery_multiple_terms() throws {
         let b = Search.keywordMatchQueryBuilder(on: app.db, terms: ["a", "b"])
-        XCTAssertEqual(renderSQL(b), #"SELECT DISTINCT 'keyword' AS "match_type", "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", NULL AS "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("keyword", $1) AS "levenshtein_dist" FROM "search", UNNEST("keywords") AS "keyword" WHERE "keyword" ILIKE $2 ORDER BY "levenshtein_dist" LIMIT 50"#)
-        XCTAssertEqual(binds(b), ["a b", "%a b%"])
+        XCTAssertEqual(renderSQL(b), #"SELECT DISTINCT 'keyword' AS "match_type", "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", NULL AS "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("keyword", $1) AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", UNNEST("keywords") AS "keyword", plainto_tsquery($2) AS "tsquery", setweight(to_tsvector("keyword"), 'B') AS "tsvector" WHERE "keyword" ILIKE $3 ORDER BY "tsrankvalue" LIMIT 50"#)
+        XCTAssertEqual(binds(b), ["a b", "a b", "%a b%"])
     }
 
     func test_authorMatchQuery_single_term() throws {
         let b = Search.authorMatchQueryBuilder(on: app.db, terms: ["a"])
-        XCTAssertEqual(renderSQL(b), #"SELECT DISTINCT 'author' AS "match_type", NULL AS "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("repo_owner", $1) AS "levenshtein_dist" FROM "search" WHERE "repo_owner" ILIKE $2 ORDER BY "levenshtein_dist" LIMIT 50"#)
-        XCTAssertEqual(binds(b), ["a", "%a%"])
+        XCTAssertEqual(renderSQL(b), #"SELECT DISTINCT 'author' AS "match_type", NULL AS "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("repo_owner", $1) AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($2) AS "tsquery", setweight(to_tsvector("repo_owner"), 'A') AS "tsvector" WHERE "repo_owner" ILIKE $3 ORDER BY "levenshtein_dist" LIMIT 50"#)
+        XCTAssertEqual(binds(b), ["a", "a", "%a%"])
     }
 
     func test_authorMatchQuery_multiple_term() throws {
         let b = Search.authorMatchQueryBuilder(on: app.db, terms: ["a", "b"])
-        XCTAssertEqual(renderSQL(b), #"SELECT DISTINCT 'author' AS "match_type", NULL AS "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("repo_owner", $1) AS "levenshtein_dist" FROM "search" WHERE "repo_owner" ILIKE $2 ORDER BY "levenshtein_dist" LIMIT 50"#)
-        XCTAssertEqual(binds(b), ["a b", "%a b%"])
+        XCTAssertEqual(renderSQL(b), #"SELECT DISTINCT 'author' AS "match_type", NULL AS "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("repo_owner", $1) AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($2) AS "tsquery", setweight(to_tsvector("repo_owner"), 'A') AS "tsvector" WHERE "repo_owner" ILIKE $3 ORDER BY "levenshtein_dist" LIMIT 50"#)
+        XCTAssertEqual(binds(b), ["a b", "a b", "%a b%"])
     }
 
     func test_query_sql() throws {
@@ -180,9 +180,9 @@ class SearchTests: AppTestCase {
         let query = try XCTUnwrap(Search.query(app.db, ["test"], page: 1, pageSize: 20))
         // validate
         XCTAssertEqual(renderSQL(query), """
-            SELECT * FROM ((SELECT DISTINCT 'author' AS "match_type", NULL AS "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("repo_owner", $1) AS "levenshtein_dist" FROM "search" WHERE "repo_owner" ILIKE $2 ORDER BY "levenshtein_dist" LIMIT 50) UNION ALL (SELECT DISTINCT 'keyword' AS "match_type", "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", NULL AS "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("keyword", $3) AS "levenshtein_dist" FROM "search", UNNEST("keywords") AS "keyword" WHERE "keyword" ILIKE $4 ORDER BY "levenshtein_dist" LIMIT 50) UNION ALL (SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist" FROM "search" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $5 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL ORDER BY LOWER("package_name") = $6 DESC, "score" DESC, "package_name" ASC LIMIT 21 OFFSET 0)) AS "t"
+            SELECT * FROM ((SELECT DISTINCT 'author' AS "match_type", NULL AS "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("repo_owner", $1) AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($2) AS "tsquery", setweight(to_tsvector("repo_owner"), 'A') AS "tsvector" WHERE "repo_owner" ILIKE $3 ORDER BY "levenshtein_dist" LIMIT 50) UNION ALL (SELECT DISTINCT 'keyword' AS "match_type", "keyword", NULL::UUID AS "package_id", NULL AS "package_name", NULL AS "repo_name", NULL AS "repo_owner", NULL::INT AS "score", NULL AS "summary", NULL::INT AS "stars", NULL AS "license", NULL::TIMESTAMP AS "last_commit_date", NULL::TIMESTAMP AS "last_activity_at", NULL::TEXT[] AS "keywords", NULL::BOOL AS "has_docs", LEVENSHTEIN("keyword", $4) AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", UNNEST("keywords") AS "keyword", plainto_tsquery($5) AS "tsquery", setweight(to_tsvector("keyword"), 'B') AS "tsvector" WHERE "keyword" ILIKE $6 ORDER BY "tsrankvalue" LIMIT 50) UNION ALL (SELECT 'package' AS "match_type", NULL AS "keyword", "package_id", "package_name", "repo_name", "repo_owner", "score", "summary", "stars", "license", "last_commit_date", "last_activity_at", "keywords", "has_docs", NULL::INT AS "levenshtein_dist", ts_rank("tsvector", "tsquery") AS "tsrankvalue" FROM "search", plainto_tsquery($7) AS "tsquery", setweight(to_tsvector(CONCAT_WS(' ', COALESCE("package_name", ''), COALESCE("summary", ''), ARRAY_TO_STRING("keywords", ' '))), 'A') AS "tsvector" WHERE CONCAT_WS(' ', "package_name", COALESCE("summary", ''), "repo_name", "repo_owner", ARRAY_TO_STRING("keywords", ' ')) ~* $8 AND "repo_owner" IS NOT NULL AND "repo_name" IS NOT NULL ORDER BY LOWER("package_name") = $9 DESC, "tsrankvalue" DESC, "score" DESC, "package_name" ASC LIMIT 21 OFFSET 0)) AS "t"
             """)
-        XCTAssertEqual(binds(query), ["test", "%test%", "test", "%test%", "test", "test"])
+        XCTAssertEqual(binds(query), ["test", "test", "%test%", "test", "test", "%test%", "test", "test", "test"])
     }
 
     func test_fetch_single() throws {
@@ -744,7 +744,7 @@ class SearchTests: AppTestCase {
         // validate that keyword results are ordered by levenshtein distance
         // (packages are also matched via their keywords)
         XCTAssertEqual(res.results.map(\.testDescription),
-                       ["k:topic", "k:topicb", "k:atopicb", "p:p3", "p:p2", "p:p1"])
+                       ["k:topicb", "k:atopicb", "k:topic", "p:p1", "p:p3", "p:p2"])
     }
 
     func test_search_author_multiple_results() async throws {

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -32,6 +32,17 @@ class WebpageSnapshotTests: SnapshotTestCase {
     }
     
     func test_PackageShowView() throws {
+        
+        // Work-around to set the local time zone for time sensitive
+        // tests. Sets the explicit default time zone to UTC for the duration
+        // of this test.
+        let explicitGMTTimeZone = TimeZone(identifier: "Etc/UTC")!
+        let oldDefault = NSTimeZone.default
+        NSTimeZone.default = explicitGMTTimeZone
+        defer {
+            NSTimeZone.default = oldDefault
+        }
+
         var model = PackageShow.Model.mock
         model.homepageUrl = "https://swiftpackageindex.com/"
         let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
@@ -41,6 +52,17 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     
     func test_PackageShowView_few_keywords() throws {
+        
+        // Work-around to set the local time zone for time sensitive
+        // tests. Sets the explicit default time zone to UTC for the duration
+        // of this test.
+        let explicitGMTTimeZone = TimeZone(identifier: "Etc/UTC")!
+        let oldDefault = NSTimeZone.default
+        NSTimeZone.default = explicitGMTTimeZone
+        defer {
+            NSTimeZone.default = oldDefault
+        }
+
         var model = PackageShow.Model.mock
         let keywordsWithCounts = [("tag1", 1),
                                   ("tag2", 10),
@@ -57,6 +79,17 @@ class WebpageSnapshotTests: SnapshotTestCase {
     }
 
     func test_PackageShowView_many_keywords() throws {
+        
+        // Work-around to set the local time zone for time sensitive
+        // tests. Sets the explicit default time zone to UTC for the duration
+        // of this test.
+        let explicitGMTTimeZone = TimeZone(identifier: "Etc/UTC")!
+        let oldDefault = NSTimeZone.default
+        NSTimeZone.default = explicitGMTTimeZone
+        defer {
+            NSTimeZone.default = oldDefault
+        }
+
         var model = PackageShow.Model.mock
         let keywordsWithCounts = [("tag1", 1), ("tag2", 10), ("tag3", 100), ("tag4", 1000), ("tag5", 1234),
                         ("tag6", 1250), ("tag7", 1249), ("tag8", 1251), ("tag9", 12345),


### PR DESCRIPTION
implementation (and copious experimental notes, which I WILL remove) based on the improving search discussion thread https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/discussions/1876

The code is _mostly_ functional, and in the state where I'm trying to refine initial efforts where I used `SQLRaw` to directly embed the various Postgres functions: `ts_rank`, `to_tsvector`, and `plainto_tsquery`. I wanted to get this up here so y'all could at least see the explicit work.

This version is retaining the `%ILIKE%` for actually identifying what should be returned, so it still does return irrelevant results for the query `ping`, but doesn't drop out the UIBezierCurve in the case of a search on `bezier` - and it doesn't trash the non-english queries (mandarin, for example) which rely on direct pattern matching.

There's been NO fixing of the tests (yet) - this dramatically changes the rendered SQL to extend the union to include a ranking value (`tsrankvalue`) from each sub-query set, and then orders the end results. Part of the code that I have commented out is attempting to make some weighting judgements to influence the weighting of various terms, with the hope that something like a direct package name match wouldn't need that prefixed sort order on "does the package name equal exactly". But... something I'm doing isn't working, and I haven't sorted out how to debug that part yet.

I've also not checked the performance implications of these searches. It's generating these ts_vectors on the fly - some or all of which may be more efficient as pre-generated within the establishment of the materialized search view. It's not brutally noticeable, but I also just haven't checked the numbers.