### PR TITLE
Revert Prometheus update

### DIFF
--- a/mon.yml
+++ b/mon.yml
@@ -71,7 +71,7 @@ services:
 
   prometheus:
     # https://github.com/prometheus/prometheus/releases
-    image: prom/prometheus:v2.40.2
+    image: prom/prometheus:v2.40.1
     volumes:
       - prometheus_data:/prometheus
     command: --config.file=/prometheus.yml


### PR DESCRIPTION
Again getting spurious "No data" alerts, must be the Prometheus update. (Last change to roll back would be the Grafana update if this doesn't do it.)