### PR TITLE
Route test

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -61,7 +61,7 @@ struct PackageController {
         case data
         case documentation
         case documentationRedirect
-        case images
+        case img
         case index
         case js
         case root
@@ -71,7 +71,7 @@ struct PackageController {
             switch self {
                 case .css:
                     return "text/css"
-                case  .data, .images, .index, .root, .themeSettings:
+                case  .data, .img, .index, .root, .themeSettings:
                     return "application/octet-stream"
                 case .documentation, .documentationRedirect:
                     return "text/html; charset=utf-8"
@@ -226,7 +226,7 @@ struct PackageController {
                     for: req
                 )
 
-            case .css, .data, .images, .index, .js, .root, .themeSettings:
+            case .css, .data, .img, .index, .js, .root, .themeSettings:
                 return try await awsResponse.encodeResponse(
                     status: .ok,
                     headers: req.headers
@@ -380,7 +380,7 @@ extension PackageController {
         let baseURL = "http://\(baseURLHost)/\(baseURLPath)"
 
         switch fragment {
-            case .css, .data, .documentationRedirect, .documentation, .images, .index, .js:
+            case .css, .data, .documentationRedirect, .documentation, .img, .index, .js:
                 return URI(string: "\(baseURL)/\(fragment)/\(path)")
             case .root:
                 return URI(string: "\(baseURL)/\(path)")

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -82,11 +82,11 @@ func routes(_ app: Application) throws {
             app.get(":owner", ":repository", ":reference", "data", "**") {
                 try await packageController.documentation(req: $0, fragment: .data)
             }
-            app.get(":owner", ":repository", ":reference", "images") {
-                try await packageController.documentation(req: $0, fragment: .images)
+            app.get(":owner", ":repository", ":reference", "img") {
+                try await packageController.documentation(req: $0, fragment: .img)
             }
-            app.get(":owner", ":repository", ":reference", "images", "**") {
-                try await packageController.documentation(req: $0, fragment: .images)
+            app.get(":owner", ":repository", ":reference", "img", "**") {
+                try await packageController.documentation(req: $0, fragment: .img)
             }
             app.get(":owner", ":repository", ":reference", "index") {
                 try await packageController.documentation(req: $0, fragment: .index)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -67,7 +67,7 @@ func routes(_ app: Application) throws {
             app.get(":owner", ":repository", ":reference", "documentation", ":archive", "**") {
                 try await packageController.documentation(req: $0, fragment: .documentation)
             }
-            app.get(":owner", ":repository", ":reference", "**") {
+            app.get(":owner", ":repository", ":reference", "favicon.*") {
                 try await packageController.documentation(req: $0, fragment: .root)
             }
             app.get(":owner", ":repository", ":reference", "css", "**") {

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -70,32 +70,17 @@ func routes(_ app: Application) throws {
             app.get(":owner", ":repository", ":reference", "**") {
                 try await packageController.documentation(req: $0, fragment: .root)
             }
-            app.get(":owner", ":repository", ":reference", "css") {
-                try await packageController.documentation(req: $0, fragment: .css)
-            }
             app.get(":owner", ":repository", ":reference", "css", "**") {
                 try await packageController.documentation(req: $0, fragment: .css)
-            }
-            app.get(":owner", ":repository", ":reference", "data") {
-                try await packageController.documentation(req: $0, fragment: .data)
             }
             app.get(":owner", ":repository", ":reference", "data", "**") {
                 try await packageController.documentation(req: $0, fragment: .data)
             }
-            app.get(":owner", ":repository", ":reference", "img") {
-                try await packageController.documentation(req: $0, fragment: .img)
-            }
             app.get(":owner", ":repository", ":reference", "img", "**") {
                 try await packageController.documentation(req: $0, fragment: .img)
             }
-            app.get(":owner", ":repository", ":reference", "index") {
-                try await packageController.documentation(req: $0, fragment: .index)
-            }
             app.get(":owner", ":repository", ":reference", "index", "**") {
                 try await packageController.documentation(req: $0, fragment: .index)
-            }
-            app.get(":owner", ":repository", ":reference", "js") {
-                try await packageController.documentation(req: $0, fragment: .js)
             }
             app.get(":owner", ":repository", ":reference", "js", "**") {
                 try await packageController.documentation(req: $0, fragment: .js)

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -378,10 +378,10 @@ class PackageController_routesTests: AppTestCase {
 
         // MUT
         // test base url
-        try app.test(.GET, "/owner/package/1.2.3/js") {
+        try app.test(.GET, "/owner/package/1.2.3/js/a") {
             XCTAssertEqual($0.status, .ok)
             XCTAssertEqual($0.content.contentType?.description, "application/javascript")
-            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/js/")
+            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/js/a")
         }
 
         // test path a/b
@@ -401,10 +401,10 @@ class PackageController_routesTests: AppTestCase {
 
         // MUT
         // test base url
-        try app.test(.GET, "/owner/package/1.2.3/css") {
+        try app.test(.GET, "/owner/package/1.2.3/css/a") {
             XCTAssertEqual($0.status, .ok)
             XCTAssertEqual($0.content.contentType?.description, "text/css")
-            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/css/")
+            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/css/a")
         }
 
         // test path a/b
@@ -424,10 +424,10 @@ class PackageController_routesTests: AppTestCase {
 
         // MUT
         // test base url
-        try app.test(.GET, "/owner/package/1.2.3/data") {
+        try app.test(.GET, "/owner/package/1.2.3/data/a") {
             XCTAssertEqual($0.status, .ok)
             XCTAssertEqual($0.content.contentType?.description, "application/octet-stream")
-            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/data/")
+            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/data/a")
         }
 
         // test path a/b

--- a/restfiles/route-test.restfile
+++ b/restfiles/route-test.restfile
@@ -1,0 +1,202 @@
+# Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+requests:
+
+    /:
+        url: ${base_url}/
+        validation:
+            status: 200
+    /add-a-package:
+        url: ${base_url}/add-a-package
+        validation:
+            status: 200
+    /docs/builds:
+        url: ${base_url}/docs/builds
+        validation:
+            status: 200
+    /faq:
+        url: ${base_url}/faq
+        validation:
+            status: 200
+    /package-collections:
+        url: ${base_url}/package-collections
+        validation:
+            status: 200
+    /privacy:
+        url: ${base_url}/privacy
+        validation:
+            status: 200
+    /try-in-a-playground:
+        url: ${base_url}/try-in-a-playground
+        validation:
+            status: 200
+
+    # doccy-proxy
+    /:owner/:repository/:reference/documentation:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/documentation
+        validation:
+            status: 200
+    /:owner/:repository/:reference/documentation/:archive:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/documentation/semanticversion
+        validation:
+            status: 200
+    /:owner/:repository/:reference/documentation/:archive/**:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/documentation/semanticversion/index.html
+        validation:
+            status: 200
+    /:owner/:repository/:reference/**:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/index.html
+        validation:
+            status: 200
+# FIXME: invalid route
+# /:owner/:repository/:reference/css:
+#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/css
+#     validation:
+#         status: 200
+    /:owner/:repository/:reference/css/**:
+        # NB: this will likely need updating (or leaving a known file in S3)
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/css/index.ef288297.css
+        validation:
+            status: 200
+# FIXME: invalid route
+# /:owner/:repository/:reference/data:
+#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/data
+#     validation:
+#         status: 200
+    /:owner/:repository/:reference/data/**:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/data/documentation/semanticversion.json
+        validation:
+            status: 200
+# FIXME: invalid route
+# /:owner/:repository/:reference/img:
+#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/img
+#     validation:
+#         status: 200
+    /:owner/:repository/:reference/img/**:
+        # NB: this will likely need updating (or leaving a known file in S3)
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/img/added-icon.d6f7e47d.svg
+        validation:
+            status: 200
+# FIXME: invalid route
+# /:owner/:repository/:reference/index:
+#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/index
+#     validation:
+#         status: 200
+    /:owner/:repository/:reference/index/**:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/index/index.json
+        validation:
+            status: 200
+# FIXME: invalid route
+# /:owner/:repository/:reference/js:
+#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/js
+#     validation:
+#         status: 200
+    /:owner/:repository/:reference/js/**:
+        # NB: this will likely need updating (or leaving a known file in S3)
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/js/index.78cbd158.js
+        validation:
+            status: 200
+    /:owner/:repository/:reference/theme-settings.json:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/theme-settings.json
+        validation:
+            status: 200
+
+    # package routes
+    /:owner/:repository:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion
+        validation:
+            status: 200
+    /:owner/:repository/readme:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/readme
+        validation:
+            status: 200
+    /:owner/:repository/releases:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/releases
+        validation:
+            status: 200
+    /:owner/:repository/builds:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/builds
+        validation:
+            status: 200
+    /:owner/:repository/information-for-package-maintainers:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/information-for-package-maintainers
+        validation:
+            status: 200
+
+    # author routes
+    /:owner/collection.json:
+        url: ${base_url}/SwiftPackageIndex/collection.json
+        validation:
+            status: 200
+    /:owner:
+        url: ${base_url}/SwiftPackageIndex
+        validation:
+            status: 200
+
+    /keywords/:keyword:
+        url: ${base_url}/keywords/swift
+        validation:
+            status: 200
+    /build-monitor:
+        url: ${base_url}/build-monitor
+        validation:
+            status: 200
+    /builds/:id:
+        # NB: this will need updating if/when the build is superseded
+        url: ${base_url}/builds/CC649445-5CC3-4EFB-AE1C-E8D352BB2747
+        validation:
+            status: 200
+    /search:
+        url: ${base_url}/search
+        validation:
+            status: 200
+
+    # api
+    /api/version:
+        url: ${base_url}/api/version
+        validation:
+            status: 200
+    /api/search:
+        url: ${base_url}/api/search
+        validation:
+            status: 200
+    /api/packages/:owner/:repository/badge:
+        url: ${base_url}/api/packages/SwiftPackageIndex/SemanticVersion/badge
+        query:
+            type: platforms
+        validation:
+            status: 200
+    # SKIP testing POST requests
+    # | POST | /api/package-collections                                 |
+    # | POST | /api/versions/:id/builds                                 |
+    # | POST | /api/versions/:id/trigger-build                          |
+    # | POST | /api/packages/:owner/:repository/trigger-builds          |
+
+    /packages.rss:
+        url: ${base_url}/packages.rss
+        validation:
+            status: 200
+    /releases.rss:
+        url: ${base_url}/releases.rss
+        validation:
+            status: 200
+    /sitemap.xml:
+        url: ${base_url}/sitemap.xml
+        validation:
+            status: 200
+    /metrics:
+        url: ${base_url}/metrics
+        validation:
+            status: 200

--- a/restfiles/route-test.restfile
+++ b/restfiles/route-test.restfile
@@ -60,49 +60,24 @@ requests:
         url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/index.html
         validation:
             status: 200
-# FIXME: invalid route
-# /:owner/:repository/:reference/css:
-#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/css
-#     validation:
-#         status: 200
     /:owner/:repository/:reference/css/**:
         # NB: this will likely need updating (or leaving a known file in S3)
         url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/css/index.ef288297.css
         validation:
             status: 200
-# FIXME: invalid route
-# /:owner/:repository/:reference/data:
-#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/data
-#     validation:
-#         status: 200
     /:owner/:repository/:reference/data/**:
         url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/data/documentation/semanticversion.json
         validation:
             status: 200
-# FIXME: invalid route
-# /:owner/:repository/:reference/img:
-#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/img
-#     validation:
-#         status: 200
     /:owner/:repository/:reference/img/**:
         # NB: this will likely need updating (or leaving a known file in S3)
         url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/img/added-icon.d6f7e47d.svg
         validation:
             status: 200
-# FIXME: invalid route
-# /:owner/:repository/:reference/index:
-#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/index
-#     validation:
-#         status: 200
     /:owner/:repository/:reference/index/**:
         url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/index/index.json
         validation:
             status: 200
-# FIXME: invalid route
-# /:owner/:repository/:reference/js:
-#     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/js
-#     validation:
-#         status: 200
     /:owner/:repository/:reference/js/**:
         # NB: this will likely need updating (or leaving a known file in S3)
         url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/js/index.78cbd158.js

--- a/restfiles/route-test.restfile
+++ b/restfiles/route-test.restfile
@@ -61,8 +61,8 @@ requests:
         url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/documentation/semanticversion/index.html
         validation:
             status: 200
-    /:owner/:repository/:reference/**:
-        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/index.html
+    /:owner/:repository/:reference/favicon.*:
+        url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/favicon.svg
         validation:
             status: 200
     /:owner/:repository/:reference/css/**:

--- a/restfiles/route-test.restfile
+++ b/restfiles/route-test.restfile
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Usage instructions:
+# - Launch the server with AWS_DOCS_BUCKET set to spi-dev-docs
+# - Run route-test via
+# env base_url=http://localhost:8080 rester restfiles/route-test.restfile
+
 requests:
 
     /:


### PR DESCRIPTION
This adds a `route-tests.restfile` testing all GET routes (generated via `swift run Run show-routes`).

The tests all pass when running against a local server pointing to S3 `spi-dev-docs`. There are some server-specific bits of data in the test routes that are hard to generalise. I.e. `route-tests.restfile` is always going to be env/server-specific to a degree. For instance, we won't have a build-UUID that we can test against that exist on all envs.

The purpose of this test file is to have an easy way to ensure all urls are working as expected when transitioning to pointfreeco's URL parser/printer library.

This test also surfaced a number of issues in the doccy-proxy routes:
- the `images` route was misspelled, it needed to be `img`
- there are a number of directory routes that seem superfluous (i.e. they can't actually be tested)