### PR TITLE
Enable “has binary targets” in production

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -336,9 +336,6 @@ extension PackageShow.Model {
     }
 
     func binaryTargetsItem() -> Node<HTML.ListContext> {
-        guard Environment.current == .development
-        else { return .empty }
-
         guard hasBinaryTargets else { return .empty }
 
         func linkNode(for name: String, url: String) -> Node<HTML.BodyContext> {


### PR DESCRIPTION
Thanks so much, @samdeane, and apologies that this took so long to go live!

There is still the outstanding issue in #1947, but it may be a while until that's fixed so let's get this change live. More [context here](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1947#issuecomment-1232705370).