### PR TITLE
Package update

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swift-server/async-http-client.git",
       "state" : {
-        "revision" : "864c8d9e0ead5de7ba70b61c8982f89126710863",
-        "version" : "1.15.0"
+        "revision" : "333e60cc90f52973f7ee29cd8e3a7f6adfe79f4e",
+        "version" : "1.17.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/async-kit.git",
       "state" : {
-        "revision" : "9acea4c92f51a5885c149904f0d11db4712dda80",
-        "version" : "1.16.0"
+        "revision" : "a61da00d404ec91d12766f1b9aac7d90777b484d",
+        "version" : "1.17.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent.git",
       "state" : {
-        "revision" : "8d6015096200b4c2f17b884eb966defc42a2ad1d",
-        "version" : "4.7.1"
+        "revision" : "4b4d8bf15a06fd60137e9c543e5503c4b842654e",
+        "version" : "4.8.0"
       }
     },
     {
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent-kit.git",
       "state" : {
-        "revision" : "21d99b0c66cf86867a779bac831d800aac22f5e6",
-        "version" : "1.41.0"
+        "revision" : "559dc9c730cde77cc9dac76fba73d6e0855f0220",
+        "version" : "1.42.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/fluent-postgres-driver.git",
       "state" : {
-        "revision" : "f2b084417472e6a153d555905796f0ef0bb6fc37",
-        "version" : "2.5.1"
+        "revision" : "afc07463fc5589f5bf95f98ae2719d13ad9fbbcf",
+        "version" : "2.6.0"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/multipart-kit.git",
       "state" : {
-        "revision" : "3a31859efeb054cdcd407fe152802ddc5c58bbce",
-        "version" : "4.5.3"
+        "revision" : "1adfd69df2da08f7931d4281b257475e32c96734",
+        "version" : "4.5.4"
       }
     },
     {
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/postgres-kit.git",
       "state" : {
-        "revision" : "8ea9274633374d01bdef10da3206db74f3e261d6",
-        "version" : "2.9.1"
+        "revision" : "3ad08265aade48fff5f2ec772e96ecf51b7900a2",
+        "version" : "2.10.0"
       }
     },
     {
@@ -157,8 +157,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/sql-kit.git",
       "state" : {
-        "revision" : "fcc29f543b3de7b661cbe7540805974234cb9740",
-        "version" : "3.24.0"
+        "revision" : "d547122756534d8224d4599739da0e82e4695623",
+        "version" : "3.25.0"
       }
     },
     {
@@ -265,8 +265,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "9b2848d76f5caad08b97e71a04345aa5bdb23a06",
-        "version" : "2.49.0"
+        "revision" : "e0cc6dd6ffa8e6a6f565938acd858b24e47902d0",
+        "version" : "2.50.0"
       }
     },
     {
@@ -274,8 +274,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-extras.git",
       "state" : {
-        "revision" : "cc1e5275079380c859417dbea8588531f1a90ec3",
-        "version" : "1.18.0"
+        "revision" : "0e0d0aab665ff1a0659ce75ac003081f2b1c8997",
+        "version" : "1.19.0"
       }
     },
     {
@@ -292,8 +292,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "4fb7ead803e38949eb1d6fabb849206a72c580f3",
-        "version" : "2.23.0"
+        "revision" : "9d0d5d8798a576fbf674a823734e65e15ca5f2ec",
+        "version" : "2.23.1"
       }
     },
     {
@@ -301,8 +301,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "c0d9a144cfaec8d3d596aadde3039286a266c15c",
-        "version" : "1.15.0"
+        "revision" : "59b966415dd336db6f388bbfe3fb43cfa549b981",
+        "version" : "1.16.0"
       }
     },
     {
@@ -382,8 +382,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "ba1a308a58ba9d78c5100588d7d8b6e615a98248",
-        "version" : "4.75.0"
+        "revision" : "f4b00a5350238fe896d865d96d64f12fcbbeda95",
+        "version" : "4.76.0"
       }
     },
     {
@@ -391,8 +391,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/websocket-kit.git",
       "state" : {
-        "revision" : "2b8885974e8d9f522e787805000553f4f7cce8a0",
-        "version" : "2.7.0"
+        "revision" : "2166cbe932b29b6419f9cd751e8b27c647e1238e",
+        "version" : "2.8.0"
       }
     },
     {


### PR DESCRIPTION
The Github action that does this automatically needs an update https://github.com/MarcoEidinger/swift-package-dependencies-check/issues/16, hence the manual PR this week.

14 dependencies have changed:
~ async-http-client 1.15.0 -> async-http-client 1.17.0
~ fluent 4.7.1 -> fluent 4.8.0
~ postgres-kit 2.9.1 -> postgres-kit 2.10.0
~ vapor 4.75.0 -> vapor 4.76.0
~ async-kit 1.16.0 -> async-kit 1.17.0
~ websocket-kit 2.7.0 -> websocket-kit 2.8.0
~ sql-kit 3.24.0 -> sql-kit 3.25.0
~ multipart-kit 4.5.3 -> multipart-kit 4.5.4
~ fluent-kit 1.41.0 -> fluent-kit 1.42.0
~ swift-nio 2.49.0 -> swift-nio 2.50.0
~ fluent-postgres-driver 2.5.1 -> fluent-postgres-driver 2.6.0
~ swift-nio-extras 1.18.0 -> swift-nio-extras 1.19.0
~ swift-nio-transport-services 1.15.0 -> swift-nio-transport-services 1.16.0
~ swift-nio-ssl 2.23.0 -> swift-nio-ssl 2.23.1

Release notes URLs (updating from):
https://github.com/swift-server/async-http-client/releases (1.15.0)
https://github.com/vapor/fluent/releases (4.7.1)
https://github.com/vapor/postgres-kit/releases (2.9.1)
https://github.com/vapor/vapor/releases (4.75.0)
https://github.com/vapor/async-kit/releases (1.16.0)
https://github.com/vapor/websocket-kit/releases (2.7.0)
https://github.com/vapor/sql-kit/releases (3.24.0)
https://github.com/vapor/multipart-kit/releases (4.5.3)
https://github.com/vapor/fluent-kit/releases (1.41.0)
https://github.com/apple/swift-nio/releases (2.49.0)
https://github.com/vapor/fluent-postgres-driver/releases (2.5.1)
https://github.com/apple/swift-nio-extras/releases (1.18.0)
https://github.com/apple/swift-nio-transport-services/releases (1.15.0)
https://github.com/apple/swift-nio-ssl/releases (2.23.0)