### PR TITLE
Cope better with badly encoded URLs in README files

### DIFF
--- a/Sources/App/Views/PackageController/PackageReadme+Model.swift
+++ b/Sources/App/Views/PackageController/PackageReadme+Model.swift
@@ -61,7 +61,7 @@ extension PackageReadme {
             do {
                 let imageElements = try element.select("img")
                 for imageElement in imageElements {
-                    guard let imageUrl = URL(string: try imageElement.attr("src"))
+                    guard let imageUrl = URL(withPotentiallyPercentEncodedPath: try imageElement.attr("src"))
                     else { continue }
 
                     // Assume all images are relative to GitHub as that's the only current source for README data.

--- a/Sources/App/Views/PackageController/PackageReadme+Model.swift
+++ b/Sources/App/Views/PackageController/PackageReadme+Model.swift
@@ -61,7 +61,7 @@ extension PackageReadme {
             do {
                 let imageElements = try element.select("img")
                 for imageElement in imageElements {
-                    guard let imageUrl = URL(withPotentiallyPercentEncodedPath: try imageElement.attr("src"))
+                    guard let imageUrl = URL(withPotentiallyUnencodedPath: try imageElement.attr("src"))
                     else { continue }
 
                     // Assume all images are relative to GitHub as that's the only current source for README data.
@@ -82,7 +82,7 @@ extension PackageReadme {
             do {
                 let linkElements = try element.select("a")
                 for linkElement in linkElements {
-                    guard let linkUrl = URL(withPotentiallyPercentEncodedPath: try linkElement.attr("href"))
+                    guard let linkUrl = URL(withPotentiallyUnencodedPath: try linkElement.attr("href"))
                     else { continue }
 
                     // Assume all links are relative to GitHub as that's the only current source for README data.
@@ -102,7 +102,7 @@ extension PackageReadme {
 }
 
 extension URL {
-    init?(withPotentiallyPercentEncodedPath string: String) {
+    init?(withPotentiallyUnencodedPath string: String) {
         if let url = URL(string: string) {
             self = url
         } else if let encodedString = string.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),

--- a/Sources/App/Views/PackageController/PackageReadme+Model.swift
+++ b/Sources/App/Views/PackageController/PackageReadme+Model.swift
@@ -105,7 +105,7 @@ extension URL {
     init?(withPotentiallyPercentEncodedPath string: String) {
         if let url = URL(string: string) {
             self = url
-        } else if let encodedString = string.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+        } else if let encodedString = string.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
                   let encodedUrl = URL(string: encodedString) {
             self = encodedUrl
         } else {

--- a/Sources/App/Views/PackageController/PackageReadme+Model.swift
+++ b/Sources/App/Views/PackageController/PackageReadme+Model.swift
@@ -100,3 +100,16 @@ extension PackageReadme {
         }
     }
 }
+
+extension URL {
+    init?(withPotentiallyPercentEncodedPath string: String) {
+        if let url = URL(string: string) {
+            self = url
+        } else if let encodedString = string.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed),
+                  let encodedUrl = URL(string: encodedString) {
+            self = encodedUrl
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/App/Views/PackageController/PackageReadme+Model.swift
+++ b/Sources/App/Views/PackageController/PackageReadme+Model.swift
@@ -82,7 +82,7 @@ extension PackageReadme {
             do {
                 let linkElements = try element.select("a")
                 for linkElement in linkElements {
-                    guard let linkUrl = URL(string: try linkElement.attr("href"))
+                    guard let linkUrl = URL(withPotentiallyPercentEncodedPath: try linkElement.attr("href"))
                     else { continue }
 
                     // Assume all links are relative to GitHub as that's the only current source for README data.

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -88,8 +88,8 @@ class PackageReadmeModelTests: SnapshotTestCase {
                             <a href="https://example.com/absolute/url">Absolute link.</a>
                             <a href="/root/relative/url">Root relative link.</a>
                             <a href="relative/url">Relative link.</a>
-                            <a src="/url/with/encoded%20spaces.png">
-                            <a src="/url/with/unencoded spaces.png">
+                            <a href="/url/with/encoded%20spaces">Encoded spaces.</a>
+                            <a href="/url/with/unencoded spaces">Unencoded spaces.</a>
                             <a href="#anchor">Anchor link.</a>
                             <a>Invalid link.</a>
                         </article>

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -109,6 +109,7 @@ class PackageReadmeModelTests: SnapshotTestCase {
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/encoded%20spaces")).absoluteString, "/encoded%20spaces")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/unencoded spaces")).absoluteString, "/unencoded%20spaces")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/multiple {unencoded}")).absoluteString, "/multiple%20%7Bunencoded%7D")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/partially%20{encoded}")).absoluteString, "/partially%20%7Bencoded%7D")
 
         // Absolute URLs
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/and/path")).absoluteString, "https://full.host/and/path")

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -101,4 +101,15 @@ class PackageReadmeModelTests: SnapshotTestCase {
         let readme = try XCTUnwrap(model.readme)
         assertSnapshot(matching: readme, as: .lines)
     }
+
+    func test_url_initWithPotentiallyPercentEncodedPath() throws {
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/root/relative/url")).absoluteString, "/root/relative/url")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "relative/url")).absoluteString, "relative/url")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/relative/encoded%20spaces")).absoluteString, "/relative/encoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/relative/unencoded spaces")).absoluteString, "/relative/unencoded%20spaces")
+
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/and/path")).absoluteString, "https://full.host/and/path")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/encoded%20spaces")).absoluteString, "https://full.host/encoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/unencoded spaces")).absoluteString, "https://full.host/unencoded%20spaces")
+    }
 }

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -102,18 +102,18 @@ class PackageReadmeModelTests: SnapshotTestCase {
         assertSnapshot(matching: readme, as: .lines)
     }
 
-    func test_url_initWithPotentiallyPercentEncodedPath() throws {
+    func test_url_initWithPotentiallyUnencodedPath() throws {
         // Relative URLs
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/root/relative/url")).absoluteString, "/root/relative/url")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "relative/url")).absoluteString, "relative/url")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/encoded%20spaces")).absoluteString, "/encoded%20spaces")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/unencoded spaces")).absoluteString, "/unencoded%20spaces")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/multiple%20%7Bencoded%7D")).absoluteString, "/multiple%20%7Bencoded%7D")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/multiple {unencoded}")).absoluteString, "/multiple%20%7Bunencoded%7D")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "/root/relative/url")).absoluteString, "/root/relative/url")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "relative/url")).absoluteString, "relative/url")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "/encoded%20spaces")).absoluteString, "/encoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "/unencoded spaces")).absoluteString, "/unencoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "/multiple%20%7Bencoded%7D")).absoluteString, "/multiple%20%7Bencoded%7D")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "/multiple {unencoded}")).absoluteString, "/multiple%20%7Bunencoded%7D")
 
         // Absolute URLs
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/and/path")).absoluteString, "https://full.host/and/path")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/encoded%20spaces")).absoluteString, "https://full.host/encoded%20spaces")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/unencoded spaces")).absoluteString, "https://full.host/unencoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "https://full.host/and/path")).absoluteString, "https://full.host/and/path")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "https://full.host/encoded%20spaces")).absoluteString, "https://full.host/encoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "https://full.host/unencoded spaces")).absoluteString, "https://full.host/unencoded%20spaces")
     }
 }

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -59,6 +59,8 @@ class PackageReadmeModelTests: SnapshotTestCase {
                             <img src="https://example.com/absolute/image/url.png">
                             <img src="/root/relative/image/url.png">
                             <img src="relative/image/url.png">
+                            <img src="/url/with/encoded%20spaces.png">
+                            <img src="/url/with/unencoded spaces.png">
                             <img>
                         </article>
                     </div>
@@ -86,6 +88,8 @@ class PackageReadmeModelTests: SnapshotTestCase {
                             <a href="https://example.com/absolute/url">Absolute link.</a>
                             <a href="/root/relative/url">Root relative link.</a>
                             <a href="relative/url">Relative link.</a>
+                            <a src="/url/with/encoded%20spaces.png">
+                            <a src="/url/with/unencoded spaces.png">
                             <a href="#anchor">Anchor link.</a>
                             <a>Invalid link.</a>
                         </article>

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -108,8 +108,8 @@ class PackageReadmeModelTests: SnapshotTestCase {
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "relative/url")).absoluteString, "relative/url")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/encoded%20spaces")).absoluteString, "/encoded%20spaces")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/unencoded spaces")).absoluteString, "/unencoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/multiple%20%7Bencoded%7D")).absoluteString, "/multiple%20%7Bencoded%7D")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/multiple {unencoded}")).absoluteString, "/multiple%20%7Bunencoded%7D")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/partially%20{encoded}")).absoluteString, "/partially%20%7Bencoded%7D")
 
         // Absolute URLs
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/and/path")).absoluteString, "https://full.host/and/path")

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -103,11 +103,14 @@ class PackageReadmeModelTests: SnapshotTestCase {
     }
 
     func test_url_initWithPotentiallyPercentEncodedPath() throws {
+        // Relative URLs
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/root/relative/url")).absoluteString, "/root/relative/url")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "relative/url")).absoluteString, "relative/url")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/relative/encoded%20spaces")).absoluteString, "/relative/encoded%20spaces")
-        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/relative/unencoded spaces")).absoluteString, "/relative/unencoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/encoded%20spaces")).absoluteString, "/encoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/unencoded spaces")).absoluteString, "/unencoded%20spaces")
+        XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "/multiple {unencoded}")).absoluteString, "/multiple%20%7Bunencoded%7D")
 
+        // Absolute URLs
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/and/path")).absoluteString, "https://full.host/and/path")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/encoded%20spaces")).absoluteString, "https://full.host/encoded%20spaces")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyPercentEncodedPath: "https://full.host/unencoded spaces")).absoluteString, "https://full.host/unencoded%20spaces")

--- a/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeImages.1.txt
+++ b/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeImages.1.txt
@@ -2,4 +2,6 @@
 <img src="https://example.com/absolute/image/url.png"> 
 <img src="https://github.com/root/relative/image/url.png"> 
 <img src="relative/image/url.png"> 
+<img src="https://github.com/url/with/encoded%20spaces.png"> 
+<img src="https://github.com/url/with/unencoded%20spaces.png"> 
 <img>

--- a/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeLinks.1.txt
+++ b/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeLinks.1.txt
@@ -2,7 +2,7 @@
 <a href="https://example.com/absolute/url">Absolute link.</a> 
 <a href="https://github.com/root/relative/url">Root relative link.</a> 
 <a href="relative/url">Relative link.</a> 
-<a src="/url/with/encoded%20spaces.png"> </a>
-<a src="/url/with/unencoded%20spaces.png"> </a>
+<a href="https://github.com/url/with/encoded%20spaces">Encoded spaces.</a> 
+<a href="https://github.com/url/with/unencoded%20spaces">Unencoded spaces.</a> 
 <a href="#anchor">Anchor link.</a> 
 <a>Invalid link.</a>

--- a/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeLinks.1.txt
+++ b/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeLinks.1.txt
@@ -2,5 +2,7 @@
 <a href="https://example.com/absolute/url">Absolute link.</a> 
 <a href="https://github.com/root/relative/url">Root relative link.</a> 
 <a href="relative/url">Relative link.</a> 
+<a src="/url/with/encoded%20spaces.png"> </a>
+<a src="/url/with/unencoded%20spaces.png"> </a>
 <a href="#anchor">Anchor link.</a> 
 <a>Invalid link.</a>


### PR DESCRIPTION
Fixes #1917

Alright. The fix to #1917 is tricky and I could use a second opinion on the best way to fix it. I originally assumed *all* relative URLs were broken but this is not the case. It’s an issue with unencoded characters in URLs.

For example:

```
https://example.com/encoded%20url.png
/encoded%20url.png
```

Both render fine as the URLs are correctly encoded. Whereas:

```
https://example.com/unencoded url.png
/encoded url.png
```
Both break as these are not valid URLs as spaces are not allowed. This would also break for other characters that are not allowed, like `<`, `{`, etc… 

So, that’s the problem defined.

---

My thought on how to fix this was to make a new initialiser on `URL` that coped with this situation. `URL(string:)` returns nil for the unencoded URLs (because they are not URLs) and I thought that could be used to work around the issue. This draft PR contains an implementation based on that.

However, while it works well for relative URLs where *all* invalid characters are either encoded or unencoded. It does not work at all for URLs that have partially encoded URLs, or *any* absolute URL.

Take the example of initialising with an absolute URL:

```
https://full.host/unencoded spaces
```

That fails initialisation with `URL(string:)` because it’s not a valid URL, so the code attempts to encode the input, which now includes a valid `:` between the protocol and the host, meaning it outputs:

```
https%3A//full.host/unencoded%20spaces
```

I’m not sure how to fix this without writing a URL parser, which we absolutely should not do.