### PR TITLE
Doc report api

### DIFF
--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -21,7 +21,7 @@ extension API {
 
     enum BuildController {
         static func buildReport(req: Request) async throws -> HTTPStatus {
-            let dto = try req.content.decode(PostCreateBuildDTO.self)
+            let dto = try req.content.decode(PostBuildReportDTO.self)
             let version = try await App.Version
                 .find(req.parameters.get("id"), on: req.db)
                 .unwrap(or: Abort(.notFound))

--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -87,7 +87,7 @@ extension API {
 
         static func docReport(req: Request) async throws -> HTTPStatus {
             let dto = try req.content.decode(PostDocReportDTO.self)
-            let build = try await Build.find(dto.buildId, on: req.db)
+            let build = try await Build.find(req.parameters.get("id"), on: req.db)
                 .unwrap(or: Abort(.notFound))
 
             let docUpload = DocUpload(id: UUID(),

--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -85,6 +85,10 @@ extension API {
             return .noContent
         }
 
+        static func docReport(req: Request) async throws -> HTTPStatus {
+            .noContent
+        }
+
         static func trigger(req: Request) throws -> EventLoopFuture<Build.TriggerResponse> {
             guard let id = req.parameters.get("id"),
                   let versionId = UUID(uuidString: id)

--- a/Sources/App/Controllers/API/API+DTOs.swift
+++ b/Sources/App/Controllers/API/API+DTOs.swift
@@ -35,4 +35,13 @@ extension API {
         var status: Build.Status
         var swiftVersion: SwiftVersion
     }
+
+    struct PostDocReportDTO: Codable {
+        var buildId: UUID
+        var error: String?
+        var fileCount: Int?
+        var logUrl: String?
+        var mbSize: Int?
+        var status: DocUpload.Status
+    }
 }

--- a/Sources/App/Controllers/API/API+DTOs.swift
+++ b/Sources/App/Controllers/API/API+DTOs.swift
@@ -23,7 +23,7 @@ extension API {
         var swiftVersion: SwiftVersion
     }
 
-    struct PostCreateBuildDTO: Codable {
+    struct PostBuildReportDTO: Codable {
         var buildCommand: String?
         var buildId: UUID
         var docArchives: [DocArchive]?

--- a/Sources/App/Controllers/API/API+DTOs.swift
+++ b/Sources/App/Controllers/API/API+DTOs.swift
@@ -37,7 +37,6 @@ extension API {
     }
 
     struct PostDocReportDTO: Codable {
-        var buildId: UUID
         var error: String?
         var fileCount: Int?
         var logUrl: String?

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -81,7 +81,7 @@ enum Api: Resourceable {
     }
 
     enum BuildsPathComponents: String, Resourceable {
-        case docReport
+        case docReport = "doc-report"
     }
 
     enum PackagesPathComponents: String, Resourceable {
@@ -93,7 +93,7 @@ enum Api: Resourceable {
         @available(*, deprecated)
         // TODO: remove builds endpoint once builder transition is complete
         case builds
-        case buildReport
+        case buildReport = "build-report"
         case triggerBuild = "trigger-build"
     }
 

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -29,6 +29,7 @@ import Vapor
 
 
 enum Api: Resourceable {
+    case builds(_ id: Parameter<UUID>, BuildsPathComponents)
     case packages(_ owner: Parameter<String>, _ repository: Parameter<String>, PackagesPathComponents)
     case packageCollections
     case search
@@ -37,6 +38,10 @@ enum Api: Resourceable {
 
     var path: String {
         switch self {
+            case let .builds(.value(id), next):
+                return "builds/\(id.uuidString)/\(next.path)"
+            case .builds(.key, _):
+                fatalError("path must not be called with a name parameter")
             case let .packages(.value(owner), .value(repo), next):
                 return "packages/\(owner)/\(repo)/\(next.path)"
             case .packages:
@@ -56,6 +61,10 @@ enum Api: Resourceable {
 
     var pathComponents: [PathComponent] {
         switch self {
+            case let .builds(.key, remainder):
+                return ["builds", ":id"] + remainder.pathComponents
+            case .builds(.value, _):
+                fatalError("pathComponents must not be called with a value parameter")
             case let .packages(.key, .key, remainder):
                 return ["packages", ":owner", ":repository"] + remainder.pathComponents
             case .packages:
@@ -71,6 +80,10 @@ enum Api: Resourceable {
         }
     }
 
+    enum BuildsPathComponents: String, Resourceable {
+        case docReport
+    }
+
     enum PackagesPathComponents: String, Resourceable {
         case badge
         case triggerBuilds = "trigger-builds"
@@ -81,7 +94,6 @@ enum Api: Resourceable {
         // TODO: remove builds endpoint once builder transition is complete
         case builds
         case buildReport
-        case docReport
         case triggerBuild = "trigger-build"
     }
 

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -77,7 +77,10 @@ enum Api: Resourceable {
     }
 
     enum VersionsPathComponents: String, Resourceable {
+        @available(*, deprecated)
+        // TODO: remove builds endpoint once builder transition is complete
         case builds
+        case buildReport
         case triggerBuild = "trigger-build"
     }
 

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -81,6 +81,7 @@ enum Api: Resourceable {
         // TODO: remove builds endpoint once builder transition is complete
         case builds
         case buildReport
+        case docReport
         case triggerBuild = "trigger-build"
     }
 

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -64,7 +64,7 @@ final class DocUpload: Model, Content {
         logUrl: String? = nil,
         mbSize: Int? = nil,
         status: Status
-    ) throws {
+    ) {
         self.id = id
         self.error = error
         self.fileCount = fileCount

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -166,6 +166,8 @@ func routes(_ app: Application) throws {
         app.group(User.TokenAuthenticator(), User.guardMiddleware()) { protected in
             protected.on(.POST, SiteURL.api(.versions(.key, .builds)).pathComponents,
                          use: API.BuildController.buildReport)
+            protected.on(.POST, SiteURL.api(.versions(.key, .buildReport)).pathComponents,
+                         use: API.BuildController.buildReport)
             protected.post(SiteURL.api(.versions(.key, .triggerBuild)).pathComponents,
                            use: API.BuildController.trigger)
             protected.post(SiteURL.api(.packages(.key, .key, .triggerBuilds)).pathComponents,

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -168,7 +168,7 @@ func routes(_ app: Application) throws {
                          use: API.BuildController.buildReport)
             protected.on(.POST, SiteURL.api(.versions(.key, .buildReport)).pathComponents,
                          use: API.BuildController.buildReport)
-            protected.on(.POST, SiteURL.api(.versions(.key, .docReport)).pathComponents,
+            protected.on(.POST, SiteURL.api(.builds(.key, .docReport)).pathComponents,
                          use: API.BuildController.docReport)
             protected.post(SiteURL.api(.versions(.key, .triggerBuild)).pathComponents,
                            use: API.BuildController.trigger)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -168,6 +168,8 @@ func routes(_ app: Application) throws {
                          use: API.BuildController.buildReport)
             protected.on(.POST, SiteURL.api(.versions(.key, .buildReport)).pathComponents,
                          use: API.BuildController.buildReport)
+            protected.on(.POST, SiteURL.api(.versions(.key, .docReport)).pathComponents,
+                         use: API.BuildController.docReport)
             protected.post(SiteURL.api(.versions(.key, .triggerBuild)).pathComponents,
                            use: API.BuildController.trigger)
             protected.post(SiteURL.api(.packages(.key, .key, .triggerBuilds)).pathComponents,

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -428,14 +428,12 @@ class ApiTests: AppTestCase {
         let p = try await savePackageAsync(on: app.db, "1")
         let v = try Version(package: p, latest: .defaultBranch)
         try await v.save(on: app.db)
-        let versionId = try v.requireID()
         let b = try Build(version: v, platform: .ios, status: .ok, swiftVersion: .v5_7)
         try await b.save(on: app.db)
         let buildId = try b.requireID()
 
         do {  // MUT - initial insert
-            let dto: API.PostDocReportDTO = .init(buildId: buildId,
-                                                  error: "too large",
+            let dto: API.PostDocReportDTO = .init(error: "too large",
                                                   fileCount: 70_000,
                                                   logUrl: "log url",
                                                   mbSize: 900,
@@ -443,7 +441,7 @@ class ApiTests: AppTestCase {
             let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
             try await app.test(
                 .POST,
-                "api/versions/\(versionId)/docReport",
+                "api/builds/\(buildId)/docReport",
                 headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -223,7 +223,7 @@ class ApiTests: AppTestCase {
             let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
             try app.test(
                 .POST,
-                "api/versions/\(versionId)/buildReport",
+                "api/versions/\(versionId)/build-report",
                 headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
@@ -261,7 +261,7 @@ class ApiTests: AppTestCase {
             let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
             try app.test(
                 .POST,
-                "api/versions/\(versionId)/buildReport",
+                "api/versions/\(versionId)/build-report",
                 headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
@@ -297,7 +297,7 @@ class ApiTests: AppTestCase {
             let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
             try app.test(
                 .POST,
-                "api/versions/\(versionId)/buildReport",
+                "api/versions/\(versionId)/build-report",
                 headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
@@ -331,7 +331,7 @@ class ApiTests: AppTestCase {
         let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
         try app.test(
             .POST,
-            "api/versions/\(versionId)/buildReport",
+            "api/versions/\(versionId)/build-report",
             headers: .bearerApplicationJSON("secr3t"),
             body: body,
             afterResponse: { res in
@@ -361,7 +361,7 @@ class ApiTests: AppTestCase {
         // MUT - no auth header
         try app.test(
             .POST,
-            "api/versions/\(versionId)/buildReport",
+            "api/versions/\(versionId)/build-report",
             headers: .applicationJSON,
             body: body,
             afterResponse: { res in
@@ -374,7 +374,7 @@ class ApiTests: AppTestCase {
         // MUT - wrong token
         try app.test(
             .POST,
-            "api/versions/\(versionId)/buildReport",
+            "api/versions/\(versionId)/build-report",
             headers: .bearerApplicationJSON("wrong"),
             body: body,
             afterResponse: { res in
@@ -388,7 +388,7 @@ class ApiTests: AppTestCase {
         Current.builderToken = { nil }
         try app.test(
             .POST,
-            "api/versions/\(versionId)/buildReport",
+            "api/versions/\(versionId)/build-report",
             headers: .bearerApplicationJSON("secr3t"),
             body: body,
             afterResponse: { res in
@@ -418,7 +418,7 @@ class ApiTests: AppTestCase {
             let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
             try await app.test(
                 .POST,
-                "api/builds/\(buildId)/docReport",
+                "api/builds/\(buildId)/doc-report",
                 headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
@@ -441,7 +441,7 @@ class ApiTests: AppTestCase {
             let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
             try await app.test(
                 .POST,
-                "api/builds/\(buildId)/docReport",
+                "api/builds/\(buildId)/doc-report",
                 headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
@@ -466,7 +466,7 @@ class ApiTests: AppTestCase {
             let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
             try await app.test(
                 .POST,
-                "api/builds/\(nonExistingBuildId)/docReport",
+                "api/builds/\(nonExistingBuildId)/doc-report",
                 headers: .bearerApplicationJSON("secr3t"),
                 body: body,
                 afterResponse: { res in
@@ -493,7 +493,7 @@ class ApiTests: AppTestCase {
         // MUT - no auth header
         try await app.test(
             .POST,
-            "api/builds/\(buildId)/docReport",
+            "api/builds/\(buildId)/doc-report",
             headers: .applicationJSON,
             body: body,
             afterResponse: { res in
@@ -506,7 +506,7 @@ class ApiTests: AppTestCase {
         // MUT - wrong token
         try await app.test(
             .POST,
-            "api/builds/\(buildId)/docReport",
+            "api/builds/\(buildId)/doc-report",
             headers: .bearerApplicationJSON("wrong"),
             body: body,
             afterResponse: { res in
@@ -520,7 +520,7 @@ class ApiTests: AppTestCase {
         Current.builderToken = { nil }
         try await app.test(
             .POST,
-            "api/builds/\(buildId)/docReport",
+            "api/builds/\(buildId)/doc-report",
             headers: .bearerApplicationJSON("secr3t"),
             body: body,
             afterResponse: { res in

--- a/Tests/AppTests/DocUploadTests.swift
+++ b/Tests/AppTests/DocUploadTests.swift
@@ -30,12 +30,12 @@ final class DocUploadTests: AppTestCase {
         try await v.save(on: app.db)
         let b = try Build(id: buildId, version: v, platform: .linux, status: .ok, swiftVersion: .v5_7)
         try await b.save(on: app.db)
-        let d = try DocUpload(id: docUploadId,
-                              error: "error",
-                              fileCount: 1,
-                              logUrl: "logUrl",
-                              mbSize: 2,
-                              status: .ok)
+        let d = DocUpload(id: docUploadId,
+                          error: "error",
+                          fileCount: 1,
+                          logUrl: "logUrl",
+                          mbSize: 2,
+                          status: .ok)
 
         // MUT
         try await d.attach(to: b, on: app.db)
@@ -170,7 +170,7 @@ final class DocUploadTests: AppTestCase {
         try await b1.save(on: app.db)
         let b2 = try Build(id: UUID(), version: v2, platform: .linux, status: .ok, swiftVersion: .v5_7)
         try await b2.save(on: app.db)
-        let docUpload = try DocUpload(id: UUID(), status: .ok)
+        let docUpload = DocUpload(id: UUID(), status: .ok)
         try await docUpload.attach(to: b1, on: app.db)
 
         // MUT
@@ -195,7 +195,7 @@ final class DocUploadTests: AppTestCase {
         try await b1.save(on: app.db)
         let b2 = try Build(id: UUID(), version: v, platform: .ios, status: .ok, swiftVersion: .v5_7)
         try await b2.save(on: app.db)
-        let docUpload = try DocUpload(id: UUID(), status: .ok)
+        let docUpload = DocUpload(id: UUID(), status: .ok)
         try await docUpload.attach(to: b1, on: app.db)
 
         // MUT
@@ -220,9 +220,9 @@ final class DocUploadTests: AppTestCase {
         try await b1.save(on: app.db)
         let b2 = try Build(id: UUID(), version: v, platform: .ios, status: .ok, swiftVersion: .v5_7)
         try await b2.save(on: app.db)
-        let docUpload1 = try DocUpload(id: UUID(), status: .ok)
+        let docUpload1 = DocUpload(id: UUID(), status: .ok)
         try await docUpload1.attach(to: b1, on: app.db)
-        let docUpload2 = try DocUpload(id: UUID(), status: .ok)
+        let docUpload2 = DocUpload(id: UUID(), status: .ok)
 
         // MUT
         do {

--- a/Tests/AppTests/SiteURLTests.swift
+++ b/Tests/AppTests/SiteURLTests.swift
@@ -105,6 +105,8 @@ class SiteURLTests: XCTestCase {
             let uuid = UUID()
             XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .builds)).path,
                            "api/versions/\(uuid.uuidString)/builds")
+            XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .buildReport)).path,
+                           "api/versions/\(uuid.uuidString)/buildReport")
             XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .triggerBuild)).path,
                            "api/versions/\(uuid.uuidString)/trigger-build")
         }

--- a/Tests/AppTests/SiteURLTests.swift
+++ b/Tests/AppTests/SiteURLTests.swift
@@ -107,6 +107,8 @@ class SiteURLTests: XCTestCase {
                            "api/versions/\(uuid.uuidString)/builds")
             XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .buildReport)).path,
                            "api/versions/\(uuid.uuidString)/buildReport")
+            XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .docReport)).path,
+                           "api/versions/\(uuid.uuidString)/docReport")
             XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .triggerBuild)).path,
                            "api/versions/\(uuid.uuidString)/trigger-build")
         }

--- a/Tests/AppTests/SiteURLTests.swift
+++ b/Tests/AppTests/SiteURLTests.swift
@@ -106,9 +106,9 @@ class SiteURLTests: XCTestCase {
             XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .builds)).path,
                            "api/versions/\(uuid.uuidString)/builds")
             XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .buildReport)).path,
-                           "api/versions/\(uuid.uuidString)/buildReport")
+                           "api/versions/\(uuid.uuidString)/build-report")
             XCTAssertEqual(SiteURL.api(.builds(.value(uuid), .docReport)).path,
-                           "api/builds/\(uuid.uuidString)/docReport")
+                           "api/builds/\(uuid.uuidString)/doc-report")
             XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .triggerBuild)).path,
                            "api/versions/\(uuid.uuidString)/trigger-build")
         }

--- a/Tests/AppTests/SiteURLTests.swift
+++ b/Tests/AppTests/SiteURLTests.swift
@@ -107,8 +107,8 @@ class SiteURLTests: XCTestCase {
                            "api/versions/\(uuid.uuidString)/builds")
             XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .buildReport)).path,
                            "api/versions/\(uuid.uuidString)/buildReport")
-            XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .docReport)).path,
-                           "api/versions/\(uuid.uuidString)/docReport")
+            XCTAssertEqual(SiteURL.api(.builds(.value(uuid), .docReport)).path,
+                           "api/builds/\(uuid.uuidString)/docReport")
             XCTAssertEqual(SiteURL.api(.versions(.value(uuid), .triggerBuild)).path,
                            "api/versions/\(uuid.uuidString)/trigger-build")
         }


### PR DESCRIPTION
This adds the doc reporting API

```
POST /api/builds/{buildId}/docReport
```

I've also changed the build reporting API to be in line with this from

```
POST /api/versions/{versionId}/buildReport
```

This API used to be

```
POST /api/versions/{version}/builds
```

when it actually _created_ builds when the endpoint was hit. This has been different for a while now since we are creating the `Build` records on trigger and the the build reporting merely updates the record.

I think not going with "pure" REST endpoints makes more sense here because the reports do a little more than simply update the records. They also update relationships and so the dedicated `xxxReport` endpoint probably makes sense.

NB: I've left the old

```
POST /api/versions/{version}/builds
```

in place (with deprecation warnings) for now so we don't need to worry about deployment order. I'll take it out once the `builder` has transitioned.