### PR TITLE
Fix Xcode 14.3 build errors/warnings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,6 @@ let package = Package(
                  revision: "db112a2104eae7fa8412ea80210d0f60b89a377e"),
         .package(url: "https://github.com/apple/swift-package-manager.git", branch: "release/5.7"),
         .package(url: "https://github.com/handya/OhhAuth.git", from: "1.4.0"),
-        .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.7.1"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.7.2"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
         .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0-rc"),
@@ -68,3 +67,14 @@ let package = Package(
     ],
     swiftLanguageVersions: [.v5]
 )
+
+#if swift(>=5.8)
+// FIXME: switch back to release version
+package.dependencies.append(
+    .package(url: "https://github.com/pointfreeco/swift-parsing.git", branch: "swift-5-8")
+)
+#else
+package.dependencies.append(
+    .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.7.1")
+)
+#endif

--- a/Sources/App/Controllers/API/API+PackageCollectionController.swift
+++ b/Sources/App/Controllers/API/API+PackageCollectionController.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Fluent
+import PackageCollectionsModel
 import Vapor
 
 


### PR DESCRIPTION
This adds support for building and running the project with Xcode 14.3 / Swift 5.8.

Xcode 14.2 / Swift 5.7 also still work.