### PR TITLE
Redirect to the first available documentation archive if no archive is supplied on the URL

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -105,7 +105,9 @@ struct PackageController {
 
         let url = try Self.awsDocumentationURL(owner: owner, repository: repository, reference: reference, fragment: fragment, path: path)
         let awsResponse = try await Current.fetchDocumentation(req.client, url)
-        guard (200..<399).contains(awsResponse.status.code) else {
+
+        // Never let a request continue if the AWS request fails, except to a potential `/owner/repo/ref/documentation/` redirect.
+        guard (200..<399).contains(awsResponse.status.code) || fragment == .documentationRedirect else {
             // Convert anything that isn't a 2xx or 3xx from AWS into a 404 from us.
             throw Abort(.notFound)
         }

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -142,22 +142,6 @@ struct PackageController {
                                                                                              reference: reference,
                                                                                              docArchive: docArchive.name))
 
-// Possible solution if the `first`-based one doesn't work
-//            case .documentationRedirect:
-//                let queryResult = try await Joined3<Version, Package, Repository>
-//                    .query(on: req.db,
-//                           join: \Version.$package.$id == \Package.$id, method: .inner,
-//                           join: \Package.$id == \Repository.$package.$id, method: .inner)
-//                    .filter(Repository.self, \.$owner, .custom("ilike"), owner)
-//                    .filter(Repository.self, \.$name, .custom("ilike"), repository)
-//                    .filter(\Version.$docArchives != nil)
-//                    .field(Version.self, \.$reference)
-//                    .field(Version.self, \.$docArchives)
-//                    .all()
-//                guard let version = queryResult.first(where: { result in
-//                    "\(result.model.reference)" == reference
-//                }) else { throw Abort(.notFound) }
-
             case .documentation:
                 let queryResult = try await Joined3<Version, Package, Repository>
                     .query(on: req.db,

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -114,11 +114,11 @@ struct PackageController {
 
         switch fragment {
             case .documentationRedirect:
-                let possibleReferences: [Reference] = {
+                let referenceToMatch: Reference = {
                     if let semanticVersion = SemanticVersion(reference) {
-                        return [ .branch(reference), .tag(semanticVersion, reference) ]
+                        return .tag(semanticVersion, reference)
                     } else {
-                        return [ .branch(reference) ]
+                        return .branch(reference)
                     }
                 }()
 
@@ -128,7 +128,7 @@ struct PackageController {
                            join: \Package.$id == \Repository.$package.$id, method: .inner)
                     .filter(Repository.self, \.$owner, .custom("ilike"), owner)
                     .filter(Repository.self, \.$name, .custom("ilike"), repository)
-                    .filter(\Version.$reference ~~ possibleReferences)
+                    .filter(\Version.$reference == referenceToMatch)
                     .filter(\Version.$docArchives != nil)
                     .field(Version.self, \.$docArchives)
                     .first()

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -94,8 +94,10 @@ struct DocumentationPageProcessor {
             return .li(
                 .if(version.reference == reference, .class("current")),
                 .a(
-                    .href(relativeDocumentationURL(reference: version.reference,
-                                                   docArchive: currentArchive.name)),
+                    .href(Self.relativeDocumentationURL(owner: repositoryOwner,
+                                                        repository: repositoryName,
+                                                        reference: version.reference,
+                                                        docArchive: currentArchive.name)),
                     .span(
                         .class(version.kind.cssClass),
                         .text(version.reference)
@@ -131,7 +133,10 @@ struct DocumentationPageProcessor {
                         .li(
                             .if(archive.isCurrent, .class("current")),
                             .a(
-                                .href(relativeDocumentationURL(reference: reference, docArchive: archive.name)),
+                                .href(Self.relativeDocumentationURL(owner: repositoryOwner,
+                                                                    repository: repositoryName,
+                                                                    reference: reference,
+                                                                    docArchive: archive.name)),
                                 .text(archive.name)
                             )
                         )
@@ -164,8 +169,10 @@ struct DocumentationPageProcessor {
                                         .unwrap(latestStable.docArchives.first) { docArchive in
                                                 .group(
                                                     .a(
-                                                        .href(relativeDocumentationURL(reference: latestStable.reference,
-                                                                                       docArchive: docArchive)),
+                                                        .href(Self.relativeDocumentationURL(owner:repositoryOwner,
+                                                                                            repository: repositoryName,
+                                                                                            reference: latestStable.reference,
+                                                                                            docArchive: docArchive)),
                                                         .text("View latest stable docs")
                                                     ),
                                                     .text(".")
@@ -245,8 +252,8 @@ struct DocumentationPageProcessor {
     }
 
     // Note: When this gets merged back with the refactored SiteURL, note that it's duplicated in `PackageShow.Model`.
-    func relativeDocumentationURL(reference: String, docArchive: String) -> String {
-        "/\(repositoryOwner)/\(repositoryName)/\(reference)/documentation/\(docArchive.lowercased())"
+    static func relativeDocumentationURL(owner: String, repository: String, reference: String, docArchive: String) -> String {
+        "/\(owner)/\(repository)/\(reference)/documentation/\(docArchive.lowercased())"
     }
 
     var latestStableLinkExplanatoryText: String {

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -67,7 +67,7 @@ public func configure(_ app: Application) throws -> String {
                                 tlsConfiguration: tlsConfig,
                                 maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
                                 // Set sqlLogLevel to .info to log SQL queries with the default log level.
-                                sqlLogLevel: .debug),
+                                sqlLogLevel: .info),
                       as: .psql)
     
     do {  // Migration 001 - schema 1.0

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -67,7 +67,7 @@ public func configure(_ app: Application) throws -> String {
                                 tlsConfiguration: tlsConfig,
                                 maxConnectionsPerEventLoop: maxConnectionsPerEventLoop,
                                 // Set sqlLogLevel to .info to log SQL queries with the default log level.
-                                sqlLogLevel: .info),
+                                sqlLogLevel: .debug),
                       as: .psql)
     
     do {  // Migration 001 - schema 1.0

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -59,7 +59,7 @@ func routes(_ app: Application) throws {
 
         do {  // temporary, hacky docc-proxy
             app.get(":owner", ":repository", ":reference", "documentation") {
-                try await packageController.documentation(req: $0, fragment: .documentation)
+                try await packageController.documentation(req: $0, fragment: .documentationRedirect)
             }
             app.get(":owner", ":repository", ":reference", "documentation", ":archive") {
                 try await packageController.documentation(req: $0, fragment: .documentation)

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -246,6 +246,8 @@ class PackageController_routesTests: AppTestCase {
         try app.test(.GET, "/owner/package/main/documentation") {
             XCTAssertEqual($0.status, .temporaryRedirect)
         }
+
+        // TODO: Add another test here for a semantic version reference
     }
 
     func test_documentationRoot_noRedirect() throws {
@@ -269,6 +271,8 @@ class PackageController_routesTests: AppTestCase {
         try app.test(.GET, "/owner/package/main/documentation") {
             XCTAssertEqual($0.status, .notFound)
         }
+
+        // TODO: Add another test here for a semantic version reference
     }
 
     func test_documentation() throws {

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -312,20 +312,6 @@ class PackageController_routesTests: AppTestCase {
             .save(on: app.db).wait()
 
         // MUT
-        // test base url
-        try app.test(.GET, "/owner/package/1.2.3/documentation") {
-            XCTAssertEqual($0.status, .ok)
-            XCTAssertEqual($0.content.contentType?.description, "text/html; charset=utf-8")
-            XCTAssertTrue(
-                $0.body.asString().contains("<p>/owner/package/1.2.3/documentation/</p>"),
-                "was: \($0.body.asString())"
-            )
-            // Assert body includes the docc.css stylesheet link (as a test that our proxy header injection works)
-            XCTAssertTrue($0.body.asString()
-                    .contains(#"<link rel="stylesheet" href="/docc.css?test">"#),
-                          "was: \($0.body.asString())")
-        }
-
         // test path a/b
         try app.test(.GET, "/owner/package/1.2.3/documentation/a/b") {
             XCTAssertEqual($0.status, .ok)

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -327,7 +327,7 @@ class PackageController_routesTests: AppTestCase {
         }
 
         // Test case insensitive path.
-        try app.test(.GET, "/Owner/Package/1.2.3/documentation") {
+        try app.test(.GET, "/Owner/Package/1.2.3/documentation/a/b") {
             XCTAssertEqual($0.status, .ok)
         }
     }

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -225,7 +225,7 @@ class PackageController_routesTests: AppTestCase {
         )
     }
 
-    func test_documentationRedirect() throws {
+    func test_documentationRoot_redirect() throws {
         // setup
         Current.fetchDocumentation = { _, uri in
                 .init(status: .notFound)

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -241,13 +241,22 @@ class PackageController_routesTests: AppTestCase {
                     packageName: "pkg",
                     reference: .branch("main"))
         .save(on: app.db).wait()
+        try Version(package: pkg,
+                    commit: "9876543210",
+                    commitDate: Date(timeIntervalSince1970: 0),
+                    docArchives: [.init(name: "docs", title: "Docs")],
+                    latest: .release,
+                    packageName: "pkg",
+                    reference: .tag(.init(1, 0, 0), "1.0.0"))
+        .save(on: app.db).wait()
 
         // MUT
         try app.test(.GET, "/owner/package/main/documentation") {
-            XCTAssertEqual($0.status, .temporaryRedirect)
+            XCTAssertEqual($0.status, .seeOther)
         }
-
-        // TODO: Add another test here for a semantic version reference
+        try app.test(.GET, "/owner/package/1.0.0/documentation") {
+            XCTAssertEqual($0.status, .seeOther)
+        }
     }
 
     func test_documentationRoot_noRedirect() throws {
@@ -266,13 +275,22 @@ class PackageController_routesTests: AppTestCase {
                     packageName: "pkg",
                     reference: .branch("main"))
         .save(on: app.db).wait()
+        try Version(package: pkg,
+                    commit: "9876543210",
+                    commitDate: Date(timeIntervalSince1970: 0),
+                    docArchives: [], // No docArchives!
+                    latest: .release,
+                    packageName: "pkg",
+                    reference: .tag(.init(1, 0, 0), "1.0.0"))
+        .save(on: app.db).wait()
 
         // MUT
         try app.test(.GET, "/owner/package/main/documentation") {
             XCTAssertEqual($0.status, .notFound)
         }
-
-        // TODO: Add another test here for a semantic version reference
+        try app.test(.GET, "/owner/package/1.0.0/documentation") {
+            XCTAssertEqual($0.status, .notFound)
+        }
     }
 
     func test_documentation() throws {


### PR DESCRIPTION
Fixes #1924

Now, adding a reference and /documentation on any package URL will redirect to the first docArchive if one exists.