### PR TITLE
5.7-nightly base image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a
+      image: registry.gitlab.com/finestructure/spi-base:0.8.0
     services:
       postgres:
         image: postgres:13.7-alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:0.7.1
+      image: registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a
     services:
       postgres:
         image: postgres:13.7-alpine

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: registry.gitlab.com/finestructure/spi-base:0.7.1
+      image: registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a
+      image: registry.gitlab.com/finestructure/spi-base:0.8.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # ================================
 # Build image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:0.7.1 as build
+FROM registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a as build
 WORKDIR /build
 
 # First just resolve dependencies.
@@ -37,7 +37,7 @@ RUN swift build \
 # Run image
 # ================================
 # we need a special base image so that we can run `swift dump-package`
-FROM registry.gitlab.com/finestructure/spi-base:0.7.1
+FROM registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a
 
 WORKDIR /run
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # ================================
 # Build image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a as build
+FROM registry.gitlab.com/finestructure/spi-base:0.8.0 as build
 WORKDIR /build
 
 # First just resolve dependencies.
@@ -37,7 +37,7 @@ RUN swift build \
 # Run image
 # ================================
 # we need a special base image so that we can run `swift dump-package`
-FROM registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a
+FROM registry.gitlab.com/finestructure/spi-base:0.8.0
 
 WORKDIR /run
 

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -176,7 +176,7 @@ The trickiest part of this is to ensure the test or app container can connect to
 So, in order to run the tests in a Linux container run:
 
 ```
-docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:0.7.1 swift test
+docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a swift test
 ```
 
 Make sure you use the most recent `spi-base` image. You can find the latest image name in the `test-docker` target, which also provides a convenient way to run all all tests in a docker container.

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -176,7 +176,7 @@ The trickiest part of this is to ensure the test or app container can connect to
 So, in order to run the tests in a Linux container run:
 
 ```
-docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a swift test
+docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:0.8.0 swift test
 ```
 
 Make sure you use the most recent `spi-base` image. You can find the latest image name in the `test-docker` target, which also provides a convenient way to run all all tests in a docker container.

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test-docker:
 	@# run tests inside a docker container
 	docker run --rm -v "$(PWD)":/host -w /host \
 	  --add-host=host.docker.internal:host-gateway \
-	  registry.gitlab.com/finestructure/spi-base:0.7.1 \
+	  registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a \
 	  make test
 
 test-e2e: db-reset reconcile ingest analyze

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test-docker:
 	@# run tests inside a docker container
 	docker run --rm -v "$(PWD)":/host -w /host \
 	  --add-host=host.docker.internal:host-gateway \
-	  registry.gitlab.com/finestructure/spi-base:02ffeabd701ea48f35cd1634ef6450c232aa214a \
+	  registry.gitlab.com/finestructure/spi-base:0.8.0 \
 	  make test
 
 test-e2e: db-reset reconcile ingest analyze


### PR DESCRIPTION
Switching to a 5.7-nightly base image. Do this sooner rather than later so we can analyse 5.7-only packages properly.

Will switch to the release version later. The docker images are always a couple of days behind the Xcode releases, so this will unblock us on that front as well once Xcode 14 final comes out.