### PR TITLE
Prevent empty `li` tags when packages have no authors

### DIFF
--- a/Sources/App/Core/PackageContributors.swift
+++ b/Sources/App/Core/PackageContributors.swift
@@ -20,6 +20,11 @@ import Vapor
 struct PackageAuthors: Codable, Equatable {
     var authors: [Author]
     var numberOfContributors: Int
+
+    var hasAuthors: Bool {
+        // No need to check numberOfContributors here. If there are no authors, there are no authors.
+        authors.isEmpty == false
+    }
 }
 
 enum PackageContributors {

--- a/Sources/App/Views/PackageController/PackageShow+Model.swift
+++ b/Sources/App/Views/PackageController/PackageShow+Model.swift
@@ -274,7 +274,10 @@ extension PackageShow.Model {
 
     func authorsListItem() -> Node<HTML.ListContext> {
         guard Environment.current == .development else { return .empty }
-        guard let authors else { return .empty }
+
+        guard let authors, authors.hasAuthors
+        else { return .empty }
+
         var nodes = authors.authors.map { author -> Node<HTML.BodyContext> in
             if let authorURL = author.url {
                 return .a(.href(authorURL), .text(author.name))

--- a/Tests/AppTests/PackageContributorsTests.swift
+++ b/Tests/AppTests/PackageContributorsTests.swift
@@ -17,6 +17,18 @@ import XCTest
 @testable import App
 
 class PackageContributorsTests : AppTestCase {
+
+    func test_packageAuthors_hasAuthors() throws {
+        let noPackageAuthors = PackageAuthors(authors: [], numberOfContributors: 0)
+
+        let somePackageAuthors = PackageAuthors(authors: [
+            .init(name: "Person One"),
+            .init(name: "Person Two")
+        ], numberOfContributors: 0)
+
+        XCTAssertFalse(noPackageAuthors.hasAuthors)
+        XCTAssertTrue(somePackageAuthors.hasAuthors)
+    }
   
     func test_CommitSelector_primaryContributors() throws {
         


### PR DESCRIPTION
We need to look into why these are blank, but we also shouldn't be putting out a blank `li` tag if there are no authors.

<img width="265" alt="Screenshot 2022-10-25 at 17 15 13@2x" src="https://user-images.githubusercontent.com/5180/197827563-d7132ccd-a6ed-48d9-93fe-f2378bddd7a1.png">
