### PR TITLE
Change default documentation link to point to the latest stable release, if available

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -117,7 +117,15 @@ extension PackageShow {
                 let packageId = result.package.id
             else { return nil }
 
-            let defaultDocArchive = result.defaultBranchVersion.docArchives?.first?.title
+            let defaultDocumentationMetadata: DocumentationMetadata? = {
+                if let releaseVersion = result.releaseVersion {
+                    return .init(reference: "\(releaseVersion.reference)",
+                                 defaultArchive: releaseVersion.docArchives?.first?.title)
+                } else {
+                    return .init(reference: "\(result.defaultBranchVersion.reference)",
+                                 defaultArchive: result.defaultBranchVersion.docArchives?.first?.title)
+                }
+            }()
 
             self.init(
                 packageId: packageId,
@@ -151,9 +159,7 @@ extension PackageShow {
                 score: result.package.score,
                 isArchived: repository.isArchived,
                 homepageUrl: repository.homepageUrl,
-                documentationMetadata: DocumentationMetadata(
-                    reference: result.repository.defaultBranch,
-                    defaultArchive: defaultDocArchive),
+                documentationMetadata: defaultDocumentationMetadata,
                 dependencyCodeSnippets: Self.packageDependencyCodeSnippets(
                     packageURL: result.package.url,
                     defaultBranchReference: result.defaultBranchVersion.model.reference,

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -118,12 +118,15 @@ extension PackageShow {
             else { return nil }
 
             let defaultDocumentationMetadata: DocumentationMetadata? = {
-                if let releaseVersion = result.releaseVersion {
+                if let releaseVersion = result.releaseVersion,
+                   let releaseVersionDocArchive = releaseVersion.docArchives?.first {
                     return .init(reference: "\(releaseVersion.reference)",
-                                 defaultArchive: releaseVersion.docArchives?.first?.title)
-                } else {
+                                 defaultArchive: releaseVersionDocArchive.title)
+                } else if let defaultBranchDocArchive = result.defaultBranchVersion.docArchives?.first {
                     return .init(reference: "\(result.defaultBranchVersion.reference)",
-                                 defaultArchive: result.defaultBranchVersion.docArchives?.first?.title)
+                                 defaultArchive: defaultBranchDocArchive.title)
+                } else {
+                    return nil
                 }
             }()
 

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -117,16 +117,24 @@ extension PackageShow {
                 let packageId = result.package.id
             else { return nil }
 
+
             let defaultDocumentationMetadata: DocumentationMetadata? = {
-                if let releaseVersion = result.releaseVersion,
-                   let releaseVersionDocArchive = releaseVersion.docArchives?.first {
-                    return .init(reference: "\(releaseVersion.reference)",
-                                 defaultArchive: releaseVersionDocArchive.title)
-                } else if let defaultBranchDocArchive = result.defaultBranchVersion.docArchives?.first {
-                    return .init(reference: "\(result.defaultBranchVersion.reference)",
-                                 defaultArchive: defaultBranchDocArchive.title)
+                if Environment.current == .development {
+                    if let releaseVersion = result.releaseVersion,
+                       let releaseVersionDocArchive = releaseVersion.docArchives?.first {
+                        return .init(reference: "\(releaseVersion.reference)",
+                                     defaultArchive: releaseVersionDocArchive.title)
+                    } else if let defaultBranchDocArchive = result.defaultBranchVersion.docArchives?.first {
+                        return .init(reference: "\(result.defaultBranchVersion.reference)",
+                                     defaultArchive: defaultBranchDocArchive.title)
+                    } else {
+                        return nil
+                    }
                 } else {
-                    return nil
+                    // Previous logic, until we're ready to roll out versioned documentation.
+                    return DocumentationMetadata(
+                        reference: result.repository.defaultBranch,
+                        defaultArchive: result.defaultBranchVersion.docArchives?.first?.title)
                 }
             }()
 


### PR DESCRIPTION
Fixes #1836

Gated for release, but this now generates a version to stable documentation where available. The link will always try to exist, though, so if an author adds a `.spi.yml` but does not release a stable version, it will link to default branch docs.