### PR TITLE
Revert mon update

### DIFF
--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -154,6 +154,12 @@ class AnalyzerTests: AppTestCase {
                                   logger: app.logger,
                                   mode: .limit(10))
 
+        // Attempt to fix
+        //    ✖ test_analyze, XCTAssertEqual failed: ("33") is not equal to ("34") -
+        //    ✖ test_analyze, failed - Snapshot does not match reference.
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/actions/runs/3513107047/jobs/5885715992
+        await Task.yield()
+
         // validation
         let outDir = try checkoutDir.value.unwrap()
         XCTAssert(outDir.hasSuffix("SPI-checkouts"), "unexpected checkout dir, was: \(outDir)")

--- a/mon.yml
+++ b/mon.yml
@@ -20,7 +20,7 @@ services:
 
   grafana:
     # https://github.com/grafana/grafana/releases
-    image: grafana/grafana:9.2.5
+    image: grafana/grafana:9.2.4
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
       GF_USERS_ALLOW_SIGN_UP: 'false'
@@ -42,7 +42,7 @@ services:
 
   loki:
     # https://github.com/grafana/loki/releases
-    image: grafana/loki:2.7.0
+    image: grafana/loki:2.6.1
     command: -config.file=/loki.yml
     configs:
       - source: loki_cfg
@@ -71,7 +71,7 @@ services:
 
   prometheus:
     # https://github.com/prometheus/prometheus/releases
-    image: prom/prometheus:v2.40.2
+    image: prom/prometheus:v2.40.1
     volumes:
       - prometheus_data:/prometheus
     command: --config.file=/prometheus.yml

--- a/mon.yml
+++ b/mon.yml
@@ -20,7 +20,7 @@ services:
 
   grafana:
     # https://github.com/grafana/grafana/releases
-    image: grafana/grafana:9.2.4
+    image: grafana/grafana:9.2.5
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
       GF_USERS_ALLOW_SIGN_UP: 'false'
@@ -71,7 +71,7 @@ services:
 
   prometheus:
     # https://github.com/prometheus/prometheus/releases
-    image: prom/prometheus:v2.40.1
+    image: prom/prometheus:v2.40.2
     volumes:
       - prometheus_data:/prometheus
     command: --config.file=/prometheus.yml


### PR DESCRIPTION
Looks like the Loki update is giving us stray "Deployed" annotations. Reverting for now.

<img width="206" alt="CleanShot 2022-11-21 at 13 03 46@2x" src="https://user-images.githubusercontent.com/65520/203049242-f38391ab-7a29-43a8-8727-5bccbcfc083c.png">
