### PR TITLE
Issue 2217

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -389,7 +389,7 @@ extension Analyze {
         let incoming = try await getIncomingVersions(client: client, logger: logger, package: package)
 
         let throttled = throttle(
-            lastestExistingVersion: existing.latestBranchVersion,
+            latestExistingVersion: existing.latestBranchVersion,
             incoming: incoming
         )
         let origDiff = Version.diff(local: existing, incoming: incoming)
@@ -446,8 +446,8 @@ extension Analyze {
     }
 
 
-    static func throttle(lastestExistingVersion: Version?, incoming: [Version]) -> [Version] {
-        guard let existingVersion = lastestExistingVersion else {
+    static func throttle(latestExistingVersion: Version?, incoming: [Version]) -> [Version] {
+        guard let existingVersion = latestExistingVersion else {
             // there's no existing branch version -> leave incoming alone (which will lead to addition)
             return incoming
         }

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -459,11 +459,20 @@ extension Analyze {
 
         let ageOfExistingVersion = Current.date().timeIntervalSinceReferenceDate - existingVersion.commitDate.timeIntervalSinceReferenceDate
 
-        // if existing version isn't older than our "window", keep it - otherwise
-        // use the latest incoming version
-        let resultingBranchVersion = ageOfExistingVersion < Constants.branchVersionRefreshDelay
-        ? existingVersion
-        : incomingVersion
+        let resultingBranchVersion: Version
+        if existingVersion.reference.branchName != incomingVersion.reference.branchName {
+            // if branch names differ we've got a renamed default branch and want to make
+            // sure it's updated as soon as possible -> no throttling
+            resultingBranchVersion = incomingVersion
+        } else {
+            // if existing version isn't older than our "window", keep it - otherwise
+            // use the latest incoming version
+            if ageOfExistingVersion < Constants.branchVersionRefreshDelay {
+                resultingBranchVersion = existingVersion
+            } else {
+                resultingBranchVersion = incomingVersion
+            }
+        }
 
         return incoming
             .filter(!\.isBranch)        // remove all branch versions

--- a/Sources/App/Models/Reference.swift
+++ b/Sources/App/Models/Reference.swift
@@ -48,6 +48,15 @@ enum Reference: Equatable, Hashable {
     
     var isRelease: Bool { semVer?.isStable ?? false }
 
+    var branchName: String? {
+        switch self {
+            case let .branch(name):
+                return name
+            case .tag:
+                return nil
+        }
+    }
+
     var tagName: String? {
         switch self {
             case .branch:

--- a/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
+++ b/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
@@ -84,6 +84,8 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
 
     func test_throttle_branch_ref_change() throws {
         // Test behaviour when changing default branch names
+        // Changed to return [new] to avoid branch renames causing 404s
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2217
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
@@ -95,11 +97,13 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let res = Analyze.throttle(latestExistingVersion: old, incoming: [new])
 
         // validate
-        XCTAssertEqual(res, [old])
+        XCTAssertEqual(res, [new])
     }
 
     func test_throttle_rename() throws {
         // Ensure incoming branch renames are throttled
+        // Changed to return [new] to avoid branch renames causing 404s
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2217
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
@@ -111,7 +115,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let res = Analyze.throttle(latestExistingVersion: old, incoming: [new])
 
         // validate
-        XCTAssertEqual(res, [old])
+        XCTAssertEqual(res, [new])
     }
 
     func test_throttle_multiple_incoming_branches_keep_old() throws {

--- a/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
+++ b/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
@@ -29,7 +29,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", -.hours(1), .branch("main"))
 
         // MUT
-        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(latestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [old])
@@ -45,7 +45,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .branch("main"))
 
         // MUT
-        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(latestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [new])
@@ -61,7 +61,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .tag(2, 0, 0))
 
         // MUT
-        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(latestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [new])
@@ -76,7 +76,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .branch("main"))
 
         // MUT
-        let res = Analyze.throttle(lastestExistingVersion: nil, incoming: [new])
+        let res = Analyze.throttle(latestExistingVersion: nil, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [new])
@@ -92,7 +92,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .branch("main"))
 
         // MUT
-        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(latestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [old])
@@ -108,7 +108,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new = try makeVersion(pkg, "sha", .hours(-1), .branch("main-new"))
 
         // MUT
-        let res = Analyze.throttle(lastestExistingVersion: old, incoming: [new])
+        let res = Analyze.throttle(latestExistingVersion: old, incoming: [new])
 
         // validate
         XCTAssertEqual(res, [old])
@@ -128,7 +128,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new2 = try makeVersion(pkg, "sha_new2", .hours(-1), .branch("main"))
 
         // MUT
-        let res = Analyze.throttle(lastestExistingVersion: old,
+        let res = Analyze.throttle(latestExistingVersion: old,
                                    incoming: [new0, new1, new2].shuffled())
 
         // validate
@@ -149,7 +149,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let new2 = try makeVersion(pkg, "sha_new2", .hours(-1), .branch("main"))
 
         // MUT
-        let res = Analyze.throttle(lastestExistingVersion: old,
+        let res = Analyze.throttle(latestExistingVersion: old,
                                    incoming: [new0, new1, new2].shuffled())
 
         // validate
@@ -294,7 +294,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
             let inc = try makeVersion(pkg, "sha-inc", .hours(-23), .branch("main"))
 
             // MUT
-            let res = Analyze.throttle(lastestExistingVersion: ex, incoming: [inc])
+            let res = Analyze.throttle(latestExistingVersion: ex, incoming: [inc])
 
             // validate
             XCTAssertEqual(res, [ex])
@@ -305,7 +305,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
             let inc = try makeVersion(pkg, "sha-inc", .hours(-26), .branch("main"))
 
             // MUT
-            let res = Analyze.throttle(lastestExistingVersion: ex, incoming: [inc])
+            let res = Analyze.throttle(latestExistingVersion: ex, incoming: [inc])
 
             // validate
             XCTAssertEqual(res, [ex])
@@ -316,7 +316,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
             let inc = try makeVersion(pkg, "sha-inc", .hours(-28), .branch("main"))
 
             // MUT
-            let res = Analyze.throttle(lastestExistingVersion: ex, incoming: [inc])
+            let res = Analyze.throttle(latestExistingVersion: ex, incoming: [inc])
 
             // validate
             XCTAssertEqual(res, [inc])


### PR DESCRIPTION
Fixes #2217 

I've checked and we can't really loosen our reliance on default branch presence that I contemplated in the issue. The underlying query is difficult to adjust and given how rare and typically short-lived this problem is (even before mitigation) it's not really worth the effort.

This change prevents throttling of default branches after name changes and should limit the exposure to a couple of hours at worst.

One other remedy we could seek if this continues to be an issue is to prioritise packages with default branch name changes for analysis, like we do with new packages. However, we can't simply make them "new" packages to piggy back on the existing priority, because it would also announce it as a new package (home page, social).

We'd have to introduce an additional priority, making this a bigger change, and one we shouldn't make at this time.

We can test this patch by deploying from the branch to `dev`, which has the same data problem as `prod`.