### PR TITLE
Doc reports schema

### DIFF
--- a/Sources/App/Migrations/061/CreateDocUpload.swift
+++ b/Sources/App/Migrations/061/CreateDocUpload.swift
@@ -33,9 +33,7 @@ struct CreateDocUpload: AsyncMigration {
         // data fields
             .field("error", .string)
             .field("file_count", .int)
-            .field("log_group", .string)
-            .field("log_region", .string)
-            .field("log_stream", .string)
+            .field("log_url", .string)
             .field("mb_size", .int)
             .field("status", .string, .required)
 

--- a/Sources/App/Migrations/061/CreateDocUpload.swift
+++ b/Sources/App/Migrations/061/CreateDocUpload.swift
@@ -45,10 +45,8 @@ struct CreateDocUpload: AsyncMigration {
         do {  // add constraints to builds table
             try await database.schema("builds")
                   .field("doc_upload_id", .uuid, .references("doc_uploads", "id"))
-
             // Ensure no doc_upload can be referenced from multiple builds (versions)
                   .unique(on: "doc_upload_id", name: docUploadIdConstraint)
-
                   .update()
             try await (database as! SQLDatabase).raw(
                 // Ensure there's only one doc_upload per version

--- a/Sources/App/Migrations/061/CreateDocUpload.swift
+++ b/Sources/App/Migrations/061/CreateDocUpload.swift
@@ -40,6 +40,9 @@ struct CreateDocUpload: AsyncMigration {
                 .field("mb_size", .int)
                 .field("status", .string, .required)
 
+            // constraints
+                .unique(on: "build_id")
+
                 .create()
         }
         do {  // add constraints to builds table

--- a/Sources/App/Migrations/061/CreateDocUpload.swift
+++ b/Sources/App/Migrations/061/CreateDocUpload.swift
@@ -1,0 +1,51 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+
+
+struct CreateDocUpload: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("doc_uploads")
+
+        // managed fields
+            .id()
+            .field("created_at", .datetime)
+            .field("updated_at", .datetime)
+
+        // reference fields
+            .field("build_id", .uuid,
+                   .references("builds", "id", onDelete: .cascade), .required)
+            .field("version_id", .uuid,
+                   .references("versions", "id", onDelete: .cascade), .required)
+
+        // data fields
+            .field("error", .string)
+            .field("file_count", .int)
+            .field("log_group", .string)
+            .field("log_region", .string)
+            .field("log_stream", .string)
+            .field("mb_size", .int)
+            .field("status", .string, .required)
+
+        // constraints
+            .unique(on: "version_id")
+
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("doc_uploads").delete()
+    }
+}

--- a/Sources/App/Migrations/061/CreateDocUpload.swift
+++ b/Sources/App/Migrations/061/CreateDocUpload.swift
@@ -40,7 +40,7 @@ struct CreateDocUpload: AsyncMigration {
             .field("status", .string, .required)
 
         // constraints
-            .unique(on: "version_id")
+            .unique(on: "version_id") // automatically implies .unique(on: "build_id")
 
             .create()
     }

--- a/Sources/App/Migrations/061/CreateDocUpload.swift
+++ b/Sources/App/Migrations/061/CreateDocUpload.swift
@@ -59,11 +59,9 @@ struct CreateDocUpload: AsyncMigration {
         try await (database as! SQLDatabase).raw(
             #"DROP INDEX "\#(raw: versionIdPartialConstraint)""#
         ).run()
-
         try await database.schema("builds")
             .deleteConstraint(name: docUploadIdConstraint)
             .update()
-
         try await database.schema("builds")
             .deleteField("doc_upload_id")
             .update()

--- a/Sources/App/Migrations/061/CreateDocUpload.swift
+++ b/Sources/App/Migrations/061/CreateDocUpload.swift
@@ -28,6 +28,10 @@ struct CreateDocUpload: AsyncMigration {
                 .field("created_at", .datetime)
                 .field("updated_at", .datetime)
 
+            // reference fields
+                .field("build_id", .uuid,
+                       .references("builds", "id", onDelete: .cascade), .required)
+
             // data fields
                 .field("error", .string)
                 .field("file_count", .int)
@@ -39,8 +43,7 @@ struct CreateDocUpload: AsyncMigration {
         }
         do {  // add reference field to builds table
             try await database.schema("builds")
-                  .field("doc_upload_id", .uuid,
-                         .references("doc_uploads", "id", onDelete: .cascade))
+                  .field("doc_upload_id", .uuid, .references("doc_uploads", "id"))
                   .unique(on: "version_id", "doc_upload_id",
                           name: versionIdDocUploadIdConstraint)
                   .unique(on: "doc_upload_id", name: docUploadIdConstraint)

--- a/Sources/App/Migrations/061/CreateDocUpload.swift
+++ b/Sources/App/Migrations/061/CreateDocUpload.swift
@@ -55,6 +55,9 @@ struct CreateDocUpload: AsyncMigration {
         try await database.schema("builds")
             .deleteConstraint(name: docUploadIdConstraint)
             .deleteConstraint(name: versionIdDocUploadIdConstraint)
+            .update()
+
+        try await database.schema("builds")
             .deleteField("doc_upload_id")
             .update()
         try await database.schema("doc_uploads").delete()

--- a/Sources/App/Migrations/061/CreateDocUpload.swift
+++ b/Sources/App/Migrations/061/CreateDocUpload.swift
@@ -16,7 +16,6 @@ import Fluent
 
 
 struct CreateDocUpload: AsyncMigration {
-    let versionIdDocUploadIdConstraint = "uq:builds.version_id+builds.doc_upload_id"
     let docUploadIdConstraint = "uq:builds.doc_upload_id"
 
     func prepare(on database: Database) async throws {
@@ -44,8 +43,6 @@ struct CreateDocUpload: AsyncMigration {
         do {  // add reference field to builds table
             try await database.schema("builds")
                   .field("doc_upload_id", .uuid, .references("doc_uploads", "id"))
-                  .unique(on: "version_id", "doc_upload_id",
-                          name: versionIdDocUploadIdConstraint)
                   .unique(on: "doc_upload_id", name: docUploadIdConstraint)
                   .update()
         }
@@ -54,7 +51,6 @@ struct CreateDocUpload: AsyncMigration {
     func revert(on database: Database) async throws {
         try await database.schema("builds")
             .deleteConstraint(name: docUploadIdConstraint)
-            .deleteConstraint(name: versionIdDocUploadIdConstraint)
             .update()
 
         try await database.schema("builds")

--- a/Sources/App/Models/Build.swift
+++ b/Sources/App/Models/Build.swift
@@ -36,6 +36,9 @@ final class Build: Model, Content {
 
     // reference fields
 
+    @OptionalParent(key: "doc_upload_id")
+    var docUpload: DocUpload?
+
     @Parent(key: "version_id")
     var version: Version
 

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -33,14 +33,6 @@ final class DocUpload: Model, Content {
     @Timestamp(key: "updated_at", on: .update)
     var updatedAt: Date?
 
-    // reference fields
-
-    @Parent(key: "build_id")
-    var build: Build
-
-    @Parent(key: "version_id")
-    var version: Version
-
     // data fields
 
     @Field(key: "error")
@@ -62,8 +54,7 @@ final class DocUpload: Model, Content {
 
     init(
         id: Id? = nil,
-        buildId: Build.Id,
-        versionId: Version.Id,
+        build: Build,
         error: String? = nil,
         fileCount: Int? = nil,
         logUrl: String? = nil,
@@ -71,8 +62,7 @@ final class DocUpload: Model, Content {
         status: Status
     ) {
         self.id = id
-        self.$build.id = buildId
-        self.$version.id = versionId
+        build.$docUpload.id = id
         self.error = error
         self.fileCount = fileCount
         self.logUrl = logUrl

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -82,25 +82,6 @@ final class DocUpload: Model, Content {
 }
 
 
-extension String {
-    static let replacements = [
-        // keep "$" first, so it doesn't replace the "$" in the following substitutions
-        ("$", "$2524"),
-        ("/", "$252F"),
-        ("[", "$255B"),
-        ("]", "$255D")
-    ]
-
-    var awsEncoded: String {
-        var result = self
-        for (key, value) in Self.replacements {
-            result = result.replacingOccurrences(of: key, with: value)
-        }
-        return result
-    }
-}
-
-
 extension DocUpload {
     enum Status: String, Codable, CustomStringConvertible {
         case ok

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -1,0 +1,113 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import Vapor
+
+
+final class DocUpload: Model, Content {
+    static let schema = "doc_uploads"
+
+    typealias Id = UUID
+
+    // managed fields
+
+    @ID(key: .id)
+    var id: Id?
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    // periphery:ignore
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt: Date?
+
+    // reference fields
+
+    @Parent(key: "build_id")
+    var build: Build
+
+    @Parent(key: "version_id")
+    var version: Version
+
+    // data fields
+
+    @Field(key: "error")
+    var error: String?
+
+    @Field(key: "file_count")
+    var fileCount: Int?
+
+    @Field(key: "log_group")
+    var logGroup: String?
+
+    @Field(key: "log_region")
+    var logRegion: String?
+
+    @Field(key: "log_stream")
+    var logStream: String?
+
+    @Field(key: "mb_size")
+    var mbSize: Int?
+
+    @Field(key: "status")
+    var status: Status
+
+    // FIXME: implement
+    var logUrl: String? {
+        // const link = `https://${process.env.AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${process.env.AWS_REGION}#logsV2:log-groups/log-group/${process.env.AWS_LAMBDA_LOG_GROUP_NAME.replace(/\//g, '$252F')}/log-events/${process.env.AWS_LAMBDA_LOG_STREAM_NAME.replace('$', '$2524').replace('[', '$255B').replace(']', '$255D').replace(/\//g, '$252F')}`
+        nil
+    }
+
+    init() { }
+
+    init(
+        id: Id? = nil,
+        buildId: Build.Id,
+        versionId: Version.Id,
+        error: String? = nil,
+        fileCount: Int? = nil,
+        logGroup: String? = nil,
+        logRegion: String? = nil,
+        logStream: String? = nil,
+        mbSize: Int? = nil,
+        status: Status
+    ) {
+        self.id = id
+        self.$build.id = buildId
+        self.$version.id = versionId
+        self.error = error
+        self.fileCount = fileCount
+        self.logGroup = logGroup
+        self.logRegion = logRegion
+        self.logStream = logStream
+        self.mbSize = mbSize
+        self.status = status
+    }
+}
+
+
+extension DocUpload {
+    enum Status: String, Codable, CustomStringConvertible {
+        case ok
+        case failed
+
+        var description: String {
+            switch self {
+                case .ok: return "Successful"
+                case .failed: return "Failed"
+            }
+        }
+    }
+}

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -59,7 +59,6 @@ final class DocUpload: Model, Content {
 
     init(
         id: Id? = nil,
-        build: Build,
         error: String? = nil,
         fileCount: Int? = nil,
         logUrl: String? = nil,
@@ -67,9 +66,6 @@ final class DocUpload: Model, Content {
         status: Status
     ) throws {
         self.id = id
-        self.$build.id = try build.requireID()
-        // FIXME: make this an `attach` method
-        build.$docUpload.id = id
         self.error = error
         self.fileCount = fileCount
         self.logUrl = logUrl
@@ -91,4 +87,20 @@ extension DocUpload {
             }
         }
     }
+}
+
+
+extension DocUpload {
+
+    /// Attach a ``DocUpload`` to a ``Build``, ensuring the relationship is saved on both sides. This will save changes on the ``Build`` parameter as well.
+    /// - Parameters:
+    ///   - build: ``Build`` to attach
+    ///   - database: ``Database`` to use for saving
+    func attach(to build: Build, on database: Database) async throws {
+        $build.id = try build.requireID()
+        build.$docUpload.id = try requireID()
+        try await save(on: database)
+        try await build.save(on: database)
+    }
+
 }

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -79,11 +79,13 @@ extension DocUpload {
     enum Status: String, Codable, CustomStringConvertible {
         case ok
         case failed
+        case skipped
 
         var description: String {
             switch self {
                 case .ok: return "Successful"
                 case .failed: return "Failed"
+                case .skipped: return "Skipped"
             }
         }
     }

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -33,6 +33,11 @@ final class DocUpload: Model, Content {
     @Timestamp(key: "updated_at", on: .update)
     var updatedAt: Date?
 
+    // reference fields
+
+    @Parent(key: "build_id")
+    var build: Build
+
     // data fields
 
     @Field(key: "error")
@@ -60,8 +65,10 @@ final class DocUpload: Model, Content {
         logUrl: String? = nil,
         mbSize: Int? = nil,
         status: Status
-    ) {
+    ) throws {
         self.id = id
+        self.$build.id = try build.requireID()
+        // FIXME: make this an `attach` method
         build.$docUpload.id = id
         self.error = error
         self.fileCount = fileCount

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -49,26 +49,14 @@ final class DocUpload: Model, Content {
     @Field(key: "file_count")
     var fileCount: Int?
 
-    @Field(key: "log_group")
-    var logGroup: String?
-
-    @Field(key: "log_region")
-    var logRegion: String?
-
-    @Field(key: "log_stream")
-    var logStream: String?
+    @Field(key: "log_url")
+    var logUrl: String?
 
     @Field(key: "mb_size")
     var mbSize: Int?
 
     @Field(key: "status")
     var status: Status
-
-    // FIXME: implement
-    var logUrl: String? {
-        // const link = `https://${process.env.AWS_REGION}.console.aws.amazon.com/cloudwatch/home?region=${process.env.AWS_REGION}#logsV2:log-groups/log-group/${process.env.AWS_LAMBDA_LOG_GROUP_NAME.replace(/\//g, '$252F')}/log-events/${process.env.AWS_LAMBDA_LOG_STREAM_NAME.replace('$', '$2524').replace('[', '$255B').replace(']', '$255D').replace(/\//g, '$252F')}`
-        nil
-    }
 
     init() { }
 
@@ -78,9 +66,7 @@ final class DocUpload: Model, Content {
         versionId: Version.Id,
         error: String? = nil,
         fileCount: Int? = nil,
-        logGroup: String? = nil,
-        logRegion: String? = nil,
-        logStream: String? = nil,
+        logUrl: String? = nil,
         mbSize: Int? = nil,
         status: Status
     ) {
@@ -89,11 +75,28 @@ final class DocUpload: Model, Content {
         self.$version.id = versionId
         self.error = error
         self.fileCount = fileCount
-        self.logGroup = logGroup
-        self.logRegion = logRegion
-        self.logStream = logStream
+        self.logUrl = logUrl
         self.mbSize = mbSize
         self.status = status
+    }
+}
+
+
+extension String {
+    static let replacements = [
+        // keep "$" first, so it doesn't replace the "$" in the following substitutions
+        ("$", "$2524"),
+        ("/", "$252F"),
+        ("[", "$255B"),
+        ("]", "$255D")
+    ]
+
+    var awsEncoded: String {
+        var result = self
+        for (key, value) in Self.replacements {
+            result = result.replacingOccurrences(of: key, with: value)
+        }
+        return result
     }
 }
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -273,6 +273,9 @@ public func configure(_ app: Application) throws -> String {
     do { // Migration 060 - update repository authors type
         app.migrations.add(UpdateRepositoryAuthorsType())
     }
+    do { // Migration 061 - create doc_uploads
+        app.migrations.add(CreateDocUpload())
+    }
 
     app.commands.use(Analyze.Command(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/AppTests.swift
+++ b/Tests/AppTests/AppTests.swift
@@ -29,8 +29,9 @@ class AppTests: AppTestCase {
         XCTAssertEqual(Current.fileManager.checkoutsDirectory(), "/tmp/foo")
     }
 
-    func test_migrations() throws {
-        XCTAssertNoThrow(try app.autoRevert().wait())
-        XCTAssertNoThrow(try app.autoMigrate().wait())
+    func test_migrations() async throws {
+        try await XCTAssertNoThrowAsync(try await app.autoRevert())
+        try await XCTAssertNoThrowAsync(try await app.autoMigrate())
     }
+
 }

--- a/Tests/AppTests/DocUploadTests.swift
+++ b/Tests/AppTests/DocUploadTests.swift
@@ -186,7 +186,7 @@ final class DocUploadTests: AppTestCase {
         }
     }
 
-    func test_unique_constraint_xxx() async throws {
+    func test_unique_constraint_version_id_partial() async throws {
         // Ensure no single version can reference two doc_uploads
         // setup
         let pkg = try await savePackageAsync(on: app.db, "1")
@@ -206,7 +206,7 @@ final class DocUploadTests: AppTestCase {
             XCTFail("Attaching to build with a version_id that already has a doc_upload must fail.")
         } catch let error as PostgresError where error.code == .uniqueViolation {
             // validate
-            XCTAssert(error.description.contains(#"duplicate key value violates unique constraint "uq:builds.version_id+builds.doc_upload_id""#), "was: \(error)")
+            XCTAssert(error.description.contains(#"duplicate key value violates unique constraint "uq:builds.version_id+partial""#), "was: \(error)")
         } catch {
             XCTFail("unexpected error: \(error)")
         }

--- a/Tests/AppTests/DocUploadTests.swift
+++ b/Tests/AppTests/DocUploadTests.swift
@@ -34,9 +34,7 @@ final class DocUploadTests: AppTestCase {
                           versionId: versionId,
                           error: "error",
                           fileCount: 1,
-                          logGroup: "group",
-                          logRegion: "region",
-                          logStream: "stream",
+                          logUrl: "logUrl",
                           mbSize: 2,
                           status: .ok)
 
@@ -47,9 +45,7 @@ final class DocUploadTests: AppTestCase {
             let d = try await XCTUnwrapAsync(try await DocUpload.find(docUploadId, on: app.db))
             XCTAssertEqual(d.error, "error")
             XCTAssertEqual(d.fileCount, 1)
-            XCTAssertEqual(d.logGroup, "group")
-            XCTAssertEqual(d.logRegion, "region")
-            XCTAssertEqual(d.logStream, "stream")
+            XCTAssertEqual(d.logUrl, "logUrl")
             XCTAssertEqual(d.mbSize, 2)
             XCTAssertEqual(d.status, .ok)
         }
@@ -103,10 +99,6 @@ final class DocUploadTests: AppTestCase {
         try await XCTAssertEqualAsync(try await Version.query(on: app.db).count(), 0)
         try await XCTAssertEqualAsync(try await Build.query(on: app.db).count(), 0)
         try await XCTAssertEqualAsync(try await DocUpload.query(on: app.db).count(), 0)
-    }
-
-    func test_logUrl() throws {
-        XCTFail()
     }
 
 }

--- a/Tests/AppTests/DocUploadTests.swift
+++ b/Tests/AppTests/DocUploadTests.swift
@@ -134,24 +134,19 @@ final class DocUploadTests: AppTestCase {
         try await XCTAssertEqualAsync(try await DocUpload.query(on: app.db).count(), 0)
     }
 
-    func test_unique_constraint_doc_upload_id() async throws {
+    func test_unique_constraint_doc_upload_id_1() async throws {
         // Ensure no two versions can reference the same doc_upload
         // setup
         let pkg = try await savePackageAsync(on: app.db, "1")
-        let versionId1 = UUID()
-        let v1 = try Version(id: versionId1, package: pkg)
+        let v1 = try Version(id: UUID(), package: pkg)
         try await v1.save(on: app.db)
-        let versionId2 = UUID()
-        let v2 = try Version(id: versionId2, package: pkg)
+        let v2 = try Version(id: UUID(), package: pkg)
         try await v2.save(on: app.db)
-        let buildId1 = UUID()
-        let b1 = try Build(id: buildId1, version: v1, platform: .linux, status: .ok, swiftVersion: .v5_7)
+        let b1 = try Build(id: UUID(), version: v1, platform: .linux, status: .ok, swiftVersion: .v5_7)
         try await b1.save(on: app.db)
-        let buildId2 = UUID()
-        let b2 = try Build(id: buildId2, version: v2, platform: .linux, status: .ok, swiftVersion: .v5_7)
+        let b2 = try Build(id: UUID(), version: v2, platform: .linux, status: .ok, swiftVersion: .v5_7)
         try await b2.save(on: app.db)
-        let docUploadId = UUID()
-        let docUpload = try DocUpload(id: docUploadId, status: .ok)
+        let docUpload = try DocUpload(id: UUID(), status: .ok)
         try await docUpload.attach(to: b1, on: app.db)
 
         // MUT
@@ -166,7 +161,7 @@ final class DocUploadTests: AppTestCase {
         }
     }
 
-    func test_unique_constraint_version_id_doc_upload_id() async throws {
+    func test_unique_constraint_doc_upload_id_2() async throws {
         // Ensure no single version can reference two doc_uploads
         // setup
         let pkg = try await savePackageAsync(on: app.db, "1")
@@ -179,8 +174,7 @@ final class DocUploadTests: AppTestCase {
         let buildId2 = UUID()
         let b2 = try Build(id: buildId2, version: v, platform: .ios, status: .ok, swiftVersion: .v5_7)
         try await b2.save(on: app.db)
-        let docUploadId = UUID()
-        let docUpload = try DocUpload(id: docUploadId, status: .ok)
+        let docUpload = try DocUpload(id: UUID(), status: .ok)
         try await docUpload.attach(to: b1, on: app.db)
 
         // MUT
@@ -189,7 +183,7 @@ final class DocUploadTests: AppTestCase {
             XCTFail("Attaching to another build with the same version_id must fail.")
         } catch let error as PostgresError where error.code == .uniqueViolation {
             // validate
-            XCTAssert(error.description.contains(#"duplicate key value violates unique constraint "uq:builds.version_id+builds.doc_upload_id""#), "was: \(error)")
+            XCTAssert(error.description.contains(#"duplicate key value violates unique constraint "uq:builds.doc_upload_id""#), "was: \(error)")
         } catch {
             XCTFail("unexpected error: \(error)")
         }

--- a/Tests/AppTests/DocUploadTests.swift
+++ b/Tests/AppTests/DocUploadTests.swift
@@ -28,13 +28,14 @@ final class DocUploadTests: AppTestCase {
         let v = try Version(id: versionId, package: pkg)
         try await v.save(on: app.db)
         let b = try Build(id: buildId, version: v, platform: .linux, status: .ok, swiftVersion: .v5_7)
-        let d = DocUpload(id: docUploadId,
-                          build: b,
-                          error: "error",
-                          fileCount: 1,
-                          logUrl: "logUrl",
-                          mbSize: 2,
-                          status: .ok)
+        try await b.save(on: app.db)
+        let d = try DocUpload(id: docUploadId,
+                              build: b,
+                              error: "error",
+                              fileCount: 1,
+                              logUrl: "logUrl",
+                              mbSize: 2,
+                              status: .ok)
         try await d.save(on: app.db)
         try await b.save(on: app.db)
 
@@ -63,6 +64,7 @@ final class DocUploadTests: AppTestCase {
         let v = try Version(id: versionId, package: pkg)
         try await v.save(on: app.db)
         let b = try Build(id: buildId, version: v, platform: .linux, status: .ok, swiftVersion: .v5_7)
+        try await b.save(on: app.db)
         try await DocUpload(build: b, status: .ok)
             .save(on: app.db)
         try await b.save(on: app.db)
@@ -119,7 +121,7 @@ final class DocUploadTests: AppTestCase {
 
         // MUT
         do {
-            XCTFail("Saving bad doc upload record must fail")
+            XCTFail("Implement: Saving bad doc upload record must fail")
         } catch {
             XCTAssertEqual("\(error)", "")
         }
@@ -128,7 +130,7 @@ final class DocUploadTests: AppTestCase {
     }
 
     func test_cascade() async throws {
-        XCTFail("ensure deleting a doc_upload doesn't delete the build")
+        XCTFail("Implement: Ensure deleting a doc_upload doesn't delete the build")
     }
 
 }

--- a/Tests/AppTests/DocUploadTests.swift
+++ b/Tests/AppTests/DocUploadTests.swift
@@ -1,0 +1,66 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import App
+
+import XCTVapor
+
+
+final class DocUploadTests: AppTestCase {
+
+    func test_save() async throws {
+        // setup
+        let pkg = try await savePackageAsync(on: app.db, "1")
+        let versionId = UUID()
+        let buildId = UUID()
+        let docUploadId = UUID()
+        let v = try Version(id: versionId, package: pkg)
+        try await v.save(on: app.db)
+        let b = try Build(id: buildId, version: v, platform: .linux, status: .ok, swiftVersion: .v5_7)
+        try await b.save(on: app.db)
+        let d = DocUpload(id: docUploadId,
+                          buildId: buildId,
+                          versionId: versionId,
+                          error: "error",
+                          fileCount: 1,
+                          logGroup: "group",
+                          logRegion: "region",
+                          logStream: "stream",
+                          mbSize: 2,
+                          status: .ok)
+
+        // MUT
+        try await d.save(on: app.db)
+
+        do { // validate
+            let d = try await XCTUnwrapAsync(try await DocUpload.find(docUploadId, on: app.db))
+            XCTAssertEqual(d.error, "error")
+            XCTAssertEqual(d.fileCount, 1)
+            XCTAssertEqual(d.logGroup, "group")
+            XCTAssertEqual(d.logRegion, "region")
+            XCTAssertEqual(d.logStream, "stream")
+            XCTAssertEqual(d.mbSize, 2)
+            XCTAssertEqual(d.status, .ok)
+        }
+    }
+
+    func test_delete_cascade() throws {
+        XCTFail()
+    }
+
+    func test_logUrl() throws {
+        XCTFail()
+    }
+
+}

--- a/Tests/AppTests/Helpers/XCTAsync.swift
+++ b/Tests/AppTests/Helpers/XCTAsync.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+
+func XCTUnwrapAsync<T>(_ expression: @autoclosure () async throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) async throws -> T {
+    let res = try await expression()
+    return try XCTUnwrap(res, message())
+}

--- a/Tests/AppTests/Helpers/XCTAsync.swift
+++ b/Tests/AppTests/Helpers/XCTAsync.swift
@@ -3,5 +3,12 @@ import XCTest
 
 func XCTUnwrapAsync<T>(_ expression: @autoclosure () async throws -> T?, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) async throws -> T {
     let res = try await expression()
-    return try XCTUnwrap(res, message())
+    return try XCTUnwrap(res, message(), file: file, line: line)
+}
+
+
+public func XCTAssertEqualAsync<T>(_ expression1: @autoclosure () async throws -> T, _ expression2: @autoclosure () async throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) async throws where T : Equatable {
+    let exp1 = try await expression1()
+    let exp2 = try await expression2()
+    XCTAssertEqual(exp1, exp2, message(), file: file, line: line)
 }

--- a/Tests/AppTests/Helpers/XCTAsync.swift
+++ b/Tests/AppTests/Helpers/XCTAsync.swift
@@ -12,3 +12,9 @@ public func XCTAssertEqualAsync<T>(_ expression1: @autoclosure () async throws -
     let exp2 = try await expression2()
     XCTAssertEqual(exp1, exp2, message(), file: file, line: line)
 }
+
+
+public func XCTAssertNoThrowAsync<T>(_ expression: @autoclosure () async throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) async throws {
+    let res = try await expression()
+    try XCTAssertNoThrow(res, message(), file: file, line: line)
+}

--- a/Tests/AppTests/Helpers/XCTAsync.swift
+++ b/Tests/AppTests/Helpers/XCTAsync.swift
@@ -16,5 +16,5 @@ public func XCTAssertEqualAsync<T>(_ expression1: @autoclosure () async throws -
 
 public func XCTAssertNoThrowAsync<T>(_ expression: @autoclosure () async throws -> T, _ message: @autoclosure () -> String = "", file: StaticString = #filePath, line: UInt = #line) async throws {
     let res = try await expression()
-    try XCTAssertNoThrow(res, message(), file: file, line: line)
+    XCTAssertNoThrow(res, message(), file: file, line: line)
 }


### PR DESCRIPTION
This adds the schema part of doc reporting. It comes with a set of constraints on the doc_uploads and builds tables to ensure

- no more than one doc upload can be attached to a build
- no doc upload can be referenced by more than one build (and thereby version)
- no version can reference more than one doc uploads