### PR TITLE
Make target/archive naming for documentation more consistent

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -117,7 +117,7 @@ extension PackageShow {
                 let packageId = result.package.id
             else { return nil }
 
-            let defaulDocTarget = result.defaultBranchVersion.docArchives?.first?.title
+            let defaultDocArchive = result.defaultBranchVersion.docArchives?.first?.title
 
             self.init(
                 packageId: packageId,
@@ -153,7 +153,7 @@ extension PackageShow {
                 homepageUrl: repository.homepageUrl,
                 documentationMetadata: DocumentationMetadata(
                     reference: result.repository.defaultBranch,
-                    defaultTarget: defaulDocTarget),
+                    defaultArchive: defaultDocArchive),
                 dependencyCodeSnippets: Self.packageDependencyCodeSnippets(
                     packageURL: result.package.url,
                     defaultBranchReference: result.defaultBranchVersion.model.reference,
@@ -167,16 +167,16 @@ extension PackageShow {
 
     struct DocumentationMetadata: Equatable {
         let reference: String
-        let defaultTarget: String
+        let defaultArchive: String
 
-        init?(reference: String?, defaultTarget: String?) {
+        init?(reference: String?, defaultArchive: String?) {
             guard
                 let reference = reference,
-                let defaultTarget = defaultTarget
+                let defaultArchive = defaultArchive
             else { return nil }
 
             self.reference = reference
-            self.defaultTarget = defaultTarget
+            self.defaultArchive = defaultArchive
         }
     }
     

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -248,7 +248,7 @@ enum PackageShow {
                     .unwrap(model.documentationMetadata) { metadata in
                         .li(
                             .a(
-                                .href(model.relativeDocumentationURL(reference: metadata.reference, target: metadata.defaultTarget)),
+                                .href(model.relativeDocumentationURL(reference: metadata.reference, target: metadata.defaultArchive)),
                                 .data(named: "turbo", value: String(false)),
                                 "Documentation"
                             )

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -137,7 +137,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     func test_PackageShowView_with_single_documentation_link() throws {
         var model = PackageShow.Model.mock
-        model.documentationMetadata = .init(reference: "main", defaultTarget: "Target")
+        model.documentationMetadata = .init(reference: "main", defaultArchive: "Archive")
         let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
 
         assertSnapshot(matching: page, as: .html)

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
@@ -290,7 +290,7 @@
                   </div>
                 </li>
                 <li>
-                  <a href="/Alamo/Alamofire/main/documentation/target" data-turbo="false">Documentation</a>
+                  <a href="/Alamo/Alamofire/main/documentation/archive" data-turbo="false">Documentation</a>
                 </li>
               </ul>
             </section>


### PR DESCRIPTION
No functional changes, just a refactor.