### PR TITLE
Remove incompatibleWithAppStore branding for LGPL*

### DIFF
--- a/Sources/App/Models/License.swift
+++ b/Sources/App/Models/License.swift
@@ -138,10 +138,7 @@ enum License: String, Codable, Equatable, CaseIterable {
             case .agpl_3_0,
                  .gpl,
                  .gpl_2_0,
-                 .gpl_3_0,
-                 .lgpl,
-                 .lgpl_2_1,
-                 .lgpl_3_0: return .incompatibleWithAppStore
+                 .gpl_3_0: return .incompatibleWithAppStore
             default: return .compatibleWithAppStore
         }
     }


### PR DESCRIPTION
LGPL licenses are not incompatible with the App Store. There are countless apps that ship with libraries like ffmpeg ([LGPL](https://ffmpeg.org/legal.html)). And nearly every app links, either directly or indirectly, with WebKit and JavaScriptCore ([LGPL](https://webkit.org/licensing-webkit/)).

There was once a potential issue around static linking (see [this ancient thread](https://trac.ffmpeg.org/ticket/1229)), but those concerns were obviated once iOS apps supported dynamic linking in iOS7 in 2013.