### PR TITLE
Add top level documentation pages to the sitemap for documented packages

### DIFF
--- a/Tests/AppTests/SitemapTests.swift
+++ b/Tests/AppTests/SitemapTests.swift
@@ -51,7 +51,7 @@ class SitemapTests: SnapshotTestCase {
         // setup
         Current.siteURL = { "https://indexsite.com" }
         let packages: [SiteMap.Package] = [
-            .init(owner: "foo1", repository: "bar1"),
+            .init(owner: "foo1", repository: "bar1", hasDocs: true),
             .init(owner: "foo2", repository: "bar2"),
             .init(owner: "foo3", repository: "bar3"),
         ]

--- a/Tests/AppTests/__Snapshots__/SitemapTests/test_render.1.xml
+++ b/Tests/AppTests/__Snapshots__/SitemapTests/test_render.1.xml
@@ -17,6 +17,10 @@
     <changefreq>daily</changefreq>
   </url>
   <url>
+    <loc>https://indexsite.com/foo1/bar1/documentation</loc>
+    <changefreq>daily</changefreq>
+  </url>
+  <url>
     <loc>https://indexsite.com/foo2/bar2</loc>
     <changefreq>daily</changefreq>
   </url>


### PR DESCRIPTION
Fixes #2138

> **Note:** We should _not_ include the `/documentation` path for packages with external documentation. I'm not sure whether there are strict rules for a sitemap pointing to a completely different domain, but it doesn't feel like that's what a sitemap should be used for.

This PR does *not* do this. We had a `has_docs` field already in search, so it was trivial to implement this using that. I'm going to check in on this in a week or so to see if it has had any effect and if it has, we can consider a better fix to this than what we have here, but as a quick experiment, this is the best way.