### PR TITLE
Path encode reference when constructing S3 urls

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -404,7 +404,7 @@ extension PackageController {
         }
 
         let baseURLHost = "\(bucket).s3-website.us-east-2.amazonaws.com"
-        let baseURLPath = "\(owner.lowercased())/\(repository.lowercased())/\(reference.lowercased())"
+        let baseURLPath = "\(owner.lowercased())/\(repository.lowercased())/\(reference.pathEncoded.lowercased())"
         let baseURL = "http://\(baseURLHost)/\(baseURLPath)"
 
         switch fragment {
@@ -430,4 +430,13 @@ private extension HTTPHeaders {
 
 extension PackageController.Fragment: CustomStringConvertible {
     var description: String { rawValue }
+}
+
+
+private extension String {
+    // Keep in sync with https://github.com/SwiftPackageIndex/DocUploader/blob/main/Sources/DocUploadBundle/String%2Bext.swift
+    // We should pull this out into a shared module perhaps but it's a lot of fiddling for just a single method.
+    var pathEncoded: Self {
+        replacingOccurrences(of: "/", with: ".")
+    }
 }

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -431,12 +431,3 @@ private extension HTTPHeaders {
 extension PackageController.Fragment: CustomStringConvertible {
     var description: String { rawValue }
 }
-
-
-private extension String {
-    // Keep in sync with https://github.com/SwiftPackageIndex/DocUploader/blob/main/Sources/DocUploadBundle/String%2Bext.swift
-    // We should pull this out into a shared module perhaps but it's a lot of fiddling for just a single method.
-    var pathEncoded: Self {
-        replacingOccurrences(of: "/", with: ".")
-    }
-}

--- a/Sources/App/Core/DocumentationTarget.swift
+++ b/Sources/App/Core/DocumentationTarget.swift
@@ -72,7 +72,7 @@ enum DocumentationTarget: Equatable {
             .all()
         // we need to filter client side to support pathEncoded reference equality
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2287
-            .first(where: { $0.model.reference == reference })
+            .first(where: { $0.model.reference.pathEncoded == reference.pathEncoded })
             .flatMap { $0.model.docArchives?.first?.name }
 
         return archive.map {

--- a/Sources/App/Core/DocumentationTarget.swift
+++ b/Sources/App/Core/DocumentationTarget.swift
@@ -66,10 +66,13 @@ enum DocumentationTarget: Equatable {
                    join: \Package.$id == \Repository.$package.$id, method: .inner)
             .filter(Repository.self, \.$owner, .custom("ilike"), owner)
             .filter(Repository.self, \.$name, .custom("ilike"), repository)
-            .filter(\Version.$reference == reference)
             .filter(\Version.$docArchives != nil)
             .field(Version.self, \.$docArchives)
-            .first()
+            .field(Version.self, \.$reference)
+            .all()
+        // we need to filter client side to support pathEncoded reference equality
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2287
+            .first(where: { $0.model.reference == reference })
             .flatMap { $0.model.docArchives?.first?.name }
 
         return archive.map {

--- a/Sources/App/Core/DocumentationVersion.swift
+++ b/Sources/App/Core/DocumentationVersion.swift
@@ -56,7 +56,7 @@ struct DocumentationVersion: Equatable {
 
 extension Array where Element == DocumentationVersion {
     subscript(reference reference: String) -> Element? {
-        first { "\($0.reference)".pathEncoded == reference.pathEncoded }
+        first { $0.reference == reference }
     }
 
     func latestMajorVersions() -> Self {

--- a/Sources/App/Core/DocumentationVersion.swift
+++ b/Sources/App/Core/DocumentationVersion.swift
@@ -56,7 +56,7 @@ struct DocumentationVersion: Equatable {
 
 extension Array where Element == DocumentationVersion {
     subscript(reference reference: String) -> Element? {
-        first { $0.reference == reference }
+        first { $0.reference.pathEncoded == reference.pathEncoded }
     }
 
     func latestMajorVersions() -> Self {

--- a/Sources/App/Core/DocumentationVersion.swift
+++ b/Sources/App/Core/DocumentationVersion.swift
@@ -56,7 +56,7 @@ struct DocumentationVersion: Equatable {
 
 extension Array where Element == DocumentationVersion {
     subscript(reference reference: String) -> Element? {
-        first { "\($0.reference)" == reference }
+        first { "\($0.reference)".pathEncoded == reference.pathEncoded }
     }
 
     func latestMajorVersions() -> Self {

--- a/Sources/App/Core/Extensions/String+ext.swift
+++ b/Sources/App/Core/Extensions/String+ext.swift
@@ -38,6 +38,15 @@ extension String {
 }
 
 
+extension String {
+    // Keep in sync with https://github.com/SwiftPackageIndex/DocUploader/blob/main/Sources/DocUploadBundle/String%2Bext.swift
+    // We should pull this out into a shared module perhaps but it's a lot of fiddling for just a single method.
+    var pathEncoded: Self {
+        replacingOccurrences(of: "/", with: ".")
+    }
+}
+
+
 // MARK: - Pluralisation
 
 extension String {

--- a/Sources/App/Core/Extensions/String+ext.swift
+++ b/Sources/App/Core/Extensions/String+ext.swift
@@ -42,7 +42,7 @@ extension String {
     // Keep in sync with https://github.com/SwiftPackageIndex/DocUploader/blob/main/Sources/DocUploadBundle/String%2Bext.swift
     // We should pull this out into a shared module perhaps but it's a lot of fiddling for just a single method.
     var pathEncoded: Self {
-        replacingOccurrences(of: "/", with: ".")
+        replacingOccurrences(of: "/", with: "-")
     }
 }
 

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -373,14 +373,14 @@ extension SiteURL {
             case let (.internal(reference, archive), .documentation):
                 // Point documentation fragment URLs at the archive unless there's a specific path given.
                 return path.isEmpty
-                ? "/\(owner)/\(repository)/\(reference)/\(fragment)/\(archive.lowercased())"
-                : "/\(owner)/\(repository)/\(reference)/\(fragment)/\(path)"
+                ? "/\(owner)/\(repository)/\(reference.pathEncoded)/\(fragment)/\(archive.lowercased())"
+                : "/\(owner)/\(repository)/\(reference.pathEncoded)/\(fragment)/\(path)"
 
             case let (.internal(reference, _), _):
                 // All other fragments (for instance `tutorials`) default to just the fragment plus optionally the path.
                 return path.isEmpty
-                ? "/\(owner)/\(repository)/\(reference)/\(fragment)"
-                : "/\(owner)/\(repository)/\(reference)/\(fragment)/\(path)"
+                ? "/\(owner)/\(repository)/\(reference.pathEncoded)/\(fragment)"
+                : "/\(owner)/\(repository)/\(reference.pathEncoded)/\(fragment)/\(path)"
 
             case (.universal, _):
                 return path.isEmpty

--- a/Sources/App/Models/Reference.swift
+++ b/Sources/App/Models/Reference.swift
@@ -16,7 +16,7 @@ import Foundation
 import SemanticVersion
 
 
-enum Reference: Equatable, Hashable {
+enum Reference: Hashable {
     case branch(String)
     case tag(SemanticVersion, _ tagName: String)
 
@@ -72,6 +72,30 @@ enum Reference: Equatable, Hashable {
                 return .defaultBranch
             case .tag(let semVer, _):
                 return semVer.isPreRelease ? .preRelease : .release
+        }
+    }
+}
+
+
+extension Reference: Equatable {
+    static func ==(lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+            case let (.branch(lhs), .branch(rhs)):
+                return lhs.pathEncoded == rhs.pathEncoded
+            case let (.tag(lhsVersion, lhsTagName), .tag(rhsVersion, rhsTagName)):
+                return lhsVersion == rhsVersion && lhsTagName == rhsTagName
+            case (.branch, .tag), (.tag, .branch):
+                return false
+        }
+    }
+
+    static func ==(lhs: Self, rhs: String) -> Bool {
+        switch lhs {
+            case .branch(_):
+                return lhs == .branch(rhs)
+            case .tag:
+                guard let semver = SemanticVersion(rhs) else { return false }
+                return lhs == .tag(semver)
         }
     }
 }

--- a/Sources/App/Models/Reference.swift
+++ b/Sources/App/Models/Reference.swift
@@ -16,7 +16,7 @@ import Foundation
 import SemanticVersion
 
 
-enum Reference: Hashable {
+enum Reference: Equatable, Hashable {
     case branch(String)
     case tag(SemanticVersion, _ tagName: String)
 
@@ -74,32 +74,8 @@ enum Reference: Hashable {
                 return semVer.isPreRelease ? .preRelease : .release
         }
     }
-}
 
-
-extension Reference: Equatable {
-    static func ==(lhs: Self, rhs: Self) -> Bool {
-        switch (lhs, rhs) {
-            case let (.branch(lhs), .branch(rhs)):
-                return lhs.pathEncoded == rhs.pathEncoded
-            case let (.tag(lhsVersion, lhsTagName), .tag(rhsVersion, rhsTagName)):
-                return lhsVersion == rhsVersion && lhsTagName == rhsTagName
-            case (.branch, .tag), (.tag, .branch):
-                return false
-        }
-    }
-
-    static func ==(lhs: Self, rhs: String) -> Bool {
-        switch lhs {
-            case .branch(_):
-                return lhs == .branch(rhs)
-            case .tag:
-                guard let semver = SemanticVersion(rhs) else { return false }
-                return lhs == .tag(semver)
-        }
-    }
-
-    static func !=(lhs: Self, rhs: String) -> Bool { !(lhs == rhs) }
+    var pathEncoded: String { "\(self)".pathEncoded }
 }
 
 

--- a/Sources/App/Models/Reference.swift
+++ b/Sources/App/Models/Reference.swift
@@ -98,6 +98,8 @@ extension Reference: Equatable {
                 return lhs == .tag(semver)
         }
     }
+
+    static func !=(lhs: Self, rhs: String) -> Bool { !(lhs == rhs) }
 }
 
 

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -539,6 +539,51 @@ class PackageController_routesTests: AppTestCase {
         }
     }
 
+    func test_documentation_issue_2287() async throws {
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2287
+        // Ensure references are path encoded
+        // setup
+        Current.fetchDocumentation = { _, uri in
+            // embed uri.path in the body as a simple way to test the requested url
+            .init(status: .ok, body: .init(string: "<p>\(uri.path)</p>"))
+        }
+        let pkg = try savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg,
+                          commit: "0123456789",
+                          commitDate: .t0,
+                          docArchives: [.init(name: "docs", title: "Docs")],
+                          latest: .defaultBranch,
+                          packageName: "pkg",
+                          reference: .branch("feature/1.2.3"))
+        .save(on: app.db)
+
+        // MUT
+
+        // test default path
+        try app.test(.GET, "/owner/package/documentation") {
+            XCTAssertEqual($0.status, .seeOther)
+            XCTAssertEqual($0.headers.location, "/owner/package/feature-1.2.3/documentation/docs")
+        }
+
+        // test reference root path
+        try app.test(.GET, "/owner/package/feature-1.2.3/documentation") {
+            XCTAssertEqual($0.status, .seeOther)
+            XCTAssertEqual($0.headers.location, "/owner/package/feature-1.2.3/documentation/docs")
+        }
+
+        // test path a/b
+        try app.test(.GET, "/owner/package/feature-1.2.3/documentation/a/b") {
+            XCTAssertEqual($0.status, .ok)
+            XCTAssertEqual($0.content.contentType?.description, "text/html; charset=utf-8")
+            XCTAssertTrue(
+                $0.body.asString().contains("<p>/owner/package/feature-1.2.3/documentation/a/b</p>"),
+                "was: \($0.body.asString())"
+            )
+        }
+    }
+
     func test_defaultTutorial() throws {
         // setup
         Current.fetchDocumentation = { _, uri in

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -229,6 +229,16 @@ class PackageController_routesTests: AppTestCase {
         )
     }
 
+    func test_awsDocumentationURL_issue2287() throws {
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2287
+        // reference with / needs to be escaped
+        Current.awsDocsBucket = { "docs-bucket" }
+        XCTAssertEqual(
+            try PackageController.awsDocumentationURL(owner: "linhay", repository: "SectionKit", reference: "feature/2.0.0", fragment: .documentation, path: "sectionui").string,
+            "http://docs-bucket.s3-website.us-east-2.amazonaws.com/linhay/sectionkit/feature.2.0.0/documentation/sectionui"
+        )
+    }
+
     func test_defaultDocumentation() throws {
         // setup
         Current.fetchDocumentation = { _, uri in

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -235,7 +235,7 @@ class PackageController_routesTests: AppTestCase {
         Current.awsDocsBucket = { "docs-bucket" }
         XCTAssertEqual(
             try PackageController.awsDocumentationURL(owner: "linhay", repository: "SectionKit", reference: "feature/2.0.0", fragment: .documentation, path: "sectionui").string,
-            "http://docs-bucket.s3-website.us-east-2.amazonaws.com/linhay/sectionkit/feature.2.0.0/documentation/sectionui"
+            "http://docs-bucket.s3-website.us-east-2.amazonaws.com/linhay/sectionkit/feature-2.0.0/documentation/sectionui"
         )
     }
 

--- a/Tests/AppTests/ReferenceTests.swift
+++ b/Tests/AppTests/ReferenceTests.swift
@@ -34,6 +34,30 @@ class ReferenceTests: XCTestCase {
         }
     }
 
+    func test_Equatable() throws {
+        // setup
+        let b1 = Reference.branch("b/1")
+        let b2 = Reference.branch("b/2")
+        let b1dash = Reference.branch("b-1")
+        let b2dash = Reference.branch("b-2")
+        let t1 = Reference.tag(.init("1.0.0")!)
+        let t2 = Reference.tag(.init("2.0.0")!)
+
+        XCTAssertTrue(b1 == b1)
+        XCTAssertTrue(b1 != b2)
+        XCTAssertTrue(t1 == t1)
+        XCTAssertTrue(t1 != t2)
+        XCTAssertTrue(t1 != b1)
+
+        XCTAssertTrue(b1 == b1dash)
+        XCTAssertTrue(b1 != b2dash)
+
+        XCTAssertTrue(b1 == "b/1")
+        XCTAssertTrue(b1 == "b-1")
+        XCTAssertTrue(b2 != "b/1")
+        XCTAssertTrue(b2 != "b-1")
+    }
+
     func test_isRelease() throws {
         XCTAssertTrue(Reference.tag(.init(1, 0, 0)).isRelease)
         XCTAssertFalse(Reference.tag(.init(1, 0, 0, "beta1")).isRelease)


### PR DESCRIPTION
I'll manually deploy from the branch to test this on dev.

Fixes #2287

To do:

- [x] add tests