### PR TITLE
Only show the GitHub icon on the "View on GitHub" link in the sidebar

### DIFF
--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -157,7 +157,7 @@
                         background-color: var(--bordered-button-hover);
                     }
 
-                    &[href^='https://github.com/' i] {
+                    &.github {
                         padding-left: 33px;
                         background-position: center left 8px;
                         background-repeat: no-repeat;

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -206,6 +206,7 @@ enum PackageShow {
                 .ul(
                     .li(
                         .a(
+                            .class("github"),
                             .href(model.gitHubRepositoryUrl),
                             "View on GitHub"
                         )

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -278,7 +278,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -281,7 +281,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -282,7 +282,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -278,7 +278,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -309,7 +309,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -484,7 +484,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -274,7 +274,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -171,7 +171,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -281,7 +281,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -280,7 +280,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -281,7 +281,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -220,7 +220,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -278,7 +278,7 @@
             <section class="sidebar-links">
               <ul>
                 <li>
-                  <a href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
                 </li>
                 <li class="try-in-playground">
                   <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>


### PR DESCRIPTION
Fixes #1732