### PR TITLE
Rework #1470 part 2

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -675,7 +675,7 @@ extension Analyze {
         // find previous markers
         let previous = package.model.versions.filter { $0.latest != nil }
 
-        let versions = package.model.$versions.value ?? []
+        let versions = package.model.versions
 
         // find new significant releases
         let (release, preRelease, defaultBranch) = Package.findSignificantReleases(

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -668,6 +668,7 @@ extension Analyze {
     ///   - database: `Database` object
     ///   - package: package to update
     /// - Returns: future
+    @discardableResult
     static func updateLatestVersions(on database: Database, package: Joined<Package, Repository>) async throws -> [Version] {
         try await package.model.$versions.load(on: database)
 

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -17,12 +17,21 @@ import PostgresNIO
 import Vapor
 
 
+/// Update packages (in the `[Result<Joined<Package, Repository>, Error>]` array).
+///
+/// Unlike the overload with a result parameter `Result<(Joined<Package, Repository>, [Version])` this will not use `Version` information to update the package.
+///
+/// - Parameters:
+///   - client: `Client` object
+///   - database: `Database` object
+///   - logger: `Logger` object
+///   - results: `Joined<Package, Repository>` results to update
+///   - stage: Processing stage
 func updatePackages(client: Client,
                     database: Database,
                     logger: Logger,
                     results: [Result<Joined<Package, Repository>, Error>],
                     stage: Package.ProcessingStage) async throws {
-
     let updates = await withThrowingTaskGroup(of: Void.self) { group in
         for result in results {
             group.addTask {
@@ -33,7 +42,38 @@ func updatePackages(client: Client,
                                         stage: stage)
             }
         }
+        return await group.results()
+    }
 
+    logger.debug("updateStatus ops: \(updates.count)")
+}
+
+
+/// Update packages (in the `[Result<(Joined<Package, Repository>, [Version])]` array).
+///
+/// This overload will use `Version` information to update the package, for example to compute a new package score.
+///
+/// - Parameters:
+///   - client: `Client` object
+///   - database: `Database` object
+///   - logger: `Logger` object
+///   - results: `(Joined<Package, Repository>, [Version])` results to update
+///   - stage: Processing stage
+func updatePackages(client: Client,
+                    database: Database,
+                    logger: Logger,
+                    results: [Result<(Joined<Package, Repository>, [Version]), Error>],
+                    stage: Package.ProcessingStage) async throws {
+    let updates = await withThrowingTaskGroup(of: Void.self) { group in
+        for result in results {
+            group.addTask {
+                try await updatePackage(client: client,
+                                        database: database,
+                                        logger: logger,
+                                        result: result,
+                                        stage: stage)
+            }
+        }
         return await group.results()
     }
 
@@ -47,9 +87,8 @@ func updatePackage(client: Client,
                    result: Result<Joined<Package, Repository>, Error>,
                    stage: Package.ProcessingStage) async throws {
     switch result {
-        case .success(let jpr):
-            let pkg = jpr.package
-            try await pkg.$versions.load(on: database)
+        case .success(let res):
+            let pkg = res.package
             if stage == .ingestion && pkg.status == .new {
                 // newly ingested package: leave status == .new for fast-track
                 // analysis
@@ -57,7 +96,6 @@ func updatePackage(client: Client,
                 pkg.status = .ok
             }
             pkg.processingStage = stage
-            pkg.score = Score.compute(package: jpr, versions: pkg.versions)
             do {
                 try await pkg.update(on: database)
             } catch {
@@ -73,8 +111,27 @@ func updatePackage(client: Client,
         case .failure(let error):
             try? await Current.reportError(client, .error, error)
             try await recordError(database: database, error: error, stage: stage)
-    } // switch result
+    }
+}
 
+
+func updatePackage(client: Client,
+                   database: Database,
+                   logger: Logger,
+                   result: Result<(Joined<Package, Repository>, [Version]), Error>,
+                   stage: Package.ProcessingStage) async throws {
+    // Compute the package score and update the result before passing it to `updatePackage`
+    let result = result.map {
+        let (jpr, versions) = $0
+        jpr.package.score = Score.compute(package: jpr, versions: versions)
+        return jpr
+    }
+
+    try await updatePackage(client: client,
+                            database: database,
+                            logger: logger,
+                            result: result,
+                            stage: stage)
 }
 
 
@@ -83,7 +140,7 @@ func recordError(database: Database,
                  stage: Package.ProcessingStage) async throws {
     func setStatus(id: Package.Id?, status: Package.Status) async throws {
         guard let id = id else { return }
-        return try await Package.query(on: database)
+        try await Package.query(on: database)
             .filter(\.$id == id)
             .set(\.$processingStage, to: stage)
             .set(\.$status, to: status)

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -935,30 +935,28 @@ class AnalyzerTests: AppTestCase {
         }
     }
 
-    func test_issue_577() throws {
+    func test_issue_577() async throws {
         // Duplicate "latest release" versions
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/577
         // setup
         let pkgId = UUID()
         let pkg = Package(id: pkgId, url: "1")
-        try pkg.save(on: app.db).wait()
-        try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
+        try await pkg.save(on: app.db)
+        try await Repository(package: pkg, defaultBranch: "main").save(on: app.db)
         // existing "latest release" version
-        try Version(package: pkg, latest: .release, packageName: "foo", reference: .tag(1, 2, 3))
-            .save(on: app.db).wait()
+        try await Version(package: pkg, latest: .release, packageName: "foo", reference: .tag(1, 2, 3))
+            .save(on: app.db)
         // new, not yet considered release version
-        try Version(package: pkg, packageName: "foo", reference: .tag(1, 3, 0))
-            .save(on: app.db).wait()
-        let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
+        try await Version(package: pkg, packageName: "foo", reference: .tag(1, 3, 0))
+            .save(on: app.db)
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
 
         // MUT
-        try Analyze.updateLatestVersions(on: app.db, package: jpr).wait()
+        let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         // validate
         do {  // refetch package to ensure changes are persisted
-            let pkg = try XCTUnwrap(Package.find(pkgId, on: app.db).wait())
-            try pkg.$versions.load(on: app.db).wait()
-            let versions = pkg.versions.sorted(by: { $0.createdAt! < $1.createdAt! })
+            let versions = versions.sorted(by: { $0.createdAt! < $1.createdAt! })
             XCTAssertEqual(versions.map(\.reference.description), ["1.2.3", "1.3.0"])
             XCTAssertEqual(versions.map(\.latest), [nil, .release])
         }
@@ -993,62 +991,62 @@ class AnalyzerTests: AppTestCase {
         assertSnapshot(matching: commands.value, as: .dump)
     }
 
-    func test_updateLatestVersions() throws {
+    func test_updateLatestVersions() async throws {
         // setup
         func t(_ seconds: TimeInterval) -> Date { Date(timeIntervalSince1970: seconds) }
         let pkg = Package(id: UUID(), url: "1")
-        try pkg.save(on: app.db).wait()
-        try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
-        try Version(package: pkg, commitDate: t(2), packageName: "foo", reference: .branch("main"))
-            .save(on: app.db).wait()
-        try Version(package: pkg, commitDate: t(0), packageName: "foo", reference: .tag(1, 2, 3))
-            .save(on: app.db).wait()
-        try Version(package: pkg, commitDate: t(1), packageName: "foo", reference: .tag(2, 0, 0, "rc1"))
-            .save(on: app.db).wait()
-        let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
+        try await pkg.save(on: app.db)
+        try await Repository(package: pkg, defaultBranch: "main").save(on: app.db)
+        try await Version(package: pkg, commitDate: t(2), packageName: "foo", reference: .branch("main"))
+            .save(on: app.db)
+        try await Version(package: pkg, commitDate: t(0), packageName: "foo", reference: .tag(1, 2, 3))
+            .save(on: app.db)
+        try await Version(package: pkg, commitDate: t(1), packageName: "foo", reference: .tag(2, 0, 0, "rc1"))
+            .save(on: app.db)
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
 
         // MUT
-        try Analyze.updateLatestVersions(on: app.db, package: jpr).wait()
+        let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         // validate
-        try pkg.$versions.load(on: app.db).wait()
-        let versions = pkg.versions.sorted(by: { $0.createdAt! < $1.createdAt! })
-        XCTAssertEqual(versions.map(\.reference.description), ["main", "1.2.3", "2.0.0-rc1"])
-        XCTAssertEqual(versions.map(\.latest), [.defaultBranch, .release, .preRelease])
+        do {
+            try pkg.$versions.load(on: app.db).wait()
+            let versions = versions.sorted(by: { $0.createdAt! < $1.createdAt! })
+            XCTAssertEqual(versions.map(\.reference.description), ["main", "1.2.3", "2.0.0-rc1"])
+            XCTAssertEqual(versions.map(\.latest), [.defaultBranch, .release, .preRelease])
+        }
     }
 
-    func test_updateLatestVersions_old_beta() throws {
+    func test_updateLatestVersions_old_beta() async throws {
         // Test to ensure outdated betas aren't picked up as latest versions
         // and that faulty db content (outdated beta marked as latest pre-release)
         // is correctly reset.
         // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/188
         // setup
         let pkg = Package(id: UUID(), url: "1")
-        try pkg.save(on: app.db).wait()
-        try Repository(package: pkg, defaultBranch: "main").save(on: app.db).wait()
-        try Version(package: pkg,
+        try await pkg.save(on: app.db)
+        try await Repository(package: pkg, defaultBranch: "main").save(on: app.db)
+        try await Version(package: pkg,
                     latest: .defaultBranch,
                     packageName: "foo",
                     reference: .branch("main"))
-            .save(on: app.db).wait()
-        try Version(package: pkg,
+            .save(on: app.db)
+        try await Version(package: pkg,
                     latest: .release,
                     packageName: "foo",
                     reference: .tag(2, 0, 0))
-            .save(on: app.db).wait()
-        try Version(package: pkg,
+            .save(on: app.db)
+        try await Version(package: pkg,
                     latest: .preRelease,  // this should have been nil - ensure it's reset
                     packageName: "foo",
                     reference: .tag(2, 0, 0, "rc1"))
-            .save(on: app.db).wait()
-        let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
+            .save(on: app.db)
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
 
         // MUT
-        try Analyze.updateLatestVersions(on: app.db, package: jpr).wait()
+        let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         // validate
-        let versions = try Version.query(on: app.db)
-            .sort(\.$createdAt).all().wait()
         XCTAssertEqual(versions.map(\.reference.description), ["main", "2.0.0", "2.0.0-rc1"])
         XCTAssertEqual(versions.map(\.latest), [.defaultBranch, .release, nil])
     }

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -416,7 +416,7 @@ class ApiTests: AppTestCase {
         try await Version(package: p, reference: .tag(.init(1, 2, 3))).save(on: app.db)
         let jpr = try await Package.fetchCandidate(app.db, id: p.id!).get()
         // update versions
-        _ = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
+        try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         let owner = "foo"
         let repo = "bar"

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -401,22 +401,22 @@ class ApiTests: AppTestCase {
         XCTAssertEqual(Set(versionIds), [.id0])
     }
 
-    func test_post_build_trigger_package_name() throws {
+    func test_post_build_trigger_package_name() async throws {
         // Test POST /packages/{owner}/{repo}/trigger-builds
         // setup
         Current.builderToken = { "secr3t" }
         Current.gitlabPipelineToken = { "ptoken" }
         let p = try savePackage(on: app.db, "1")
-        try Repository(package: p,
+        try await Repository(package: p,
                        defaultBranch: "main",
                        license: .mit,
                        name: "bar",
-                       owner: "foo").save(on: app.db).wait()
-        try Version(package: p, reference: .branch("main")).save(on: app.db).wait()
-        try Version(package: p, reference: .tag(.init(1, 2, 3))).save(on: app.db).wait()
-        let jpr = try Package.fetchCandidate(app.db, id: p.id!).wait()
+                       owner: "foo").save(on: app.db)
+        try await Version(package: p, reference: .branch("main")).save(on: app.db)
+        try await Version(package: p, reference: .tag(.init(1, 2, 3))).save(on: app.db)
+        let jpr = try await Package.fetchCandidate(app.db, id: p.id!).get()
         // update versions
-        _ = try Analyze.updateLatestVersions(on: app.db, package: jpr).wait()
+        _ = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         let owner = "foo"
         let repo = "bar"

--- a/Tests/AppTests/SocialTests.swift
+++ b/Tests/AppTests/SocialTests.swift
@@ -178,17 +178,16 @@ class SocialTests: AppTestCase {
                              name: "repoName",
                              owner: "repoOwner",
                              summary: "This is a test package").save(on: app.db)
-        let v1 = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
-        try await v1.save(on: app.db)
-        let v2 = try Version(package: pkg,
-                             commitDate: Date(timeIntervalSince1970: 0),
-                             packageName: "MyPackage",
-                             reference: .tag(2, 0, 0, "b1"))
-        try await v2.save(on: app.db)
-        let v3 = try Version(package: pkg, packageName: "MyPackage", reference: .branch("main"))
-        try await v3.save(on: app.db)
+        try await Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
+            .save(on: app.db)
+        try await Version(package: pkg,
+                          commitDate: Date(timeIntervalSince1970: 0),
+                          packageName: "MyPackage",
+                          reference: .tag(2, 0, 0, "b1")).save(on: app.db)
+        try await Version(package: pkg, packageName: "MyPackage", reference: .branch("main"))
+            .save(on: app.db)
         let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
-        try await Analyze.updateLatestVersions(on: app.db, package: jpr).get()
+        let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         Current.twitterCredentials = {
             .init(apiKey: ("key", "secret"), accessToken: ("key", "secret"))
@@ -201,7 +200,7 @@ class SocialTests: AppTestCase {
         // MUT
         try await Social.postToFirehose(client: app.client,
                                         package: jpr,
-                                        versions: [v1, v2, v3])
+                                        versions: versions)
 
         // validate
         XCTAssertEqual(posted, 2)
@@ -216,12 +215,12 @@ class SocialTests: AppTestCase {
                              name: "repoName",
                              owner: "repoOwner",
                              summary: "This is a test package").save(on: app.db)
-        let v1 = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
-        try await v1.save(on: app.db)
-        let v2 = try Version(package: pkg, packageName: "MyPackage", reference: .tag(2, 0, 0))
-        try await v2.save(on: app.db)
+        try await Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
+            .save(on: app.db)
+        try await Version(package: pkg, packageName: "MyPackage", reference: .tag(2, 0, 0))
+            .save(on: app.db)
         let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
-        try await Analyze.updateLatestVersions(on: app.db, package: jpr).get()
+        let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         Current.twitterCredentials = {
             .init(apiKey: ("key", "secret"), accessToken: ("key", "secret"))
@@ -238,7 +237,7 @@ class SocialTests: AppTestCase {
         // MUT
         try await Social.postToFirehose(client: app.client,
                                          package: jpr,
-                                         versions: [v1, v2])
+                                         versions: versions)
 
         // validate
         XCTAssertTrue(message?.contains("v2.0.0") ?? false)


### PR DESCRIPTION
Merge after #2135 

Fixes #1470

- Analyze.updateLatestVersion → a/a, returning the updated versions
- `analyze` is calling a new function `updateScore` using the previously loaded `Version`s
- `Common.updatePackages` is not calling `pkg.$versions.load(on: db)` anymore, fixing #1470
- Test updates according to above changes