### PR TITLE
Update SPI Playgrounds download page

### DIFF
--- a/Resources/Markdown/try-package.md
+++ b/Resources/Markdown/try-package.md
@@ -9,7 +9,11 @@ What’s the best way to know whether a package is right for your project? Try i
 
 <a class="download" href="https://spi-playgrounds-updates.swiftpackageindex.com/SPI-Playgrounds.app.zip">
   Download
-  <small>Requires macOS 11 or newer</small>
+  <small>Requires macOS 13 or newer</small>
 </a>
 
 Once downloaded and installed, click **“Try in a Playground”** from any package page on the Swift Package Index to open a Swift playground in Xcode with the package imported, ready for experimentation and testing.
+
+### Trying packages on older macOS versions
+
+The latest version of “Swift Package Index Playgrounds” requires macOS 13 or newer. If you are still on an earlier version of macOS, <a href="https://spi-playgrounds-updates.swiftpackageindex.com/releases/SPI-Playgrounds-1.0.1.app.zip">version 1.0.1 of the app is still available for download</a>.

--- a/Resources/Markdown/try-package.md
+++ b/Resources/Markdown/try-package.md
@@ -16,4 +16,4 @@ Once downloaded and installed, click **“Try in a Playground”** from any pack
 
 ### Trying packages on older macOS versions
 
-The latest version of “Swift Package Index Playgrounds” requires macOS 13 or newer. If you are still on an earlier version of macOS, <a href="https://spi-playgrounds-updates.swiftpackageindex.com/releases/SPI-Playgrounds-1.0.1.app.zip">version 1.0.1 of the app is still available for download</a>.
+The latest version of “Swift Package Index Playgrounds” requires macOS 13 or newer. If you are on an earlier version of macOS, <a href="https://spi-playgrounds-updates.swiftpackageindex.com/releases/SPI-Playgrounds-1.0.1.app.zip">version 1.0.1 of the app is still available for download</a>.


### PR DESCRIPTION
<img width="734" alt="CleanShot 2023-04-14 at 19 43 06@2x" src="https://user-images.githubusercontent.com/65520/232119007-9eaca536-b68b-45c1-93eb-03d32fa4c57b.png">

Fixes #2337 