### PR TITLE
Make all controllers enums with static funcs

### DIFF
--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -19,8 +19,8 @@ import Vapor
 
 extension API {
     
-    struct BuildController {
-        func create(req: Request) async throws -> HTTPStatus {
+    enum BuildController {
+        static func create(req: Request) async throws -> HTTPStatus {
             let dto = try req.content.decode(PostCreateBuildDTO.self)
             let version = try await App.Version
                 .find(req.parameters.get("id"), on: req.db)
@@ -87,7 +87,7 @@ extension API {
             return .noContent
         }
 
-        func trigger(req: Request) throws -> EventLoopFuture<Build.TriggerResponse> {
+        static func trigger(req: Request) throws -> EventLoopFuture<Build.TriggerResponse> {
             guard let id = req.parameters.get("id"),
                   let versionId = UUID(uuidString: id)
             else {

--- a/Sources/App/Controllers/API/API+PackageCollectionController.swift
+++ b/Sources/App/Controllers/API/API+PackageCollectionController.swift
@@ -18,9 +18,9 @@ import Vapor
 
 extension API {
 
-    struct PackageCollectionController {
+    enum PackageCollectionController {
 
-        func generate(req: Request) throws -> EventLoopFuture<SignedCollection> {
+        static func generate(req: Request) throws -> EventLoopFuture<SignedCollection> {
             AppMetrics.apiPackageCollectionGetTotal?.inc()
 
             // First try decoding "owner" type DTO

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -18,23 +18,23 @@ import Vapor
 
 extension API {
     
-    struct PackageController {
+    enum PackageController {
 
-        func index(req: Request) throws -> EventLoopFuture<[Package]> {
+        static func index(req: Request) throws -> EventLoopFuture<[Package]> {
             return Package.query(on: req.db).all()
         }
         
-        func create(req: Request) throws -> EventLoopFuture<Package> {
+        static func create(req: Request) throws -> EventLoopFuture<Package> {
             let pkg = try req.content.decode(Package.self)
             return pkg.save(on: req.db).map { pkg }
         }
         
-        func get(req: Request) throws -> EventLoopFuture<Package> {
+        static func get(req: Request) throws -> EventLoopFuture<Package> {
             return Package.find(req.parameters.get("id"), on: req.db)
                 .unwrap(or: Abort(.notFound))
         }
         
-        func replace(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+        static func replace(req: Request) throws -> EventLoopFuture<HTTPStatus> {
             let pkg = try req.content.decode(Package.self)
             return Package.find(req.parameters.get("id"), on: req.db)
                 .unwrap(or: Abort(.notFound))
@@ -42,14 +42,14 @@ extension API {
                 .transform(to: .ok)
         }
         
-        func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+        static func delete(req: Request) throws -> EventLoopFuture<HTTPStatus> {
             return Package.find(req.parameters.get("id"), on: req.db)
                 .unwrap(or: Abort(.notFound))
                 .flatMap { $0.delete(on: req.db) }
                 .transform(to: .ok)
         }
         
-        func triggerBuilds(req: Request) throws -> EventLoopFuture<HTTPStatus> {
+        static func triggerBuilds(req: Request) throws -> EventLoopFuture<HTTPStatus> {
             guard
                 let owner = req.parameters.get("owner"),
                 let repository = req.parameters.get("repository")
@@ -74,7 +74,7 @@ extension API {
                 }
         }
         
-        func run(req: Request) async throws -> Command.Response {
+        static func run(req: Request) async throws -> Command.Response {
             let cmd = req.parameters.get("command")
                 .flatMap(Command.init(rawValue:))
             let limit = req.query[Int.self, at: "limit"] ?? 10
@@ -100,7 +100,7 @@ extension API {
             }
         }
 
-        func badge(req: Request) throws -> EventLoopFuture<Badge> {
+        static func badge(req: Request) throws -> EventLoopFuture<Badge> {
             guard
                 let owner = req.parameters.get("owner"),
                 let repository = req.parameters.get("repository")

--- a/Sources/App/Controllers/AuthorController.swift
+++ b/Sources/App/Controllers/AuthorController.swift
@@ -17,7 +17,7 @@ import Plot
 import Vapor
 
 
-struct AuthorController {
+enum AuthorController {
 
     static func query(on database: Database, owner: String) -> EventLoopFuture<[Joined3<Package, Repository, Version>]> {
         Joined3<Package, Repository, Version>
@@ -33,7 +33,7 @@ struct AuthorController {
             }
     }
 
-    func show(req: Request) throws -> EventLoopFuture<HTML> {
+    static func show(req: Request) throws -> EventLoopFuture<HTML> {
         guard let owner = req.parameters.get("owner") else {
             return req.eventLoop.future(error: Abort(.notFound))
         }

--- a/Sources/App/Controllers/BuildController.swift
+++ b/Sources/App/Controllers/BuildController.swift
@@ -17,8 +17,8 @@ import Plot
 import Vapor
 
 
-struct BuildController {
-    func show(req: Request) throws -> EventLoopFuture<HTML> {
+enum BuildController {
+    static func show(req: Request) throws -> EventLoopFuture<HTML> {
         guard let id = req.parameters.get("id"),
               let buildId = UUID.init(uuidString: id)
         else { return req.eventLoop.future(error: Abort(.notFound)) }

--- a/Sources/App/Controllers/BuildMonitorController.swift
+++ b/Sources/App/Controllers/BuildMonitorController.swift
@@ -16,8 +16,8 @@ import Fluent
 import Plot
 import Vapor
 
-struct BuildMonitorController {
-    func index(req: Request) async throws -> HTML {
+enum BuildMonitorController {
+    static func index(req: Request) async throws -> HTML {
         let builds = try await BuildResult.query(on: req.db)
             .field(Build.self, \.$id)
             .field(Build.self, \.$createdAt)

--- a/Sources/App/Controllers/KeywordController.swift
+++ b/Sources/App/Controllers/KeywordController.swift
@@ -17,7 +17,7 @@ import Plot
 import Vapor
 
 
-struct KeywordController {
+enum KeywordController {
 
     static func query(on database: Database, keyword: String, page: Int, pageSize: Int) -> EventLoopFuture<Page<Joined3<Package, Repository, Version>>> {
         Joined3<Package, Repository, Version>
@@ -28,7 +28,7 @@ struct KeywordController {
             .page(page, size: pageSize)
     }
 
-    func show(req: Request) throws -> EventLoopFuture<HTML> {
+    static func show(req: Request) throws -> EventLoopFuture<HTML> {
         guard let keyword = req.parameters.get("keyword") else {
             return req.eventLoop.future(error: Abort(.notFound))
         }

--- a/Sources/App/Controllers/PackageCollectionController.swift
+++ b/Sources/App/Controllers/PackageCollectionController.swift
@@ -15,8 +15,8 @@
 import Vapor
 
 
-struct PackageCollectionController {
-    func generate(req: Request) throws -> EventLoopFuture<SignedCollection> {
+enum PackageCollectionController {
+    static func generate(req: Request) throws -> EventLoopFuture<SignedCollection> {
         AppMetrics.packageCollectionGetTotal?.inc()
 
         guard let owner = req.parameters.get("owner") else {

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -18,9 +18,9 @@ import Vapor
 import SemanticVersion
 
 
-struct PackageController {
+enum PackageController {
 
-    func show(req: Request) async throws -> Response {
+    static func show(req: Request) async throws -> Response {
         guard
             let owner = req.parameters.get("owner"),
             let repository = req.parameters.get("repository")
@@ -90,7 +90,7 @@ struct PackageController {
         var updatedAt: Date
     }
 
-    func documentation(req: Request, fragment: Fragment) async throws -> Response {
+    static func documentation(req: Request, fragment: Fragment) async throws -> Response {
         guard
             let owner = req.parameters.get("owner"),
             let repository = req.parameters.get("repository"),
@@ -239,7 +239,7 @@ struct PackageController {
         }
     }
 
-    func readme(req: Request) throws -> EventLoopFuture<Node<HTML.BodyContext>> {
+    static func readme(req: Request) throws -> EventLoopFuture<Node<HTML.BodyContext>> {
         guard
             let owner = req.parameters.get("owner"),
             let repository = req.parameters.get("repository")
@@ -260,7 +260,7 @@ struct PackageController {
             .map { $0.document() }
     }
     
-    func releases(req: Request) throws -> EventLoopFuture<Node<HTML.BodyContext>> {
+    static func releases(req: Request) throws -> EventLoopFuture<Node<HTML.BodyContext>> {
         guard
             let owner = req.parameters.get("owner"),
             let repository = req.parameters.get("repository")
@@ -274,7 +274,7 @@ struct PackageController {
             .map { PackageReleases.View(model: $0).document() }
     }
 
-    func builds(req: Request) async throws -> HTML {
+    static func builds(req: Request) async throws -> HTML {
         guard
             let owner = req.parameters.get("owner"),
             let repository = req.parameters.get("repository")
@@ -292,7 +292,7 @@ struct PackageController {
         return BuildIndex.View(path: req.url.path, model: model).document()
     }
 
-    func maintainerInfo(req: Request) throws -> EventLoopFuture<HTML> {
+    static func maintainerInfo(req: Request) throws -> EventLoopFuture<HTML> {
         guard
             let owner = req.parameters.get("owner"),
             let repository = req.parameters.get("repository")

--- a/Sources/App/Controllers/SearchController.swift
+++ b/Sources/App/Controllers/SearchController.swift
@@ -17,10 +17,9 @@ import Plot
 import Vapor
 
 
-struct SearchController {
+enum SearchController {
 
-    func show(req: Request) async throws -> HTML {
-        
+    static func show(req: Request) async throws -> HTML {
         let query = req.query[String.self, at: "query"] ?? ""
         let page = req.query[Int.self, at: "page"] ?? 1
         


### PR DESCRIPTION
Controllers don't carry any state, so top level or static functions are a better model for them than instantiating a bare struct (without any properties) just to call a function on it. This will also reduce the change footprint for the proposed parser/printer site routing changes.