### PR TITLE
Issue 1470

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -717,7 +717,7 @@ extension Analyze {
         do {
             try await Twitter.postToFirehose(client: client,
                                              package: package,
-                                             versions: versions).get()
+                                             versions: versions)
         } catch {
             logger.warning("Twitter.postToFirehose failed: \(error.localizedDescription)")
         }

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -195,7 +195,7 @@ extension Analyze {
                                  database: database,
                                  logger: logger,
                                  results: packageResults,
-                                 stage: .analysis).get()
+                                 stage: .analysis)
 
         try await RecentPackage.refresh(on: database).get()
         try await RecentRelease.refresh(on: database).get()

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -264,7 +264,7 @@ extension Analyze {
             let msg = "Failed to create checkouts directory: \(error.localizedDescription)"
             try await Current.reportError(client,
                                           .critical,
-                                          AppError.genericError(nil, msg)).get()
+                                          AppError.genericError(nil, msg))
             return
         }
     }
@@ -426,7 +426,7 @@ extension Analyze {
         } catch {
             let appError = AppError.genericError(pkgId, "Git.tag failed: \(error.localizedDescription)")
             logger.report(error: appError)
-            try? await Current.reportError(client, .error, appError).get()
+            try? await Current.reportError(client, .error, appError)
             tags = []
         }
 

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -67,11 +67,11 @@ func updatePackage(client: Client,
 
         case .failure(let error) where error as? PostgresNIO.PostgresError != nil:
             // Escalate database errors to critical
-            try await Current.reportError(client, .critical, error)
+            try? await Current.reportError(client, .critical, error)
             try await recordError(database: database, error: error, stage: stage)
 
         case .failure(let error):
-            try await Current.reportError(client, .error, error)
+            try? await Current.reportError(client, .error, error)
             try await recordError(database: database, error: error, stage: stage)
     } // switch result
 

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -21,55 +21,73 @@ func updatePackages(client: Client,
                     database: Database,
                     logger: Logger,
                     results: [Result<Joined<Package, Repository>, Error>],
-                    stage: Package.ProcessingStage) -> EventLoopFuture<Void> {
-    let updates = results.map { result -> EventLoopFuture<Void> in
-        switch result {
-            case .success(let jpr):
-                let pkg = jpr.model
-                // FIXME: Only load significant `latest` version records and release count here and change Score.compute to take those as parameters instead of all versions. We need the defaultBranch and latest stable versions for current score calculations.
-                // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1470
-                return pkg.$versions.load(on: database)
-                    .flatMap {
-                        if stage == .ingestion && pkg.status == .new {
-                            // newly ingested package: leave status == .new for fast-track
-                            // analysis
-                        } else {
-                            pkg.status = .ok
-                        }
-                        pkg.processingStage = stage
-                        pkg.score = Score.compute(package: jpr, versions: pkg.versions)
-                        return pkg.update(on: database)
-                    }
-                    .flatMapError { error in
-                        logger.report(error: error)
-                        return Current.reportError(client, .critical, error)
-                            .flatMap { database.eventLoop.future(error: error) }
-                    }
-            case .failure(let error) where error as? PostgresNIO.PostgresError != nil:
-                // Escalate database errors to critical
-                return Current.reportError(client, .critical, error)
-                    .flatMap { recordError(database: database, error: error, stage: stage) }
-            case .failure(let error):
-                return Current.reportError(client, .error, error)
-                    .flatMap { recordError(database: database, error: error, stage: stage) }
+                    stage: Package.ProcessingStage) async throws {
+
+    let updates = await withThrowingTaskGroup(of: Void.self) { group in
+        for result in results {
+            group.addTask {
+                try await updatePackage(client: client,
+                                        database: database,
+                                        logger: logger,
+                                        result: result,
+                                        stage: stage)
+            }
         }
+
+        return await group.results()
     }
+
     logger.debug("updateStatus ops: \(updates.count)")
-    return EventLoopFuture.andAllComplete(updates, on: database.eventLoop)
+}
+
+
+func updatePackage(client: Client,
+                   database: Database,
+                   logger: Logger,
+                   result: Result<Joined<Package, Repository>, Error>,
+                   stage: Package.ProcessingStage) async throws {
+    switch result {
+        case .success(let jpr):
+            let pkg = jpr.package
+            try await pkg.$versions.load(on: database)
+            if stage == .ingestion && pkg.status == .new {
+                // newly ingested package: leave status == .new for fast-track
+                // analysis
+            } else {
+                pkg.status = .ok
+            }
+            pkg.processingStage = stage
+            pkg.score = Score.compute(package: jpr, versions: pkg.versions)
+            do {
+                try await pkg.update(on: database)
+            } catch {
+                logger.report(error: error)
+                try await Current.reportError(client, .critical, error).get()
+            }
+
+        case .failure(let error) where error as? PostgresNIO.PostgresError != nil:
+            // Escalate database errors to critical
+            try await Current.reportError(client, .critical, error).get()
+            try await recordError(database: database, error: error, stage: stage)
+
+        case .failure(let error):
+            try await Current.reportError(client, .error, error).get()
+            try await recordError(database: database, error: error, stage: stage)
+    } // switch result
+
 }
 
 
 func recordError(database: Database,
                  error: Error,
-                 stage: Package.ProcessingStage) -> EventLoopFuture<Void> {
-    func setStatus(id: Package.Id?, status: Package.Status) -> EventLoopFuture<Void> {
-        guard let id = id else { return database.eventLoop.future() }
-        return Package.query(on: database)
+                 stage: Package.ProcessingStage) async throws {
+    func setStatus(id: Package.Id?, status: Package.Status) async throws {
+        guard let id = id else { return }
+        return try await Package.query(on: database)
             .filter(\.$id == id)
             .set(\.$processingStage, to: stage)
             .set(\.$status, to: status)
             .update()
-        
     }
 
     switch error as? AppError {
@@ -80,26 +98,26 @@ func recordError(database: Database,
             database.logger.error("\(stage) error: \(error.localizedDescription)")
     }
 
-    guard let error = error as? AppError else { return database.eventLoop.future() }
+    guard let error = error as? AppError else { return }
     
     switch error {
         case let .analysisError(id, _):
-            return setStatus(id: id, status: .analysisFailed)
+            try await setStatus(id: id, status: .analysisFailed)
         case .envVariableNotSet, .shellCommandFailed:
-            return database.eventLoop.future()
+            break
         case let .genericError(id, _):
-            return setStatus(id: id, status: .ingestionFailed)
+            try await setStatus(id: id, status: .ingestionFailed)
         case let .invalidPackageCachePath(id, _):
-            return setStatus(id: id, status: .invalidCachePath)
+            try await setStatus(id: id, status: .invalidCachePath)
         case let .cacheDirectoryDoesNotExist(id, _):
-            return setStatus(id: id, status: .cacheDirectoryDoesNotExist)
+            try await setStatus(id: id, status: .cacheDirectoryDoesNotExist)
         case let .invalidPackageUrl(id, _):
-            return setStatus(id: id, status: .invalidUrl)
+            try await setStatus(id: id, status: .invalidUrl)
         case let .invalidRevision(id, _):
-            return setStatus(id: id, status: .analysisFailed)
+            try await setStatus(id: id, status: .analysisFailed)
         case let .metadataRequestFailed(id, _, _):
-            return setStatus(id: id, status: .metadataRequestFailed)
+            try await setStatus(id: id, status: .metadataRequestFailed)
         case let .noValidVersions(id, _):
-            return setStatus(id: id, status: .noValidVersions)
+            try await setStatus(id: id, status: .noValidVersions)
     }
 }

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -62,16 +62,16 @@ func updatePackage(client: Client,
                 try await pkg.update(on: database)
             } catch {
                 logger.report(error: error)
-                try await Current.reportError(client, .critical, error).get()
+                try await Current.reportError(client, .critical, error)
             }
 
         case .failure(let error) where error as? PostgresNIO.PostgresError != nil:
             // Escalate database errors to critical
-            try await Current.reportError(client, .critical, error).get()
+            try await Current.reportError(client, .critical, error)
             try await recordError(database: database, error: error, stage: stage)
 
         case .failure(let error):
-            try await Current.reportError(client, .error, error).get()
+            try await Current.reportError(client, .error, error)
             try await recordError(database: database, error: error, stage: stage)
     } // switch result
 

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -131,7 +131,7 @@ func ingest(client: Client,
                                     database: database,
                                     logger: logger,
                                     results: updates,
-                                    stage: .ingestion).get()
+                                    stage: .ingestion)
 }
 
 

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -67,7 +67,7 @@ struct AppEnvironment {
                        _ swiftVersion: SwiftVersion,
                        _ versionID: Version.Id) -> EventLoopFuture<Build.TriggerResponse>
     var twitterCredentials: () -> Twitter.Credentials?
-    var twitterPostTweet: (_ client: Client, _ tweet: String) -> EventLoopFuture<Void>
+    var twitterPostTweet: (_ client: Client, _ tweet: String) async throws -> Void
 }
 
 

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -52,7 +52,7 @@ struct AppEnvironment {
     var logger: () -> Logger?
     var metricsPushGatewayUrl: () -> String?
     var random: (_ range: ClosedRange<Double>) -> Double
-    var reportError: (_ client: Client, _ level: AppError.Level, _ error: Error) -> EventLoopFuture<Void>
+    var reportError: (_ client: Client, _ level: AppError.Level, _ error: Error) async throws -> Void
     var rollbarToken: () -> String?
     var rollbarLogLevel: () -> AppError.Level
     var setLogger: (Logger) -> Void

--- a/Sources/App/Core/AppError.swift
+++ b/Sources/App/Core/AppError.swift
@@ -82,10 +82,10 @@ extension AppError.Level: Comparable {
 
 
 extension AppError {
-    static func report(_ client: Client, _ level: Level, _ error: Error) -> EventLoopFuture<Void> {
-        guard level >= Current.rollbarLogLevel() else { return client.eventLoop.future() }
-        return Rollbar.createItem(client: client,
-                                  level: .init(level: level),
-                                  message: error.localizedDescription)
+    static func report(_ client: Client, _ level: Level, _ error: Error) async throws {
+        guard level >= Current.rollbarLogLevel() else { return }
+        try await Rollbar.createItem(client: client,
+                                     level: .init(level: level),
+                                     message: error.localizedDescription)
     }
 }

--- a/Sources/App/Core/ErrorMiddleware.swift
+++ b/Sources/App/Core/ErrorMiddleware.swift
@@ -30,7 +30,7 @@ final class ErrorMiddleware: AsyncMiddleware {
 
             if isCritical {
                 Task.detached {
-                    try await Current.reportError(req.client, .critical, error).get()
+                    try await Current.reportError(req.client, .critical, error)
                 }
                 Current.logger()?.critical("\(error): \(req.url)")
             } else {

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -105,13 +105,12 @@ extension Github {
         let response = try await client.get(uri, headers: headers(with: token))
 
         guard !isRateLimited(response) else {
-            return try await Current
-                .reportError(client,
-                             .critical,
-                             AppError.metadataRequestFailed(nil, .tooManyRequests, uri))
-                .flatMap {
-                    client.eventLoop.future(error: Error.requestFailed(.tooManyRequests))
-                }.get()
+            try await Current.reportError(
+                client,
+                .critical,
+                AppError.metadataRequestFailed(nil, .tooManyRequests, uri)
+            )
+            throw Error.requestFailed(.tooManyRequests)
         }
 
         guard response.status == .ok else {
@@ -156,15 +155,14 @@ extension Github {
         }
 
         guard !isRateLimited(response) else {
-            return try await Current
-                .reportError(client,
-                             .critical,
-                             AppError.metadataRequestFailed(nil,
-                                                            .tooManyRequests,
-                                                            Self.graphQLApiUri))
-                .flatMap {
-                    client.eventLoop.future(error: Error.requestFailed(.tooManyRequests))
-                }.get()
+            try await Current.reportError(
+                client,
+                .critical,
+                AppError.metadataRequestFailed(nil,
+                                               .tooManyRequests,
+                                               Self.graphQLApiUri)
+            )
+            throw Error.requestFailed(.tooManyRequests)
         }
 
         guard response.status == .ok else {

--- a/Sources/App/Core/Rollbar.swift
+++ b/Sources/App/Core/Rollbar.swift
@@ -19,12 +19,12 @@ enum Rollbar {
     static func createItem(client: Client,
                            level: Item.Level,
                            message: String,
-                           environment: Environment = (try? Environment.detect()) ?? .testing) -> EventLoopFuture<Void> {
+                           environment: Environment = (try? Environment.detect()) ?? .testing) async throws {
         guard let token = Current.rollbarToken() else {
             // fail silently
-            return client.eventLoop.future()
+            return
         }
-        return client.post(rollbarURI) { req in
+        _ = try await client.post(rollbarURI) { req in
             try req.content.encode(
                 Rollbar.Item(accessToken: token,
                              environment: environment,
@@ -32,7 +32,6 @@ enum Rollbar {
                              message: message)
             )
         }
-        .transform(to: ())
     }
     
     static var rollbarURI: URI { URI("https://api.rollbar.com/api/1/item/") }

--- a/Sources/App/Core/Twitter.swift
+++ b/Sources/App/Core/Twitter.swift
@@ -35,9 +35,9 @@ enum Twitter {
         var accessToken: (key: String, secret: String)
     }
 
-    static func post(client: Client, tweet: String) -> EventLoopFuture<Void> {
+    static func post(client: Client, tweet: String) async throws {
         guard let credentials = Current.twitterCredentials() else {
-            return client.eventLoop.future(error: Error.missingCredentials)
+            throw Error.missingCredentials
         }
         let url: URL = URL(string: "\(apiUrl)?status=\(tweet.urlEncodedString())")!
         let signature = OhhAuth.calculateSignature(
@@ -51,13 +51,10 @@ enum Twitter {
         var headers: HTTPHeaders = .init()
         headers.add(name: "Authorization", value: signature)
         headers.add(name: "Content-Type", value: "application/x-www-form-urlencoded")
-        return client.post(URI(string: url.absoluteString), headers: headers)
-            .flatMapThrowing { response in
-                guard response.status == .ok else {
-                    throw Error.requestFailed(response.status, response.body?.asString() ?? "")
-                }
-            }
-            .transform(to: ())
+        let response = try await client.post(URI(string: url.absoluteString), headers: headers)
+        guard response.status == .ok else {
+            throw Error.requestFailed(response.status, response.body?.asString() ?? "")
+        }
     }
 
 }
@@ -128,21 +125,21 @@ extension Twitter {
 
     static func postToFirehose(client: Client,
                                package: Joined<Package, Repository>,
-                               version: Version) -> EventLoopFuture<Void> {
+                               version: Version) async throws {
         guard Current.allowTwitterPosts() else {
-            return client.eventLoop.future(error: Error.postingDisabled)
+            throw Error.postingDisabled
         }
         guard let message = firehoseMessage(package: package,
                                             version: version)
         else {
-            return client.eventLoop.future(error: Error.invalidMessage)
+            throw Error.invalidMessage
         }
-        return Current.twitterPostTweet(client, message)
+        try await Current.twitterPostTweet(client, message)
     }
 
     static func postToFirehose(client: Client,
                                package: Joined<Package, Repository>,
-                               versions: [Version]) -> EventLoopFuture<Void> {
+                               versions: [Version]) async throws {
         let (release, preRelease, defaultBranch) = Package.findSignificantReleases(
             versions: versions,
             branch: package.repository?.defaultBranch
@@ -154,12 +151,11 @@ extension Twitter {
                   let id = version.id else { return false }
             return idsLatest.contains(id)
         }
-        return versions.map {
-            postToFirehose(client: client,
-                           package: package,
-                           version: $0)
+        for version in versions {
+            try await postToFirehose(client: client,
+                                     package: package,
+                                     version: version)
         }
-        .flatten(on: client.eventLoop)
     }
 
 }

--- a/Tests/AppTests/AnalyzeErrorTests.swift
+++ b/Tests/AppTests/AnalyzeErrorTests.swift
@@ -32,15 +32,8 @@ final class AnalyzeErrorTests: AppTestCase {
     let badPackageID: Package.Id = .id0
     let goodPackageID: Package.Id = .id1
 
-    actor Validator {
-        static var reportedErrors = [Error]()
-        static var tweets = [String]()
-
-        static func reset() {
-            reportedErrors = []
-            tweets = []
-        }
-    }
+    let reportedErrors = ActorIsolated<[Error]>([])
+    let tweets = ActorIsolated<[String]>([])
 
     static var defaultShellRun: (ShellOutCommand, String) throws -> String = { cmd, path in
         switch cmd {
@@ -61,7 +54,8 @@ final class AnalyzeErrorTests: AppTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        Validator.reset()
+        await reportedErrors.setValue([])
+        await tweets.setValue([])
 
         // Silence logging
         app.logger = .init(label: "noop") { _ in SwiftLogNoOpLogHandler() }
@@ -108,14 +102,13 @@ final class AnalyzeErrorTests: AppTestCase {
         }
 
         Current.reportError = { _, _, error in
-            Validator.reportedErrors.append(error)
+            await self.reportedErrors.withValue { $0.append(error) }
         }
 
         Current.shell.run = Self.defaultShellRun
 
         Current.twitterPostTweet = { client, message in
-            Validator.tweets.append(message)
-            return self.app.eventLoopGroup.future()
+            await self.tweets.withValue { $0.append(message) }
         }
     }
 
@@ -142,17 +135,19 @@ final class AnalyzeErrorTests: AppTestCase {
 
         // validate
         try await defaultValidation()
-        XCTAssertEqual(Validator.reportedErrors.count, 1)
-        let error = try Validator.reportedErrors.first.unwrap().localizedDescription
-        XCTAssertTrue(
-            error.contains(
+        try await reportedErrors.withValue { errors in
+            XCTAssertEqual(errors.count, 1)
+            let error = try errors.first.unwrap().localizedDescription
+            XCTAssertTrue(
+                error.contains(
                 #"""
                 Analysis failed: refreshCheckout failed: Shell command failed:
                 command: "git clone https://github.com/foo/1
                 """#
-            ),
-            "was: \(error)"
-        )
+                ),
+                "was: \(error)"
+            )
+        }
     }
 
     func test_analyze_updateRepository_invalidPackageCachePath() async throws {
@@ -172,16 +167,18 @@ final class AnalyzeErrorTests: AppTestCase {
 
         // validate
         try await defaultValidation()
-        XCTAssertEqual(Validator.reportedErrors.count, 1)
-        let error = try Validator.reportedErrors.first.unwrap().localizedDescription
-        XCTAssertTrue(
-            error.contains(
+        try await reportedErrors.withValue { errors in
+            XCTAssertEqual(errors.count, 1)
+            let error = try errors.first.unwrap().localizedDescription
+            XCTAssertTrue(
+                error.contains(
                 #"""
                 Invalid packge cache path: foo/1
                 """#
-            ),
-            "was: \(error)"
-        )
+                ),
+                "was: \(error)"
+            )
+        }
     }
 
     func test_analyze_getPackageInfo_gitCheckout_error() async throws {
@@ -204,16 +201,18 @@ final class AnalyzeErrorTests: AppTestCase {
 
         // validate
         try await defaultValidation()
-        XCTAssertEqual(Validator.reportedErrors.count, 1)
-        let error = try Validator.reportedErrors.first.unwrap().localizedDescription
-        XCTAssertTrue(
-            error.contains(
+        try await reportedErrors.withValue { errors in
+            XCTAssertEqual(errors.count, 1)
+            let error = try errors.first.unwrap().localizedDescription
+            XCTAssertTrue(
+                error.contains(
                 #"""
                 No valid version found for package 'https://github.com/foo/1'
                 """#
-            ),
-            "was: \(error)"
-        )
+                ),
+                "was: \(error)"
+            )
+        }
     }
 
     func test_analyze_dumpPackage_missing_manifest() async throws {
@@ -233,17 +232,19 @@ final class AnalyzeErrorTests: AppTestCase {
 
         // validate
         try await defaultValidation()
-        XCTAssertEqual(Validator.reportedErrors.count, 1)
-        let error = try Validator.reportedErrors.first.unwrap().localizedDescription
-        print(error)
-        XCTAssertTrue(
-            error.contains(
+        try await reportedErrors.withValue { errors in
+            XCTAssertEqual(errors.count, 1)
+            let error = try errors.first.unwrap().localizedDescription
+            print(error)
+            XCTAssertTrue(
+                error.contains(
                 #"""
                 No valid version found for package 'https://github.com/foo/1'
                 """#
-            ),
-            "was: \(error)"
-        )
+                ),
+                "was: \(error)"
+            )
+        }
     }
 
 
@@ -258,13 +259,15 @@ extension AnalyzeErrorTests {
         XCTAssertEqual(versions.count, 2)
         XCTAssertEqual(versions.filter(\.isBranch).first?.latest, .defaultBranch)
         XCTAssertEqual(versions.filter(\.isTag).first?.latest, .release)
-        XCTAssertEqual(Validator.tweets, [
+        await tweets.withValue { tweets in
+            XCTAssertEqual(tweets, [
             """
             ⬆️ foo just released foo-2 v1.2.3
 
             http://localhost:8080/foo/2#releases
             """
-        ])
+            ])
+        }
     }
 }
 

--- a/Tests/AppTests/AnalyzeErrorTests.swift
+++ b/Tests/AppTests/AnalyzeErrorTests.swift
@@ -109,7 +109,6 @@ final class AnalyzeErrorTests: AppTestCase {
 
         Current.reportError = { _, _, error in
             Validator.reportedErrors.append(error)
-            return self.app.eventLoopGroup.future()
         }
 
         Current.shell.run = Self.defaultShellRun

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -745,7 +745,7 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(targets.map(\.name), ["t1", "t2"])
     }
 
-    func test_updatePackage() throws {
+    func test_updatePackage() async throws {
         // setup
         let packages = try savePackages(on: app.db, ["1", "2"].asURLs)
             .map(Joined<Package, Repository>.init(model:))
@@ -756,15 +756,15 @@ class AnalyzerTests: AppTestCase {
         ]
 
         // MUT
-        try updatePackages(client: app.client,
-                           database: app.db,
-                           logger: app.logger,
-                           results: results,
-                           stage: .analysis).wait()
+        try await updatePackages(client: app.client,
+                                 database: app.db,
+                                 logger: app.logger,
+                                 results: results,
+                                 stage: .analysis)
 
         // validate
         do {
-            let packages = try Package.query(on: app.db).sort(\.$url).all().wait()
+            let packages = try await Package.query(on: app.db).sort(\.$url).all()
             assertEquals(packages, \.status, [.noValidVersions, .ok])
             assertEquals(packages, \.processingStage, [.analysis, .analysis])
         }

--- a/Tests/AppTests/ErrorMiddlewareTests.swift
+++ b/Tests/AppTests/ErrorMiddlewareTests.swift
@@ -64,7 +64,6 @@ class ErrorMiddlewareTests: AppTestCase {
         var errorReported = false
         Current.reportError = { _, level, error in
             errorReported = true
-            return self.future(())
         }
         
         try app.test(.GET, "404", afterResponse: { response in
@@ -81,7 +80,6 @@ class ErrorMiddlewareTests: AppTestCase {
                 reportedLevel = level
                 reportedError = error.localizedDescription
             }
-            return self.future(())
         }
         
         try app.test(.GET, "500", afterResponse: { response in

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -31,10 +31,10 @@ class ErrorReportingTests: AppTestCase {
         }
     }
     
-    func test_Rollbar_createItem() throws {
+    func test_Rollbar_createItem() async throws {
         Current.rollbarToken = { "token" }
         let client = MockClient { _, resp in resp.status = .ok }
-        try Rollbar.createItem(client: client, level: .critical, message: "Test critical").wait()
+        try await Rollbar.createItem(client: client, level: .critical, message: "Test critical")
     }
     
     func test_Ingestor_error_reporting() async throws {
@@ -47,7 +47,6 @@ class ErrorReportingTests: AppTestCase {
         Current.reportError = { _, level, error in
             reportedLevel = level
             reportedError = error as? AppError
-            return self.future(())
         }
         
         // MUT
@@ -74,7 +73,6 @@ class ErrorReportingTests: AppTestCase {
         Current.reportError = { _, level, error in
             reportedLevel = level
             reportedError = error
-            return self.future(())
         }
         
         // MUT

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -20,7 +20,7 @@ import XCTVapor
 class ErrorReportingTests: AppTestCase {
     
     func test_recordError() async throws {
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackageAsync(on: app.db, "1")
         try await recordError(database: app.db,
                               error: AppError.invalidPackageUrl(pkg.id, "foo"),
                               stage: .ingestion)
@@ -39,7 +39,7 @@ class ErrorReportingTests: AppTestCase {
     
     func test_Ingestor_error_reporting() async throws {
         // setup
-        try savePackages(on: app.db, ["1", "2"], processingStage: .reconciliation)
+        try await savePackagesAsync(on: app.db, ["1", "2"], processingStage: .reconciliation)
         Current.fetchMetadata = { _, _ in throw AppError.invalidPackageUrl(nil, "foo") }
         
         var reportedLevel: AppError.Level? = nil
@@ -59,7 +59,8 @@ class ErrorReportingTests: AppTestCase {
     
     func test_Analyzer_error_reporting() async throws {
         // setup
-        try savePackages(on: app.db, ["1", "2"].asGithubUrls.asURLs, processingStage: .ingestion)
+        try await savePackagesAsync(on: app.db, ["1", "2"].asGithubUrls.asURLs,
+                                    processingStage: .ingestion)
         Current.fileManager.fileExists = { _ in true }
         Current.shell.run = { cmd, path in
             if cmd.string == "git tag" { return "1.0.0" }
@@ -88,7 +89,7 @@ class ErrorReportingTests: AppTestCase {
     
     func test_invalidPackageCachePath() async throws {
         // setup
-        try savePackages(on: app.db, ["1", "2"], processingStage: .ingestion)
+        try await savePackagesAsync(on: app.db, ["1", "2"], processingStage: .ingestion)
         
         // MUT
         try await Analyze.analyze(client: app.client,

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -73,11 +73,11 @@ class ErrorReportingTests: AppTestCase {
             return "invalid"
         }
         
-        var reportedLevel: AppError.Level? = nil
-        var reportedError: Error? = nil
+        let reportedLevel = ActorIsolated<AppError.Level?>(nil)
+        let reportedError = ActorIsolated<Error?>(nil)
         Current.reportError = { _, level, error in
-            reportedLevel = level
-            reportedError = error
+            await reportedLevel.setValue(level)
+            await reportedError.setValue(error)
         }
         
         // MUT
@@ -87,8 +87,12 @@ class ErrorReportingTests: AppTestCase {
                                   mode: .limit(10))
         
         // validation
-        XCTAssertNotNil(reportedError)
-        XCTAssertEqual(reportedLevel, .error)
+        await reportedLevel.withValue {
+            XCTAssertEqual($0, .error)
+        }
+        await reportedError.withValue {
+            XCTAssertNotNil($0)
+        }
     }
     
     func test_invalidPackageCachePath() async throws {

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -19,11 +19,11 @@ import XCTVapor
 
 class ErrorReportingTests: AppTestCase {
     
-    func test_recordError() throws {
+    func test_recordError() async throws {
         let pkg = try savePackage(on: app.db, "1")
-        try recordError(database: app.db,
-                        error: AppError.invalidPackageUrl(pkg.id, "foo"),
-                        stage: .ingestion).wait()
+        try await recordError(database: app.db,
+                              error: AppError.invalidPackageUrl(pkg.id, "foo"),
+                              stage: .ingestion)
         do {
             let pkg = try fetch(id: pkg.id, on: app.db)
             XCTAssertEqual(pkg.status, .invalidUrl)

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -253,7 +253,6 @@ class GithubTests: AppTestCase {
         Current.reportError = { _, level, error in
             reportedLevel = level
             reportedError = error
-            return self.future(())
         }
         
         // MUT

--- a/Tests/AppTests/Helpers/ActorIsolated.swift
+++ b/Tests/AppTests/Helpers/ActorIsolated.swift
@@ -1,0 +1,113 @@
+// Copyright 2020-2023 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// From https://github.com/pointfreeco/swift-composable-architecture/blob/ed3a380f09a81e72636d7b0699bf2dd2e6313780/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift#L297
+
+/// A generic wrapper for isolating a mutable value to an actor.
+///
+/// This type is most useful when writing tests for when you want to inspect what happens inside
+/// an effect. For example, suppose you have a feature such that when a button is tapped you
+/// track some analytics:
+///
+/// ```swift
+/// @Dependency(\.analytics) var analytics
+///
+/// func reduce(into state: inout State, action: Action) -> EffectTask<Action> {
+///   switch action {
+///   case .buttonTapped:
+///     return .fireAndForget { try await self.analytics.track("Button Tapped") }
+///   }
+/// }
+/// ```
+///
+/// Then, in tests we can construct an analytics client that appends events to a mutable array
+/// rather than actually sending events to an analytics server. However, in order to do this in
+/// a safe way we should use an actor, and ``ActorIsolated`` makes this easy:
+///
+/// ```swift
+/// @MainActor
+/// func testAnalytics() async {
+///   let store = TestStore(…)
+///
+///   let events = ActorIsolated<[String]>([])
+///   store.dependencies.analytics = AnalyticsClient(
+///     track: { event in
+///       await events.withValue { $0.append(event) }
+///     }
+///   )
+///
+///   await store.send(.buttonTapped)
+///
+///   await events.withValue { XCTAssertEqual($0, ["Button Tapped"]) }
+/// }
+/// ```
+@dynamicMemberLookup
+public final actor ActorIsolated<Value: Sendable> {
+  /// The actor-isolated value.
+  public var value: Value
+
+  /// Initializes actor-isolated state around a value.
+  ///
+  /// - Parameter value: A value to isolate in an actor.
+  public init(_ value: Value) {
+    self.value = value
+  }
+
+  public subscript<Subject>(dynamicMember keyPath: KeyPath<Value, Subject>) -> Subject {
+    self.value[keyPath: keyPath]
+  }
+
+  /// Perform an operation with isolated access to the underlying value.
+  ///
+  /// Useful for inspecting an actor-isolated value for a test assertion:
+  ///
+  /// ```swift
+  /// let didOpenSettings = ActorIsolated(false)
+  /// store.dependencies.openSettings = { await didOpenSettings.setValue(true) }
+  ///
+  /// await store.send(.settingsButtonTapped)
+  ///
+  /// await didOpenSettings.withValue { XCTAssertTrue($0) }
+  /// ```
+  ///
+  /// - Parameters: operation: An operation to be performed on the actor with the underlying value.
+  /// - Returns: The result of the operation.
+  public func withValue<T: Sendable>(
+    _ operation: @Sendable (inout Value) async throws -> T
+  ) async rethrows -> T {
+    var value = self.value
+    defer { self.value = value }
+    return try await operation(&value)
+  }
+
+  /// Overwrite the isolated value with a new value.
+  ///
+  /// Useful for setting an actor-isolated value when a tested dependency runs.
+  ///
+  /// ```swift
+  /// let didOpenSettings = ActorIsolated(false)
+  /// store.dependencies.openSettings = { await didOpenSettings.setValue(true) }
+  ///
+  /// await store.send(.settingsButtonTapped)
+  ///
+  /// await didOpenSettings.withValue { XCTAssertTrue($0) }
+  /// ```
+  ///
+  /// - Parameter newValue: The value to replace the current isolated value with.
+  public func setValue(_ newValue: Value) {
+    self.value = newValue
+  }
+}
+

--- a/Tests/AppTests/Helpers/ActorIsolated.swift
+++ b/Tests/AppTests/Helpers/ActorIsolated.swift
@@ -1,19 +1,27 @@
-// Copyright 2020-2023 Dave Verwer, Sven A. Schmidt, and other contributors.
+// MIT License
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
+// Copyright (c) 2020 Point-Free, Inc.
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
 //
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
-
-// From https://github.com/pointfreeco/swift-composable-architecture/blob/ed3a380f09a81e72636d7b0699bf2dd2e6313780/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift#L297
+// Extracted from https://github.com/pointfreeco/swift-composable-architecture/blob/ed3a380f09a81e72636d7b0699bf2dd2e6313780/Sources/ComposableArchitecture/Effects/ConcurrencySupport.swift#L297
+// Add any changes via extensions in a new file rather than making changes here.
 
 /// A generic wrapper for isolating a mutable value to an actor.
 ///

--- a/Tests/AppTests/Helpers/QueueIsolated.swift
+++ b/Tests/AppTests/Helpers/QueueIsolated.swift
@@ -1,0 +1,53 @@
+// Copyright 2020-2022 Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+
+// Modeled after ActorIsolated with synchronisation via a queue instead of an actor, allowing
+// sync access where async isn't possible.
+
+@dynamicMemberLookup
+public final class QueueIsolated<Value> {
+    private var _queue = DispatchQueue(label: "queue-isolated")
+
+    public var value: Value
+
+    public init(_ value: Value) {
+        self.value = value
+    }
+
+    public subscript<Subject>(dynamicMember keyPath: KeyPath<Value, Subject>) -> Subject {
+        _queue.sync {
+            self.value[keyPath: keyPath]
+        }
+    }
+
+    public func withValue<T>(
+        _ operation: (inout Value) throws -> T
+    ) rethrows -> T {
+        try _queue.sync {
+            var value = self.value
+            defer { self.value = value }
+            return try operation(&value)
+        }
+    }
+
+    public func setValue(_ newValue: Value) {
+        _queue.async {
+            self.value = newValue
+        }
+    }
+}
+

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -268,7 +268,7 @@ class IngestorTests: AppTestCase {
                                  database: app.db,
                                  logger: app.logger,
                                  results: results,
-                                 stage: .ingestion).get()
+                                 stage: .ingestion)
         
         // validate
         do {
@@ -294,7 +294,7 @@ class IngestorTests: AppTestCase {
                                  database: app.db,
                                  logger: app.logger,
                                  results: results,
-                                 stage: .ingestion).get()
+                                 stage: .ingestion)
         
         // validate
         do {

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -388,7 +388,6 @@ class IngestorTests: AppTestCase {
             // Errors seen here go to Rollbar
             reportedLevel = level
             reportedError = error.localizedDescription
-            return self.future(())
         }
         let lastUpdate = Date()
         

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -79,7 +79,7 @@ extension AppEnvironment {
                 eventLoop.future(.init(status: .ok, webUrl: "http://web_url"))
             },
             twitterCredentials: { nil },
-            twitterPostTweet: { _, _ in eventLoop.future() }
+            twitterPostTweet: { _, _ in }
         )
     }
 }

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -69,7 +69,7 @@ extension AppEnvironment {
             logger: { nil },
             metricsPushGatewayUrl: { "http://pushgateway:9091" },
             random: Double.random,
-            reportError: { _, _, _ in eventLoop.future(()) },
+            reportError: { _, _, _ in },
             rollbarToken: { nil },
             rollbarLogLevel: { .critical },
             setLogger: { _ in },

--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -37,12 +37,12 @@ class QueryPerformanceTests: XCTestCase {
 
     func test_Search_packageMatchQuery() async throws {
         let query = Search.packageMatchQueryBuilder(on: app.db, terms: ["a"], filters: [])
-        try await assertQueryPerformance(query, expectedCost: 830, variation: 50)
+        try await assertQueryPerformance(query, expectedCost: 880, variation: 50)
     }
 
     func test_Search_keywordMatchQuery() async throws {
         let query = Search.keywordMatchQueryBuilder(on: app.db, terms: ["a"])
-        try await assertQueryPerformance(query, expectedCost: 3520, variation: 150)
+        try await assertQueryPerformance(query, expectedCost: 3670, variation: 150)
     }
 
     func test_Search_authorMatchQuery() async throws {
@@ -146,7 +146,7 @@ class QueryPerformanceTests: XCTestCase {
               JOIN versions v ON v.package_id = p.id
             WHERE v.reference ->> 'branch' = r.default_branch
             """)
-        try await assertQueryPerformance(query, expectedCost: 21_400, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 21_690, variation: 200)
     }
 
 }


### PR DESCRIPTION
This isn't addressing #1470 yet but it's worth merging in preparation. It moves a few essential bits over to async/await and introduces a way to handle test validations of async handlers.

Our current method of doing that via static properties on `actor Validation` isn't actually correct. Saw this in a tweet (which I can't find anymore) and which makes sense since we don't actually use `await` to read or write the values. We're essentially just tricking TSAN into OKing this.

To do:

- [x] migrate `actor Validation` code
- [x] figure out how to attribute `ActorIsolated`