### PR TITLE
Build matrix snapshot fixes

### DIFF
--- a/Sources/App/Views/PackageController/Builds/BuildIndex+Model.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+Model.swift
@@ -157,17 +157,17 @@ extension BuildIndex.Model {
         var node: Node<HTML.BodyContext> {
             guard let value = value else {
                 // No value indicates a missing/pending build
-                return cell(text: "Build Pending")
+                return cell(text: "Pending")
             }
 
             let buildURL = SiteURL.builds(.value(value.id)).relativeURL()
 
             switch value.status {
-                case .ok: return cell(text: "Build Succeeded", linkURL: buildURL, cssClass: "succeeded", generatedDocs: generatedDocs)
-                case .failed: return cell(text: "Build Failed", linkURL: buildURL, cssClass: "failed", generatedDocs: generatedDocs)
-                case .triggered: return cell(text: "Build Queued")
-                case .infrastructureError: return cell(text: "Build Errored")
-                case .timeout: return cell(text: "Build Timed Out")
+                case .ok: return cell(text: "Succeeded", linkURL: buildURL, cssClass: "succeeded", generatedDocs: generatedDocs)
+                case .failed: return cell(text: "Failed", linkURL: buildURL, cssClass: "failed", generatedDocs: generatedDocs)
+                case .triggered: return cell(text: "Queued")
+                case .infrastructureError: return cell(text: "Errored")
+                case .timeout: return cell(text: "Timed Out")
             }
         }
 

--- a/Tests/AppTests/BuildIndexModelTests.swift
+++ b/Tests/AppTests/BuildIndexModelTests.swift
@@ -170,16 +170,16 @@ class BuildIndexModelTests: AppTestCase {
     func test_BuildCell() throws {
         let id = UUID()
         XCTAssertEqual(BuildCell("1.2.3", .release, id, .ok, generatedDocs: false).node.render(), """
-            <div class="succeeded"><a href="/builds/\(id.uuidString)">Build Succeeded</a></div>
+            <div class="succeeded"><a href="/builds/\(id.uuidString)">Succeeded</a></div>
             """)
         XCTAssertEqual(BuildCell("1.2.3", .release, id, .ok, generatedDocs: true).node.render(), """
-            <div class="succeeded"><a href="/builds/\(id.uuidString)">Build Succeeded</a><span class="generated-docs" title="If successful, this build generated package documentation."></span></div>
+            <div class="succeeded"><a href="/builds/\(id.uuidString)">Succeeded</a><span class="generated-docs" title="If successful, this build generated package documentation."></span></div>
             """)
         XCTAssertEqual(BuildCell("1.2.3", .release, id, .failed, generatedDocs: false).node.render(), """
-            <div class="failed"><a href="/builds/\(id.uuidString)">Build Failed</a></div>
+            <div class="failed"><a href="/builds/\(id.uuidString)">Failed</a></div>
             """)
         XCTAssertEqual(BuildCell("1.2.3", .release).node.render(), """
-            <div><span>Build Pending</span></div>
+            <div><span>Pending</span></div>
             """)
     }
 
@@ -208,9 +208,9 @@ class BuildIndexModelTests: AppTestCase {
             ),
             .div(
                 .class("results"),
-                .div(.class("succeeded"), .a(.href("/builds/\(id.uuidString)"), .text("Build Succeeded"))),
-                .div(.span(.text("Build Pending"))),
-                .div(.class("failed"), .a(.href("/builds/\(id.uuidString)"), .text("Build Failed")))
+                .div(.class("succeeded"), .a(.href("/builds/\(id.uuidString)"), .text("Succeeded"))),
+                .div(.span(.text("Pending"))),
+                .div(.class("failed"), .a(.href("/builds/\(id.uuidString)"), .text("Failed")))
             )
         )
         XCTAssertEqual(node.render(), expectation.render())
@@ -241,7 +241,7 @@ class BuildIndexModelTests: AppTestCase {
                     .class("succeeded"),
                     .a(
                         .href("/builds/\(id.uuidString)"),
-                        .text("Build Succeeded")
+                        .text("Succeeded")
                     ),
                     .span(
                         .class("generated-docs"),

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.html
@@ -127,13 +127,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
               </div>
             </li>
@@ -154,13 +154,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
               </div>
             </li>
@@ -181,13 +181,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
               </div>
             </li>
@@ -208,13 +208,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
               </div>
             </li>
@@ -235,13 +235,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
               </div>
             </li>
@@ -262,13 +262,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
               </div>
             </li>
@@ -293,15 +293,15 @@
               </div>
               <div class="results">
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                   <span class="generated-docs" title="If successful, this build generated package documentation."></span>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                   <span class="generated-docs" title="If successful, this build generated package documentation."></span>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                   <span class="generated-docs" title="If successful, this build generated package documentation."></span>
                 </div>
               </div>
@@ -323,13 +323,13 @@
               </div>
               <div class="results">
                 <div class="failed">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Failed</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
                 </div>
                 <div class="failed">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Failed</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
                 </div>
                 <div class="failed">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Failed</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
                 </div>
               </div>
             </li>
@@ -350,13 +350,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Queued</span>
+                  <span>Queued</span>
                 </div>
                 <div>
-                  <span>Build Queued</span>
+                  <span>Queued</span>
                 </div>
                 <div>
-                  <span>Build Queued</span>
+                  <span>Queued</span>
                 </div>
               </div>
             </li>
@@ -377,13 +377,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Pending</span>
+                  <span>Pending</span>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -404,13 +404,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Timed Out</span>
+                  <span>Timed Out</span>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -431,13 +431,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Errored</span>
+                  <span>Errored</span>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -462,13 +462,13 @@
               </div>
               <div class="results">
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -489,13 +489,13 @@
               </div>
               <div class="results">
                 <div class="failed">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Failed</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
                 </div>
                 <div class="failed">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Failed</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
                 </div>
                 <div class="failed">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Failed</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
                 </div>
               </div>
             </li>
@@ -516,13 +516,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Queued</span>
+                  <span>Queued</span>
                 </div>
                 <div>
-                  <span>Build Queued</span>
+                  <span>Queued</span>
                 </div>
                 <div>
-                  <span>Build Queued</span>
+                  <span>Queued</span>
                 </div>
               </div>
             </li>
@@ -543,13 +543,13 @@
               </div>
               <div class="results">
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -570,13 +570,13 @@
               </div>
               <div class="results">
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -597,13 +597,13 @@
               </div>
               <div class="results">
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -628,13 +628,13 @@
               </div>
               <div class="results">
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -655,13 +655,13 @@
               </div>
               <div class="results">
                 <div class="failed">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Failed</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
                 </div>
                 <div class="failed">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Failed</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
                 </div>
                 <div class="failed">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Failed</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
                 </div>
               </div>
             </li>
@@ -682,13 +682,13 @@
               </div>
               <div class="results">
                 <div>
-                  <span>Build Queued</span>
+                  <span>Queued</span>
                 </div>
                 <div>
-                  <span>Build Queued</span>
+                  <span>Queued</span>
                 </div>
                 <div>
-                  <span>Build Queued</span>
+                  <span>Queued</span>
                 </div>
               </div>
             </li>
@@ -709,13 +709,13 @@
               </div>
               <div class="results">
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -736,13 +736,13 @@
               </div>
               <div class="results">
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>
@@ -763,13 +763,13 @@
               </div>
               <div class="results">
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
                 <div class="succeeded">
-                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Build Succeeded</a>
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
                 </div>
               </div>
             </li>


### PR DESCRIPTION
#2110 had an issue where the build matrix labels were too long when combined with the new "generated docs" badge. Submitting the fix to this as a separate PR rather than making that diff busier with inconsequential text changes.

![ed7b584f0797171da8af4ca196b9e595930ed3570d6d6262a02cde667d1a849b](https://user-images.githubusercontent.com/5180/199301697-d455695f-4a9c-4a9a-bf5c-1fddc85bbad4.png)
