### PR TITLE
split_queries_by_interval: 24h

### DIFF
--- a/infrastructure/loki.yml
+++ b/infrastructure/loki.yml
@@ -59,6 +59,7 @@ compactor:
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
+  split_queries_by_interval: 24h
 
 chunk_store_config:
   max_look_back_period: 168h


### PR DESCRIPTION
This setting fixes a `too many outstanding requests` error when populating a new "Logs" dashboard I've set up:

<img width="1408" alt="CleanShot 2022-09-29 at 10 17 13@2x" src="https://user-images.githubusercontent.com/65520/192978634-a842b866-fa9b-452a-8397-b576fcc56b6d.png">

Previously, I ran these Loki queries manually in the "Explore" tab but it's now possible to have these directly in a dashboard.

Note there are keyboard shortcuts to open a full window view for these: just hover over a panel with your mouse and hit "v". Hit "v" again or ESC to return to the overview.

❤️ Grafana