### PR TITLE
Move "Last updated" date into the sidebar

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -118,8 +118,7 @@ enum PackageShow {
                 ], tabContent: [
                     readmeTabContent(),
                     releasesTabContent(),
-                ]),
-                visibleMetadataSection()
+                ])
             )
         }
 
@@ -142,7 +141,11 @@ enum PackageShow {
                     .hr(
                         .class("minor")
                     ),
-                    sidebarInfoForPackageAuthors()
+                    sidebarInfoForPackageAuthors(),
+                    .hr(
+                        .class("minor")
+                    ),
+                    visibleMetadataSection()
                 )
             )
         }
@@ -280,17 +283,13 @@ enum PackageShow {
 
         func visibleMetadataSection() -> Node<HTML.BodyContext> {
             .unwrap(packageSchema?.publicationDates) { dates in
-                .section(
-                    .hr(),
-                    .p(
+                    .section(
                         .small(
                             .text("Last updated on "),
                             .text(DateFormatter.lastUpdatedOnFormatter.string(from:dates.dateModified))
                         )
                     )
-                )
             }
-
         }
 
         func readmeTabContent() -> Node<HTML.BodyContext> {

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -142,7 +142,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         var model = PackageShow.Model.mock
         model.summary = ":package: Nothing but Cache. :octocat:"
         
-        let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
         
         assertSnapshot(matching: page, as: .html)
     }
@@ -152,7 +152,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         model.license = .mit
         model.licenseUrl = "https://example.com/license.html"
 
-        let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
         assertSnapshot(matching: page, as: .html)
     }
 
@@ -161,7 +161,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         model.license = .gpl_3_0
         model.licenseUrl = "https://example.com/license.html"
 
-        let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
         assertSnapshot(matching: page, as: .html)
     }
 
@@ -170,7 +170,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         model.license = .other
         model.licenseUrl = "https://example.com/license.html"
 
-        let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
         assertSnapshot(matching: page, as: .html)
     }
 
@@ -179,7 +179,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         model.license = .none
         model.licenseUrl = nil
 
-        let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
         assertSnapshot(matching: page, as: .html)
     }
     
@@ -189,7 +189,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         var model = PackageShow.Model.mock
         model.authors = nil
         model.activity = nil
-        let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
         
         assertSnapshot(matching: page, as: .html)
     }
@@ -197,7 +197,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
     func test_PackageShowView_with_single_documentation_link() throws {
         var model = PackageShow.Model.mock
         model.documentationMetadata = .init(reference: "main", defaultArchive: "Archive")
-        let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
 
         assertSnapshot(matching: page, as: .html)
     }
@@ -232,7 +232,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                 latest: .init(referenceName: "main", results: compatible)
             )
         }
-        let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
         
         assertSnapshot(matching: page, as: .html)
     }
@@ -242,7 +242,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         var model = PackageShow.Model.mock
         model.swiftVersionBuildInfo = .init(stable: nil, beta: nil, latest: nil)
         model.platformBuildInfo = .init(stable: nil, beta: nil, latest: nil)
-        let page = { PackageShow.View(path: "", model: model, packageSchema: nil).document() }
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
 
         assertSnapshot(matching: page, as: .html)
     }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -327,6 +327,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -363,12 +367,6 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
-        </section>
-        <section>
-          <hr/>
-          <p>
-            <small>Last updated on 1 Jan 2001</small>
-          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -327,6 +327,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -396,5 +400,6 @@
       </div>
     </footer>
     <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
   </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -331,6 +331,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -367,12 +371,6 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
-        </section>
-        <section>
-          <hr/>
-          <p>
-            <small>Last updated on 1 Jan 2001</small>
-          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -324,6 +324,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -393,5 +397,6 @@
       </div>
     </footer>
     <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
   </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -355,6 +355,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -391,12 +395,6 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
-        </section>
-        <section>
-          <hr/>
-          <p>
-            <small>Last updated on 1 Jan 2001</small>
-          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -530,6 +530,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -566,12 +570,6 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
-        </section>
-        <section>
-          <hr/>
-          <p>
-            <small>Last updated on 1 Jan 2001</small>
-          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -320,6 +320,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -389,5 +393,6 @@
       </div>
     </footer>
     <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
   </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -217,6 +217,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -286,5 +290,6 @@
       </div>
     </footer>
     <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
   </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -327,6 +327,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -396,5 +400,6 @@
       </div>
     </footer>
     <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
   </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -326,6 +326,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -395,5 +399,6 @@
       </div>
     </footer>
     <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
   </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -327,6 +327,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -396,5 +400,6 @@
       </div>
     </footer>
     <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
   </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -266,6 +266,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -335,5 +339,6 @@
       </div>
     </footer>
     <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
   </body>
 </html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_single_documentation_link.1.html
@@ -327,6 +327,10 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
+            <hr class="minor"/>
+            <section>
+              <small>Last updated on 1 Jan 2001</small>
+            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -396,5 +400,6 @@
       </div>
     </footer>
     <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
   </body>
 </html>


### PR DESCRIPTION
More work on #1640 as we're *still* only showing dates for some packages! Come on, Google!

I don't really like this date in this position, so if this one is not the solution, I will be moving it back into the footer.

This also fixes that some of the Package page snapshot tests did not include the `mock` data.

<img width="879" alt="Screenshot 2022-09-12 at 13 43 55@2x" src="https://user-images.githubusercontent.com/5180/189656813-717f16e0-4e5b-4c6d-8793-b57fc4b8f622.png">
