### PR TITLE
Simplify ingestion

### DIFF
--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -68,7 +68,7 @@ func updatePackage(client: Client,
                 try await pkg.update(on: database)
             } catch {
                 logger.report(error: error)
-                try? await Current.reportError(client, .critical, error)
+                try await Current.reportError(client, .critical, error)
             }
 
         case .failure(let error) where error as? PostgresNIO.PostgresError != nil:

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -133,7 +133,11 @@ func ingest(client: Client,
                         AppMetrics.ingestMetadataFailureCount?.inc()
                 }
 
-                await updatePackage(client: client, database: database, logger: logger, result: result, stage: .ingestion)
+                do {
+                    try await updatePackage(client: client, database: database, logger: logger, result: result, stage: .ingestion)
+                } catch {
+                    logger.report(error: error)
+                }
             }
         }
     }


### PR DESCRIPTION
Addresses a holdover TODO from the ELF → a/a transition.

In ELF land, we had to make processing "wide" due to how ELF's (flat)maps work by wrapping all intermediate results in `Result` and passing them through each function via `map`/`flatMap`.

With a/a we can process this like a loop with each step just dealing with a single element but during the initial conversion it was simpler to just keep the types arranged as they were.