### PR TITLE
Allow case insensitive matching on owner and repository for documentation routes

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -120,8 +120,8 @@ struct PackageController {
                     .query(on: req.db,
                            join: \Version.$package.$id == \Package.$id, method: .inner,
                            join: \Package.$id == \Repository.$package.$id, method: .inner)
-                    .filter(Repository.self, \.$owner == owner) //TODO: Lowercase
-                    .filter(Repository.self, \.$name == repository)
+                    .filter(Repository.self, \.$owner, .custom("ilike"), owner)
+                    .filter(Repository.self, \.$name, .custom("ilike"), repository)
                     .filter(\Version.$docArchives != nil)
                     .field(Version.self, \.$reference)
                     .field(Version.self, \.$latest)

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -271,6 +271,11 @@ class PackageController_routesTests: AppTestCase {
                     .contains(#"<link rel="stylesheet" href="/docc.css?test">"#),
                           "was: \($0.body.asString())")
         }
+
+        // Test case insensitive path.
+        try app.test(.GET, "/Owner/Package/1.2.3/documentation") {
+            XCTAssertEqual($0.status, .ok)
+        }
     }
 
     func test_documentation_404() throws {


### PR DESCRIPTION
Fixes #1925