### PR TITLE
Issue 2044

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -66,6 +66,7 @@ enum PackageController {
         case index
         case js
         case themeSettings
+        case tutorials
 
         var contentType: String {
             switch self {
@@ -73,7 +74,7 @@ enum PackageController {
                     return "text/css"
                 case  .data, .favicon, .images, .img, .index, .themeSettings:
                     return "application/octet-stream"
-                case .documentation:
+                case .documentation, .tutorials:
                     return "text/html; charset=utf-8"
                 case .js:
                     return "application/javascript"
@@ -149,7 +150,7 @@ enum PackageController {
         }
 
         switch fragment {
-            case .documentation:
+            case .documentation, .tutorials:
                 let queryResult = try await Joined3<Version, Package, Repository>
                     .query(on: req.db,
                            join: \Version.$package.$id == \Package.$id, method: .inner,
@@ -387,7 +388,7 @@ extension PackageController {
         let baseURL = "http://\(baseURLHost)/\(baseURLPath)"
 
         switch fragment {
-            case .css, .data, .documentation, .images, .img, .index, .js:
+            case .css, .data, .documentation, .images, .img, .index, .js, .tutorials:
                 return URI(string: "\(baseURL)/\(fragment)/\(path)")
             case .favicon:
                 return URI(string: "\(baseURL)/\(path)")

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -60,19 +60,20 @@ enum PackageController {
         case css
         case data
         case documentation
-        case favicon
+        case faviconIco = "favicon.ico"
+        case faviconSvg = "favicon.svg"
         case images
         case img
         case index
         case js
-        case themeSettings
+        case themeSettings = "theme-settings.json"
         case tutorials
 
         var contentType: String {
             switch self {
                 case .css:
                     return "text/css"
-                case  .data, .favicon, .images, .img, .index, .themeSettings:
+                case  .data, .faviconIco, .faviconSvg, .images, .img, .index, .themeSettings:
                     return "application/octet-stream"
                 case .documentation, .tutorials:
                     return "text/html; charset=utf-8"
@@ -234,7 +235,7 @@ enum PackageController {
                     for: req
                 )
 
-            case .css, .data, .favicon, .images, .img, .index, .js, .themeSettings:
+            case .css, .data, .faviconIco, .faviconSvg, .images, .img, .index, .js, .themeSettings:
                 return try await awsResponse.encodeResponse(
                     status: .ok,
                     headers: req.headers
@@ -390,10 +391,10 @@ extension PackageController {
         switch fragment {
             case .css, .data, .documentation, .images, .img, .index, .js, .tutorials:
                 return URI(string: "\(baseURL)/\(fragment)/\(path)")
-            case .favicon:
-                return URI(string: "\(baseURL)/\(path)")
-            case .themeSettings:
-                return URI(string: "\(baseURL)/theme-settings.json")
+            case .faviconIco, .faviconSvg, .themeSettings:
+                return path.isEmpty
+                ? URI(string: "\(baseURL)/\(fragment)")
+                : URI(string: "\(baseURL)/\(path)/\(fragment)")
         }
     }
 }
@@ -445,4 +446,9 @@ extension Array where Element == PackageController.DocumentationVersion {
             return firstSemVer < secondSemVer
         }
     }
+}
+
+
+extension PackageController.Fragment: CustomStringConvertible {
+    var description: String { rawValue }
 }

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -89,6 +89,9 @@ func routes(_ app: Application) throws {
             app.get(":owner", ":repository", ":reference", "theme-settings.json") {
                 try await PackageController.documentation(req: $0, fragment: .themeSettings)
             }
+            app.get(":owner", ":repository", ":reference", "tutorials", "**") {
+                try await PackageController.documentation(req: $0, fragment: .tutorials)
+            }
         }
 
         app.get(SiteURL.package(.key, .key, .none).pathComponents,

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -65,8 +65,11 @@ func routes(_ app: Application) throws {
             app.get(":owner", ":repository", ":reference", "documentation", ":archive", "**") {
                 try await PackageController.documentation(req: $0, fragment: .documentation)
             }
-            app.get(":owner", ":repository", ":reference", "favicon.*") {
-                try await PackageController.documentation(req: $0, fragment: .favicon)
+            app.get(":owner", ":repository", ":reference", .fragment(.faviconIco)) {
+                try await PackageController.documentation(req: $0, fragment: .faviconIco)
+            }
+            app.get(":owner", ":repository", ":reference", .fragment(.faviconSvg)) {
+                try await PackageController.documentation(req: $0, fragment: .faviconSvg)
             }
             app.get(":owner", ":repository", ":reference", "css", "**") {
                 try await PackageController.documentation(req: $0, fragment: .css)
@@ -86,7 +89,7 @@ func routes(_ app: Application) throws {
             app.get(":owner", ":repository", ":reference", "js", "**") {
                 try await PackageController.documentation(req: $0, fragment: .js)
             }
-            app.get(":owner", ":repository", ":reference", "theme-settings.json") {
+            app.get(":owner", ":repository", ":reference", .fragment(.themeSettings)) {
                 try await PackageController.documentation(req: $0, fragment: .themeSettings)
             }
             app.get(":owner", ":repository", ":reference", "tutorials", "**") {
@@ -200,4 +203,9 @@ func routes(_ app: Application) throws {
             return promise.futureResult
         }
     }
+}
+
+
+private extension PathComponent {
+    static func fragment(_ fragment: PackageController.Fragment) -> Self { "\(fragment)" }
 }

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -26,6 +26,7 @@ import Vapor
 
 class AnalyzerTests: AppTestCase {
 
+    @MainActor
     func test_analyze() async throws {
         // End-to-end test, where we mock at the shell command level (i.e. we
         // don't mock the git commands themselves to ensure we're running the

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -220,7 +220,11 @@ class PackageController_routesTests: AppTestCase {
             "http://docs-bucket.s3-website.us-east-2.amazonaws.com/foo/bar/1.2.3/js/path"
         )
         XCTAssertEqual(
-            try PackageController.awsDocumentationURL(owner: "Foo", repository: "Bar", reference: "1.2.3", fragment: .themeSettings, path: "theme-settings.json").string,
+            try PackageController.awsDocumentationURL(owner: "Foo", repository: "Bar", reference: "1.2.3", fragment: .themeSettings, path: "path").string,
+            "http://docs-bucket.s3-website.us-east-2.amazonaws.com/foo/bar/1.2.3/path/theme-settings.json"
+        )
+        XCTAssertEqual(
+            try PackageController.awsDocumentationURL(owner: "Foo", repository: "Bar", reference: "1.2.3", fragment: .themeSettings, path: "").string,
             "http://docs-bucket.s3-website.us-east-2.amazonaws.com/foo/bar/1.2.3/theme-settings.json"
         )
     }

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -451,6 +451,29 @@ class PackageController_routesTests: AppTestCase {
         }
     }
 
+    func test_favicon() throws {
+        // setup
+        Current.fetchDocumentation = { _, uri in
+            // embed uri.path in the body as a simple way to test the requested url
+            .init(status: .ok,
+                  headers: ["content-type": "application/octet-stream"],
+                  body: .init(string: uri.path))
+        }
+
+        // MUT
+        try app.test(.GET, "/owner/package/1.2.3/favicon.ico") {
+            XCTAssertEqual($0.status, .ok)
+            XCTAssertEqual($0.content.contentType?.description, "application/octet-stream")
+            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/favicon.ico")
+        }
+
+        try app.test(.GET, "/owner/package/1.2.3/favicon.svg") {
+            XCTAssertEqual($0.status, .ok)
+            XCTAssertEqual($0.content.contentType?.description, "application/octet-stream")
+            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/favicon.svg")
+        }
+    }
+
     func test_themeSettings() throws {
         // setup
         Current.fetchDocumentation = { _, uri in


### PR DESCRIPTION
Fixes #2044 

This also addresses the favicon 404s we were still getting:

```
[ ERROR ] RouteNotFound.404: Not Found: /getstream/effects-library/main/favicon.ico [component: server]
```