### PR TITLE
Add Staging banner to documentation pages in development/staging environments

### DIFF
--- a/FrontEnd/docc.scss
+++ b/FrontEnd/docc.scss
@@ -57,6 +57,15 @@ footer.spi {
             color: var(--header-link-highlight);
         }
     }
+
+    .staging {
+        padding: 10px;
+        font-weight: bold;
+        text-align: center;
+        text-transform: uppercase;
+        color: var(--white);
+        background-color: var(--mid-red);
+    }
 }
 
 header.spi {
@@ -229,13 +238,4 @@ footer.spi nav {
         font-size: 13px;
         text-align: center;
     }
-}
-
-div.spi-staging {
-    padding: 10px;
-    font-weight: bold;
-    text-align: center;
-    text-transform: uppercase;
-    color: var(--white);
-    background-color: var(--mid-red);
 }

--- a/FrontEnd/docc.scss
+++ b/FrontEnd/docc.scss
@@ -230,3 +230,12 @@ footer.spi nav {
         text-align: center;
     }
 }
+
+div.spi-staging {
+    padding: 10px;
+    font-weight: bold;
+    text-align: center;
+    text-transform: uppercase;
+    color: var(--white);
+    background-color: var(--mid-red);
+}

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -60,10 +60,14 @@ struct DocumentationPageProcessor {
         do {
             document = try SwiftSoup.parse(rawHtml)
             try document.head()?.append(self.stylesheetLink)
-            try document.body()?.prepend(self.stagingBanner)
             try document.body()?.prepend(self.header)
+            if Environment.current == .development {
+                try document.body()?.prepend(self.stagingBanner)
+            }
             try document.body()?.append(self.footer)
-            try document.body()?.append(self.stagingBanner)
+            if Environment.current == .development {
+                try document.body()?.append(self.stagingBanner)
+            }
             if let analyticsScript = self.analyticsScript {
                 try document.head()?.append(analyticsScript)
             }

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -61,13 +61,7 @@ struct DocumentationPageProcessor {
             document = try SwiftSoup.parse(rawHtml)
             try document.head()?.append(self.stylesheetLink)
             try document.body()?.prepend(self.header)
-            if Environment.current == .development {
-                try document.body()?.prepend(self.stagingBanner)
-            }
             try document.body()?.append(self.footer)
-            if Environment.current == .development {
-                try document.body()?.append(self.stagingBanner)
-            }
             if let analyticsScript = self.analyticsScript {
                 try document.head()?.append(analyticsScript)
             }
@@ -145,6 +139,7 @@ struct DocumentationPageProcessor {
         return Plot.Node.group(
             .header(
                 .class("spi"),
+                .if(Environment.current == .development, stagingBanner()),
                 .div(
                     .class("inner breadcrumbs"),
                     .nav(
@@ -229,7 +224,8 @@ struct DocumentationPageProcessor {
                         .text(".")
                     )
                 )
-            )
+            ),
+            .if(Environment.current == .development, stagingBanner())
         ).render()
     }
 
@@ -255,10 +251,10 @@ struct DocumentationPageProcessor {
         }
     }
 
-    var stagingBanner: String {
-        Plot.Node.div(
-            .class("spi-staging"),
+    func stagingBanner() -> Plot.Node<HTML.BodyContext> {
+        .div(
+            .class("staging"),
             .text("Staging / Development")
-        ).render()
+        )
     }
 }

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -60,8 +60,10 @@ struct DocumentationPageProcessor {
         do {
             document = try SwiftSoup.parse(rawHtml)
             try document.head()?.append(self.stylesheetLink)
+            try document.body()?.prepend(self.stagingBanner)
             try document.body()?.prepend(self.header)
             try document.body()?.append(self.footer)
+            try document.body()?.append(self.stagingBanner)
             if let analyticsScript = self.analyticsScript {
                 try document.head()?.append(analyticsScript)
             }
@@ -247,5 +249,12 @@ struct DocumentationPageProcessor {
             case .defaultBranch: return "This documentation is from the \(reference) branch and may not reflect the latest stable release."
             default: return ""
         }
+    }
+
+    var stagingBanner: String {
+        Plot.Node.div(
+            .class("spi-staging"),
+            .text("Staging / Development")
+        ).render()
     }
 }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
@@ -9,10 +9,10 @@
   <link rel="stylesheet" href="/docc.css?test">
  </head> 
  <body>
-  <div class="spi-staging">
-   Staging / Development
-  </div>
   <header class="spi">
+   <div class="staging">
+    Staging / Development
+   </div>
    <div class="inner breadcrumbs">
     <nav>
      <ul>
@@ -44,9 +44,9 @@
      <small>The Swift Package Index is entirely funded by sponsorship. Thank you to <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server#funding-and-sponsorship">all our sponsors for their generosity</a>.</small>
     </nav>
    </div>
+   <div class="staging">
+    Staging / Development
+   </div>
   </footer>
-  <div class="spi-staging">
-   Staging / Development
-  </div>
  </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
@@ -9,6 +9,9 @@
   <link rel="stylesheet" href="/docc.css?test">
  </head> 
  <body>
+  <div class="spi-staging">
+   Staging / Development
+  </div>
   <header class="spi">
    <div class="inner breadcrumbs">
     <nav>
@@ -42,5 +45,8 @@
     </nav>
    </div>
   </footer>
+  <div class="spi-staging">
+   Staging / Development
+  </div>
  </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
@@ -9,10 +9,10 @@
   <link rel="stylesheet" href="/docc.css?test">
  </head> 
  <body>
-  <div class="spi-staging">
-   Staging / Development
-  </div>
   <header class="spi">
+   <div class="staging">
+    Staging / Development
+   </div>
    <div class="inner breadcrumbs">
     <nav>
      <ul>
@@ -60,9 +60,9 @@
      <small>The Swift Package Index is entirely funded by sponsorship. Thank you to <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server#funding-and-sponsorship">all our sponsors for their generosity</a>.</small>
     </nav>
    </div>
+   <div class="staging">
+    Staging / Development
+   </div>
   </footer>
-  <div class="spi-staging">
-   Staging / Development
-  </div>
  </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
@@ -9,6 +9,9 @@
   <link rel="stylesheet" href="/docc.css?test">
  </head> 
  <body>
+  <div class="spi-staging">
+   Staging / Development
+  </div>
   <header class="spi">
    <div class="inner breadcrumbs">
     <nav>
@@ -58,5 +61,8 @@
     </nav>
    </div>
   </footer>
+  <div class="spi-staging">
+   Staging / Development
+  </div>
  </body>
 </html>


### PR DESCRIPTION
Fixes #1938 
Merge after #1939 

<img width="1143" alt="Screenshot 2022-08-01 at 16 06 44@2x" src="https://user-images.githubusercontent.com/5180/182180530-f44d87bc-f853-4eb5-aa54-a8dc1a56de83.png">
