### PR TITLE
Tweak error logging

### DIFF
--- a/Sources/App/Core/Gitlab.swift
+++ b/Sources/App/Core/Gitlab.swift
@@ -20,7 +20,6 @@ enum Gitlab {
     static let baseURL = "https://gitlab.com/api/v4"
 
     enum Error: LocalizedError {
-        case decodingFailed(String)
         case missingConfiguration(String)
         case missingToken
         case requestFailed(HTTPStatus, URI)
@@ -109,14 +108,7 @@ extension Gitlab.Builder {
                                              webUrl: try response.content.decode(Response.self).webUrl)
             } catch {
                 let body = response.body?.asString() ?? "nil"
-                logger.error("""
-                    Trigger failed
-                    \(cloneURL) @ \(reference), \(platform) / \(swiftVersion), \(versionID)
-                    status: \(response.status)
-                    body: \(body)
-                    error: \(error)
-                    """
-                )
+                logger.error("Trigger failed: \(cloneURL) @ \(reference), \(platform) / \(swiftVersion), \(versionID), status: \(response.status), body: \(body)")
                 return .init(status: response.status, webUrl: nil)
             }
         }


### PR DESCRIPTION
For some reason the log only shows the last line, perhaps multi-line errors are getting truncated:

```
2022-09-16 12:46:38 | error: keyNotFound(CodingKeys(stringValue: "web_url", intValue: nil), Swift.DecodingError.Context(codingPath: [], debugDescription: "No value associated with key CodingKeys(stringValue: \"web_url\", intValue: nil) (\"web_url\").", underlyingError: nil)) [component: trigger-builds]
```

It worked before but that was when throwing an error - not that that should make a difference 🤷‍♂️

Either way, I just need the status code info so I can handle the rate limiting error and show only actual errors beyond that.