### PR TITLE
Fix order of documentation archives being alphabetical

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -141,8 +141,8 @@
         "repositoryURL": "https://github.com/SwiftPackageIndex/SPIManifest",
         "state": {
           "branch": null,
-          "revision": "ad6d1fb021022788af310e9048dbecfaa14e0aa1",
-          "version": "0.7.1"
+          "revision": "36eac3222fd744fe3b5621c351751d83ed518d64",
+          "version": "0.7.2"
         }
       },
       {
@@ -240,8 +240,8 @@
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
           "branch": null,
-          "revision": "8fc79cae9d03a5e623c52cc2dbd2df165a7832b0",
-          "version": "1.4.3"
+          "revision": "6fe203dc33195667ce1759bf0182975e4653ba1c",
+          "version": "1.4.4"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(name: "SnapshotTesting",
                  url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.7.2"),
         .package(url: "https://github.com/SwiftPackageIndex/SemanticVersion", from: "0.3.0"),
-        .package(url: "https://github.com/SwiftPackageIndex/SPIManifest", from: "0.7.1"),
+        .package(url: "https://github.com/SwiftPackageIndex/SPIManifest", from: "0.7.2"),
         .package(url: "https://github.com/handya/OhhAuth.git", from: "1.4.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
         .package(name: "SwiftPM", url: "https://github.com/apple/swift-package-manager.git",

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -130,12 +130,13 @@ enum PackageController {
                     .filter(Repository.self, \.$name, .custom("ilike"), repository)
                     .filter(\Version.$reference == referenceToMatch)
                     .filter(\Version.$docArchives != nil)
+                    .field(Version.self, \.$spiManifest)
                     .field(Version.self, \.$docArchives)
                     .first()
                 else { throw Abort(.notFound) }
 
                 // This package has at least one docArchive, so redirect to it.
-                guard let docArchive = queryResult.model.docArchives?.first
+                guard let docArchive = queryResult.model.docArchivesInManifestOrder?.first
                 else { throw Abort(.notFound) }
                 throw Abort.redirect(to: DocumentationPageProcessor.relativeDocumentationURL(owner: owner,
                                                                                              repository: repository,
@@ -154,6 +155,7 @@ enum PackageController {
                     .field(Version.self, \.$latest)
                     .field(Version.self, \.$packageName)
                     .field(Version.self, \.$docArchives)
+                    .field(Version.self, \.$spiManifest)
                     .field(Version.self, \.$commitDate)
                     .field(Version.self, \.$publishedAt)
                     .field(Repository.self, \.$ownerName)
@@ -163,7 +165,7 @@ enum PackageController {
                     DocumentationVersion(reference: result.model.reference,
                                          ownerName: result.relation2?.ownerName ?? owner,
                                          packageName: result.model.packageName ?? repository,
-                                         docArchives: (result.model.docArchives ?? []).map(\.title),
+                                         docArchives: (result.model.docArchivesInManifestOrder ?? []).map(\.title),
                                          latest: result.model.latest,
                                          updatedAt: result.model.publishedAt ?? result.model.commitDate)
                 }

--- a/Sources/App/Models/Version.swift
+++ b/Sources/App/Models/Version.swift
@@ -215,6 +215,23 @@ extension Version {
     }
 }
 
+extension Version {
+    var docArchivesInManifestOrder: [DocArchive]? {
+        guard let docArchives = docArchives else { return nil }
+
+        // Return the archives in any order if the targets can't be fetched.
+        guard let spiManifest = spiManifest,
+              let targets = spiManifest.allDocumentationTargets()
+        else { return docArchives }
+
+        // Match the order of archives to the targets where possible.
+        return docArchives.sorted { (lhs, rhs) in
+            let lhsIndex = targets.firstIndex(of: lhs.name) ?? 0
+            let rhsIndex = targets.firstIndex(of: rhs.name) ?? 0
+            return lhsIndex < rhsIndex
+        }
+    }
+}
 
 extension Array where Element == Version {
     // Helper to determine latest branch version in a batch

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -123,10 +123,10 @@ extension PackageShow {
 
             let defaultDocumentationMetadata: DocumentationMetadata? = {
                 if let releaseVersion = result.releaseVersion,
-                   let releaseVersionDocArchive = releaseVersion.docArchives?.first {
+                   let releaseVersionDocArchive = releaseVersion.docArchivesInManifestOrder?.first {
                     return .init(reference: "\(releaseVersion.reference)",
                                  defaultArchive: releaseVersionDocArchive.title)
-                } else if let defaultBranchDocArchive = result.defaultBranchVersion.docArchives?.first {
+                } else if let defaultBranchDocArchive = result.defaultBranchVersion.docArchivesInManifestOrder?.first {
                     return .init(reference: "\(result.defaultBranchVersion.reference)",
                                  defaultArchive: defaultBranchDocArchive.title)
                 } else {

--- a/Tests/AppTests/VersionTests.swift
+++ b/Tests/AppTests/VersionTests.swift
@@ -172,4 +172,31 @@ class VersionTests: AppTestCase {
         XCTAssertEqual(latest?.id, vid)
     }
 
+    func test_docArchivesInManifestOrder() throws {
+        // Setup
+        let pkg = try savePackage(on: app.db, "1".asGithubUrl.url)
+        let version = try Version(id: UUID(),
+                                  package: pkg,
+                                  commit: "0123456789",
+                                  commitDate: .t0,
+                                  docArchives: [
+                                    .init(name: "additional", title: "Additional"),
+                                    .init(name: "helper", title: "Helper"),
+                                    .init(name: "primary", title: "Primary"),
+                                  ],
+                                  reference: .branch("main"),
+                                  spiManifest: .init(yml: """
+                                      version: 1
+                                      builder:
+                                        configs:
+                                        - documentation_targets: [primary, additional, helper]
+                                      """))
+
+        // MUT
+        let sortedArchives = try XCTUnwrap(version.docArchivesInManifestOrder)
+
+        // Validate
+        XCTAssertEqual(sortedArchives.map(\.name), ["primary", "additional", "helper"])
+    }
+
 }


### PR DESCRIPTION
Fixes #1974 

So as I mentioned in our chat on Discord, what I’d love to do is make the logic in `docArchivesInManifestOrder` be the default getter for `docArchives`. There should be no reason to ever get these out in alphabetical order.

I tried making the `docArchives` property that’s annotated with the Fluent `@Field` attribute, but that removes the `$docArchives` definition needed for selecting the fields. Looks like that’s a `FieldProperty`, so it’s possible we could re-create that, but it feels like maybe going down the wrong road. I also tried asking in the Vapor Discord, and the consensus was that replacing the getter would be tricky and probably not worth the work.

So, I have a new plan of attack for tomorrow. A fix to how the data gets inserted via the API and a migration to correct all the data we have inserted so far.

Putting this up in draft in case you have any better ideas @finestructure.

