### PR TITLE
Fix Footer Link Padding

### DIFF
--- a/FrontEnd/styles/header_footer.scss
+++ b/FrontEnd/styles/header_footer.scss
@@ -43,7 +43,7 @@ footer {
             li {
                 margin: 0 5px;
                 list-style: none;
-                
+
                 a {
                     padding: 3px;
                 }

--- a/FrontEnd/styles/header_footer.scss
+++ b/FrontEnd/styles/header_footer.scss
@@ -22,7 +22,6 @@ footer {
     background-color: var(--header-background);
 
     a {
-        padding: 3px;
         font-size: 15px;
         font-weight: 600;
         color: var(--header-link-text);
@@ -44,6 +43,10 @@ footer {
             li {
                 margin: 0 5px;
                 list-style: none;
+                
+                a {
+                    padding: 3px;
+                }
             }
         }
     }


### PR DESCRIPTION
Noticed that the thank you sponsors link in the footer had extra padding which makes it sit weirdly in the sentence (looks like it has extra spaces on either side).

This fixes it, in theory, by only adding padding to the list item links (the navigation bar items).

Edited via GitHub, untested. Can verify once I'm on my laptop but this should only impact the "all our sponsors for their generosity" link and fix the extra padding before and after.