### PR TITLE
Support an external documentation URL

### DIFF
--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -244,7 +244,7 @@ struct DocumentationPageProcessor {
         }
     }
 
-    // Note: When this gets merged back with the refactored SiteURL, note that it's duplicated in `PackageShow.Model`.
+    // TODO: Merge this back with SiteURL at some point.
     static func relativeDocumentationURL(owner: String, repository: String, reference: String, docArchive: String) -> String {
         "/\(owner)/\(repository)/\(reference)/documentation/\(docArchive.lowercased())"
     }

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -45,7 +45,7 @@ extension PackageShow {
         var isArchived: Bool
         var hasBinaryTargets: Bool
         var homepageUrl: String?
-        var generatedDocumentationMetadata: GeneratedDocumentationMetadata?
+        var documentationUrl: String? = nil
         var dependencyCodeSnippets: [App.Version.Kind: Link]
         var weightedKeywords: [WeightedKeyword]
 
@@ -73,7 +73,7 @@ extension PackageShow {
                       isArchived: Bool,
                       hasBinaryTargets: Bool = false,
                       homepageUrl: String? = nil,
-                      generatedDocumentationMetadata: GeneratedDocumentationMetadata? = nil,
+                      documentationUrl: String? = nil,
                       dependencyCodeSnippets: [App.Version.Kind: Link],
                       weightedKeywords: [WeightedKeyword] = []) {
             self.packageId = packageId
@@ -100,7 +100,7 @@ extension PackageShow {
             self.isArchived = isArchived
             self.hasBinaryTargets = hasBinaryTargets
             self.homepageUrl = homepageUrl
-            self.generatedDocumentationMetadata = generatedDocumentationMetadata
+            self.documentationUrl = documentationUrl
             self.dependencyCodeSnippets = dependencyCodeSnippets
             self.weightedKeywords = weightedKeywords
         }
@@ -120,15 +120,20 @@ extension PackageShow {
                 let packageId = result.package.id
             else { return nil }
 
-
-            let defaultDocumentationMetadata: GeneratedDocumentationMetadata? = {
+            let documentationUrl: String? = {
                 if let releaseVersion = result.releaseVersion,
                    let releaseVersionDocArchive = releaseVersion.docArchives?.first {
-                    return .init(reference: "\(releaseVersion.reference)",
-                                 defaultArchive: releaseVersionDocArchive.title)
+                    return DocumentationPageProcessor.relativeDocumentationURL(
+                        owner: repositoryOwner,
+                        repository: repositoryName,
+                        reference: "\(releaseVersion.reference)",
+                        docArchive: releaseVersionDocArchive.title)
                 } else if let defaultBranchDocArchive = result.defaultBranchVersion.docArchives?.first {
-                    return .init(reference: "\(result.defaultBranchVersion.reference)",
-                                 defaultArchive: defaultBranchDocArchive.title)
+                    return DocumentationPageProcessor.relativeDocumentationURL(
+                        owner: repositoryOwner,
+                        repository: repositoryName,
+                        reference: "\(result.defaultBranchVersion.reference)",
+                        docArchive: defaultBranchDocArchive.title)
                 } else {
                     return nil
                 }
@@ -167,7 +172,7 @@ extension PackageShow {
                 isArchived: repository.isArchived,
                 hasBinaryTargets: result.defaultBranchVersion.hasBinaryTargets,
                 homepageUrl: repository.homepageUrl,
-                generatedDocumentationMetadata: defaultDocumentationMetadata,
+                documentationUrl: documentationUrl,
                 dependencyCodeSnippets: Self.packageDependencyCodeSnippets(
                     packageURL: result.package.url,
                     defaultBranchReference: result.defaultBranchVersion.model.reference,

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -204,11 +204,6 @@ extension PackageShow.Model {
     var gitHubRepositoryUrl: String {
         "https://github.com/\(repositoryOwner)/\(repositoryName)"
     }
-
-    // Note: When this gets merged back with the refactored SiteURL, note that it's duplicated in `DocumentationPageProcessor`.
-    func relativeDocumentationURL(reference: String, target: String) -> String {
-        "/\(repositoryOwner)/\(repositoryName)/\(reference)/documentation/\(target.lowercased())"
-    }
 }
 
 extension PackageShow.Model {

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -45,7 +45,7 @@ extension PackageShow {
         var isArchived: Bool
         var hasBinaryTargets: Bool
         var homepageUrl: String?
-        var documentationMetadata: DocumentationMetadata?
+        var generatedDocumentationMetadata: GeneratedDocumentationMetadata?
         var dependencyCodeSnippets: [App.Version.Kind: Link]
         var weightedKeywords: [WeightedKeyword]
 
@@ -73,7 +73,7 @@ extension PackageShow {
                       isArchived: Bool,
                       hasBinaryTargets: Bool = false,
                       homepageUrl: String? = nil,
-                      documentationMetadata: DocumentationMetadata? = nil,
+                      generatedDocumentationMetadata: GeneratedDocumentationMetadata? = nil,
                       dependencyCodeSnippets: [App.Version.Kind: Link],
                       weightedKeywords: [WeightedKeyword] = []) {
             self.packageId = packageId
@@ -100,7 +100,7 @@ extension PackageShow {
             self.isArchived = isArchived
             self.hasBinaryTargets = hasBinaryTargets
             self.homepageUrl = homepageUrl
-            self.documentationMetadata = documentationMetadata
+            self.generatedDocumentationMetadata = generatedDocumentationMetadata
             self.dependencyCodeSnippets = dependencyCodeSnippets
             self.weightedKeywords = weightedKeywords
         }
@@ -121,7 +121,7 @@ extension PackageShow {
             else { return nil }
 
 
-            let defaultDocumentationMetadata: DocumentationMetadata? = {
+            let defaultDocumentationMetadata: GeneratedDocumentationMetadata? = {
                 if let releaseVersion = result.releaseVersion,
                    let releaseVersionDocArchive = releaseVersion.docArchives?.first {
                     return .init(reference: "\(releaseVersion.reference)",
@@ -167,7 +167,7 @@ extension PackageShow {
                 isArchived: repository.isArchived,
                 hasBinaryTargets: result.defaultBranchVersion.hasBinaryTargets,
                 homepageUrl: repository.homepageUrl,
-                documentationMetadata: defaultDocumentationMetadata,
+                generatedDocumentationMetadata: defaultDocumentationMetadata,
                 dependencyCodeSnippets: Self.packageDependencyCodeSnippets(
                     packageURL: result.package.url,
                     defaultBranchReference: result.defaultBranchVersion.model.reference,
@@ -179,7 +179,7 @@ extension PackageShow {
         }
     }
 
-    struct DocumentationMetadata: Equatable {
+    struct GeneratedDocumentationMetadata: Equatable {
         let reference: String
         let defaultArchive: String
 

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -121,20 +121,27 @@ extension PackageShow {
             else { return nil }
 
             let documentationUrl: String? = {
-                if let releaseVersion = result.releaseVersion,
+                if let spiManifest = result.defaultBranchVersion.spiManifest,
+                   let externalDocumentationUrl = spiManifest.externalLinks?.documentation {
+                    // External documentation links have priority over generated documentation.
+                    return externalDocumentationUrl
+                } else if let releaseVersion = result.releaseVersion,
                    let releaseVersionDocArchive = releaseVersion.docArchives?.first {
+                    // Ideal case is that we have a stable release documentation.
                     return DocumentationPageProcessor.relativeDocumentationURL(
                         owner: repositoryOwner,
                         repository: repositoryName,
                         reference: "\(releaseVersion.reference)",
                         docArchive: releaseVersionDocArchive.title)
                 } else if let defaultBranchDocArchive = result.defaultBranchVersion.docArchives?.first {
+                    // Fallback is default branch documentation.
                     return DocumentationPageProcessor.relativeDocumentationURL(
                         owner: repositoryOwner,
                         repository: repositoryName,
                         reference: "\(result.defaultBranchVersion.reference)",
                         docArchive: defaultBranchDocArchive.title)
                 } else {
+                    // Suppress the documentation link in the generated page.
                     return nil
                 }
             }()

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -241,7 +241,7 @@ enum PackageShow {
                             )
                         )
                     },
-                    .unwrap(model.documentationMetadata) { metadata in
+                    .unwrap(model.generatedDocumentationMetadata) { metadata in
                         .li(
                             .a(
                                 .href(model.relativeDocumentationURL(reference: metadata.reference, target: metadata.defaultArchive)),

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -241,10 +241,10 @@ enum PackageShow {
                             )
                         )
                     },
-                    .unwrap(model.generatedDocumentationMetadata) { metadata in
+                    .unwrap(model.documentationUrl) { url in
                         .li(
                             .a(
-                                .href(model.relativeDocumentationURL(reference: metadata.reference, target: metadata.defaultArchive)),
+                                .href(url),
                                 .data(named: "turbo", value: String(false)),
                                 "Documentation"
                             )

--- a/Tests/AppTests/PackageShowModelTests.swift
+++ b/Tests/AppTests/PackageShowModelTests.swift
@@ -382,23 +382,6 @@ class PackageShowModelTests: SnapshotTestCase {
             ]
         )
     }
-
-    func test_relativeDocumentationURL() throws {
-        var model = PackageShow.Model.mock
-        model.repositoryOwner = "foo"
-        model.repositoryName = "bar"
-
-        // MUT
-        XCTAssertEqual(model.relativeDocumentationURL(reference: "main", target: "bazqux"),
-                       "/foo/bar/main/documentation/bazqux")
-
-        model.repositoryOwner = "Foo"
-        model.repositoryName = "Bar"
-
-        // MUT
-        XCTAssertEqual(model.relativeDocumentationURL(reference: "Main", target: "BazQux"),
-                       "/Foo/Bar/Main/documentation/bazqux")
-    }
 }
 
 

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -194,9 +194,9 @@ class WebpageSnapshotTests: SnapshotTestCase {
         assertSnapshot(matching: page, as: .html)
     }
 
-    func test_PackageShowView_with_single_documentation_link() throws {
+    func test_PackageShowView_with_documentation_link() throws {
         var model = PackageShow.Model.mock
-        model.generatedDocumentationMetadata = .init(reference: "main", defaultArchive: "Archive")
+        model.documentationUrl = "https://example.com/package/documentation"
         let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
 
         assertSnapshot(matching: page, as: .html)

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -196,7 +196,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     func test_PackageShowView_with_single_documentation_link() throws {
         var model = PackageShow.Model.mock
-        model.documentationMetadata = .init(reference: "main", defaultArchive: "Archive")
+        model.generatedDocumentationMetadata = .init(reference: "main", defaultArchive: "Archive")
         let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
 
         assertSnapshot(matching: page, as: .html)

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -290,7 +290,7 @@
                   </div>
                 </li>
                 <li>
-                  <a href="/Alamo/Alamofire/main/documentation/archive" data-turbo="false">Documentation</a>
+                  <a href="https://example.com/package/documentation" data-turbo="false">Documentation</a>
                 </li>
               </ul>
             </section>


### PR DESCRIPTION
Fixes #1894

The external documentation URL takes precedence over everything.