### PR TITLE
Reset all changes to Last Updated

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -118,7 +118,8 @@ enum PackageShow {
                 ], tabContent: [
                     readmeTabContent(),
                     releasesTabContent(),
-                ])
+                ]),
+                visibleMetadataSection()
             )
         }
 
@@ -141,11 +142,7 @@ enum PackageShow {
                     .hr(
                         .class("minor")
                     ),
-                    sidebarInfoForPackageAuthors(),
-                    .hr(
-                        .class("minor")
-                    ),
-                    visibleMetadataSection()
+                    sidebarInfoForPackageAuthors()
                 )
             )
         }
@@ -284,13 +281,17 @@ enum PackageShow {
 
         func visibleMetadataSection() -> Node<HTML.BodyContext> {
             .unwrap(packageSchema?.publicationDates) { dates in
-                    .section(
+                .section(
+                    .hr(),
+                    .p(
                         .small(
                             .text("Last updated on "),
                             .text(DateFormatter.lastUpdatedOnFormatter.string(from:dates.dateModified))
                         )
                     )
+                )
             }
+
         }
 
         func readmeTabContent() -> Node<HTML.BodyContext> {

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -327,10 +327,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -367,6 +363,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -327,10 +327,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -367,6 +363,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -331,10 +331,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -371,6 +367,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -324,10 +324,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -364,6 +360,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -355,10 +355,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -395,6 +391,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -530,10 +530,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -570,6 +566,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -320,10 +320,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -360,6 +356,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -217,10 +217,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -257,6 +253,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -327,10 +327,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -367,6 +363,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -326,10 +326,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -366,6 +362,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -327,10 +327,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -367,6 +363,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -266,10 +266,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -306,6 +302,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -327,10 +327,6 @@
                 <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
               </small>
             </section>
-            <hr class="minor"/>
-            <section>
-              <small>Last updated on 1 Jan 2001</small>
-            </section>
           </section>
         </article>
         <section data-controller="tab-bar" data-action="popstate@window->tab-bar#setTabFromLocation">
@@ -367,6 +363,12 @@
             </turbo-frame>
           </section>
           <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <small>Last updated on 1 Jan 2001</small>
+          </p>
         </section>
       </div>
     </main>


### PR DESCRIPTION
As promised in https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1640#issuecomment-1243690495:

> I will move the date back down and give up on this if this doesn't fix it.

I do not know how to make Google consistently detect these dates. It works well for about 50% of our packages, and we're doing everything right. I give up. 🤷‍♂️