### PR TITLE
Add `uploading` DocUpload.Status

### DIFF
--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -81,6 +81,7 @@ extension DocUpload {
         case failed
         case pending
         case skipped
+        case uploading
 
         var description: String {
             switch self {
@@ -88,6 +89,7 @@ extension DocUpload {
                 case .failed: return "Failed"
                 case .pending: return "Pending"
                 case .skipped: return "Skipped"
+                case .uploading: return "Uploading"
             }
         }
     }


### PR DESCRIPTION
This will allow us to send `pending` before starting doc generation and `uploading` before uploading.

Right now we're sending `pending` _after_ doc generation and before uploading, which means that if a job gets killed by a timeout we don't get any doc report back. This way, we'll know any `pending` ones have timed out.

All others would have `ok` or `failed` statuses.

(We can't report a `timeout` status back from the interrupt handler, because it'd be very hard to tell if the interrupt happened during a doc build.)