### PR TITLE
Extend hasDocumentation to cover pre-releases

### DIFF
--- a/Sources/App/Core/Extensions/Array+Version.swift
+++ b/Sources/App/Core/Extensions/Array+Version.swift
@@ -15,6 +15,7 @@
 
 extension [Version] {
     var defaultBranchVersion: Version? { filter { $0.latest == .defaultBranch}.first }
+    var preReleaseVersion: Version? { filter { $0.latest == .preRelease}.first }
     var releaseVersion: Version? { filter { $0.latest == .release}.first }
 
     func documentationTarget() -> DocumentationTarget? {
@@ -26,6 +27,11 @@ extension [Version] {
 
         // Ideal case is that we have a stable release documentation.
         if let version = releaseVersion,
+           let archive = version.docArchives?.first?.name {
+            return .internal(reference: "\(version.reference)", archive: archive)
+        }
+
+        if let version = preReleaseVersion,
            let archive = version.docArchives?.first?.name {
             return .internal(reference: "\(version.reference)", archive: archive)
         }


### PR DESCRIPTION
Fixes #2191

I've tested this locally with yesterday's db snapshot:

This branch:

<img width="722" alt="CleanShot 2023-03-01 at 11 11 56@2x" src="https://user-images.githubusercontent.com/65520/222109423-dc1c7f33-f03e-473f-bd98-d59405d52809.png">

Documentation links to: http://localhost:8080/apple/swift-syntax/0.50900.0-swift-DEVELOPMENT-SNAPSHOT-2023-02-27-a/documentation/swiftsyntax

`main`:

<img width="718" alt="CleanShot 2023-03-01 at 11 12 43@2x" src="https://user-images.githubusercontent.com/65520/222109616-b504e23f-0a79-41a3-8f6e-45c33290cb88.png">
