### PR TITLE
Fix docc proxy images route

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -62,6 +62,7 @@ enum PackageController {
         case documentation
         case favicon
         case images
+        case img
         case index
         case js
         case themeSettings
@@ -70,7 +71,7 @@ enum PackageController {
             switch self {
                 case .css:
                     return "text/css"
-                case  .data, .favicon, .images, .index, .themeSettings:
+                case  .data, .favicon, .images, .img, .index, .themeSettings:
                     return "application/octet-stream"
                 case .documentation:
                     return "text/html; charset=utf-8"
@@ -233,7 +234,7 @@ enum PackageController {
                     for: req
                 )
 
-            case .css, .data, .favicon, .images, .index, .js, .themeSettings:
+            case .css, .data, .favicon, .images, .img, .index, .js, .themeSettings:
                 return try await awsResponse.encodeResponse(
                     status: .ok,
                     headers: req.headers
@@ -387,7 +388,7 @@ extension PackageController {
         let baseURL = "http://\(baseURLHost)/\(baseURLPath)"
 
         switch fragment {
-            case .css, .data, .documentation, .images, .index, .js:
+            case .css, .data, .documentation, .images, .img, .index, .js:
                 return URI(string: "\(baseURL)/\(fragment)/\(path)")
             case .favicon:
                 return URI(string: "\(baseURL)/\(path)")

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -61,7 +61,7 @@ enum PackageController {
         case data
         case documentation
         case favicon
-        case img
+        case images
         case index
         case js
         case themeSettings
@@ -70,7 +70,7 @@ enum PackageController {
             switch self {
                 case .css:
                     return "text/css"
-                case  .data, .favicon, .img, .index, .themeSettings:
+                case  .data, .favicon, .images, .index, .themeSettings:
                     return "application/octet-stream"
                 case .documentation:
                     return "text/html; charset=utf-8"
@@ -233,7 +233,7 @@ enum PackageController {
                     for: req
                 )
 
-            case .css, .data, .favicon, .img, .index, .js, .themeSettings:
+            case .css, .data, .favicon, .images, .index, .js, .themeSettings:
                 return try await awsResponse.encodeResponse(
                     status: .ok,
                     headers: req.headers
@@ -387,7 +387,7 @@ extension PackageController {
         let baseURL = "http://\(baseURLHost)/\(baseURLPath)"
 
         switch fragment {
-            case .css, .data, .documentation, .img, .index, .js:
+            case .css, .data, .documentation, .images, .index, .js:
                 return URI(string: "\(baseURL)/\(fragment)/\(path)")
             case .favicon:
                 return URI(string: "\(baseURL)/\(path)")

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -77,6 +77,9 @@ func routes(_ app: Application) throws {
             app.get(":owner", ":repository", ":reference", "images", "**") {
                 try await PackageController.documentation(req: $0, fragment: .images)
             }
+            app.get(":owner", ":repository", ":reference", "img", "**") {
+                try await PackageController.documentation(req: $0, fragment: .img)
+            }
             app.get(":owner", ":repository", ":reference", "index", "**") {
                 try await PackageController.documentation(req: $0, fragment: .index)
             }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -74,8 +74,8 @@ func routes(_ app: Application) throws {
             app.get(":owner", ":repository", ":reference", "data", "**") {
                 try await PackageController.documentation(req: $0, fragment: .data)
             }
-            app.get(":owner", ":repository", ":reference", "img", "**") {
-                try await PackageController.documentation(req: $0, fragment: .img)
+            app.get(":owner", ":repository", ":reference", "images", "**") {
+                try await PackageController.documentation(req: $0, fragment: .images)
             }
             app.get(":owner", ":repository", ":reference", "index", "**") {
                 try await PackageController.documentation(req: $0, fragment: .index)

--- a/Tests/AppTests/RoutesTests.swift
+++ b/Tests/AppTests/RoutesTests.swift
@@ -1,0 +1,33 @@
+// Copyright 2020-2021 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import App
+
+import XCTVapor
+
+
+final class RoutesTests: AppTestCase {
+
+    func test_documentation_images() async throws {
+        // setup
+        Current.fetchDocumentation = { _, _ in .init(status: .ok) }
+
+        // MUT
+        try app.test(.GET, "foo/bar/1.2.3/images/baz.png") { res in
+            // validation
+            XCTAssertEqual(res.status, .ok)
+        }
+    }
+
+}

--- a/Tests/AppTests/RoutesTests.swift
+++ b/Tests/AppTests/RoutesTests.swift
@@ -30,4 +30,15 @@ final class RoutesTests: AppTestCase {
         }
     }
 
+    func test_documentation_img() async throws {
+        // setup
+        Current.fetchDocumentation = { _, _ in .init(status: .ok) }
+
+        // MUT
+        try app.test(.GET, "foo/bar/1.2.3/img/baz.png") { res in
+            // validation
+            XCTAssertEqual(res.status, .ok)
+        }
+    }
+
 }

--- a/restfiles/route-test.restfile
+++ b/restfiles/route-test.restfile
@@ -79,6 +79,11 @@ requests:
         url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/img/added-icon.d6f7e47d.svg
         validation:
             status: 200
+    # This route test can't work unless we add an image to the docs
+    # /:owner/:repository/:reference/images/**:
+    #     url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/images/added-icon.d6f7e47d.svg
+    #     validation:
+    #         status: 200
     /:owner/:repository/:reference/index/**:
         url: ${base_url}/SwiftPackageIndex/SemanticVersion/main/index/index.json
         validation:


### PR DESCRIPTION
Fixes #1983 

I'm pretty sure there was a reason I changed `images` to `img` in 1a2ddfef8c6db37daeacbb9239efdcaf502c8368. I must have seen `img` pop up and assumed that `images` was a typo. It's possible that we need to handle both routes but let's see if there actually are any `img` 404s now.