### PR TITLE
Include a canonical URL in all documentation pages

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -233,10 +233,11 @@ enum PackageController {
 
         let canonicalUrl: String? = {
             guard let canonicalTarget = documentationVersionMetadata.canonicalTarget else { return nil }
-            return SiteURL.relativeURL(owner: owner,
-                                       repository: repository,
-                                       documentation: canonicalTarget,
-                                       fragment: .documentation)
+            return Self.canonicalDocumentationUrl(from: "\(req.url)",
+                                                  owner: owner,
+                                                  repository: repository,
+                                                  fromReference: reference,
+                                                  toTarget: canonicalTarget)
         }()
 
 
@@ -434,6 +435,21 @@ extension PackageController {
     }
 }
 
+extension PackageController {
+    static func canonicalDocumentationUrl(from url: String,
+                                          owner: String,
+                                          repository: String,
+                                          fromReference: String,
+                                          toTarget target: DocumentationTarget) -> String? {
+        let urlPrefix = "/\(owner)/\(repository)/\(fromReference)/"
+        if case let .internal(canonicalReference, _) = target,
+           url.lowercased().hasPrefix(urlPrefix.lowercased()) {
+            return "/\(owner)/\(repository)/\(canonicalReference)/\(url.dropFirst(urlPrefix.count))"
+        } else {
+            return nil
+        }
+    }
+}
 
 private extension HTTPHeaders {
     func replacingOrAdding(name: Name, value: String) -> Self {

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -164,14 +164,14 @@ enum PackageController {
 
         switch fragment {
             case .documentation, .tutorials:
-                let documentationVersionMetadata = try await DocumentationVersionMetadata
+                let documentationMetadata = try await DocumentationVersionMetadata
                     .query(on: req.db, owner: owner, repository: repository)
 
                 return try await documentationResponse(
                     req: req,
                     archive: archive,
                     awsResponse: awsResponse,
-                    documentationVersionMetadata: documentationVersionMetadata,
+                    documentationMetadata: documentationMetadata,
                     fragment: fragment,
                     path: normalisedPath,
                     owner: owner,
@@ -195,23 +195,23 @@ enum PackageController {
     static func documentationResponse(req: Request,
                                       archive: String?,
                                       awsResponse: ClientResponse,
-                                      documentationVersionMetadata: DocumentationVersionMetadata,
+                                      documentationMetadata: DocumentationVersionMetadata,
                                       fragment: Fragment,
                                       path: String,
                                       owner: String,
                                       reference: String,
                                       repository: String) async throws -> Response {
 
-        guard let documentation = documentationVersionMetadata.versions[reference: reference]
+        guard let documentation = documentationMetadata.versions[reference: reference]
         else {
             // If there's no match for this reference with a docArchive, we're done!
             throw Abort(.notFound, reason: "No docArchives for this reference")
         }
 
         let availableDocumentationVersions: [DocumentationPageProcessor.AvailableDocumentationVersion] = ([
-            documentationVersionMetadata.versions.first { $0.latest == .defaultBranch },
-            documentationVersionMetadata.versions.first { $0.latest == .preRelease }
-        ] + documentationVersionMetadata.versions.latestMajorVersions())
+            documentationMetadata.versions.first { $0.latest == .defaultBranch },
+            documentationMetadata.versions.first { $0.latest == .preRelease }
+        ] + documentationMetadata.versions.latestMajorVersions())
             .compactMap { version in
                 guard let version = version
                 else { return nil }
@@ -232,7 +232,7 @@ enum PackageController {
         }
 
         let canonicalUrl: String? = {
-            guard let canonicalTarget = documentationVersionMetadata.canonicalTarget else { return nil }
+            guard let canonicalTarget = documentationMetadata.canonicalTarget else { return nil }
             return Self.canonicalDocumentationUrl(from: "\(req.url)",
                                                   owner: owner,
                                                   repository: repository,

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -158,10 +158,6 @@ enum PackageController {
 
         let awsResponse = try await awsResponse(client: req.client, owner: owner, repository: repository, reference: reference, fragment: fragment, path: path)
 
-        // Navigation events within Vue pages include a `.json` extension on the path, fresh page loads do not.
-#warning("Look into this. It's related to canonical URLs when navigating between pages, but may no longer be necessary.")
-        let normalisedPath = path.removingSuffix(".json")
-
         switch fragment {
             case .documentation, .tutorials:
                 let documentationMetadata = try await DocumentationMetadata
@@ -173,7 +169,7 @@ enum PackageController {
                     awsResponse: awsResponse,
                     documentationMetadata: documentationMetadata,
                     fragment: fragment,
-                    path: normalisedPath,
+                    path: path,
                     owner: owner,
                     reference: reference,
                     repository: repository

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -213,12 +213,12 @@ enum PackageController {
                 // There are versions in `documentationVersions` that have a nil `latest`, but given
                 // the filtering above they can be assumed to be release versions for display.
                 let versionKind = version.latest ?? .release
-                let isLatesStable = version.latest == .release
+                let isLatestStable = version.latest == .release
 
                 return .init(kind: versionKind,
                              reference: "\(version.reference)",
                              docArchives: version.docArchives,
-                             isLatestStable: isLatesStable)
+                             isLatestStable: isLatestStable)
             }
 
         let availableArchives: [DocumentationPageProcessor.AvailableArchive] = documentation.docArchives.map {

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -164,7 +164,7 @@ enum PackageController {
 
         switch fragment {
             case .documentation, .tutorials:
-                let documentationMetadata = try await DocumentationVersionMetadata
+                let documentationMetadata = try await DocumentationMetadata
                     .query(on: req.db, owner: owner, repository: repository)
 
                 return try await documentationResponse(
@@ -195,7 +195,7 @@ enum PackageController {
     static func documentationResponse(req: Request,
                                       archive: String?,
                                       awsResponse: ClientResponse,
-                                      documentationMetadata: DocumentationVersionMetadata,
+                                      documentationMetadata: DocumentationMetadata,
                                       fragment: Fragment,
                                       path: String,
                                       owner: String,

--- a/Sources/App/Core/DocumentationTarget.swift
+++ b/Sources/App/Core/DocumentationTarget.swift
@@ -49,7 +49,7 @@ enum DocumentationTarget: Equatable {
 
         return results
             .map(\.model)
-            .documentationTarget()
+            .canonicalDocumentationTarget()
     }
 
     /// Fetch DocumentationTarget for a specific reference. This returns an `internal` DocumentationTarget by definition, because `external` targets have no notion of references.

--- a/Sources/App/Core/DocumentationVersion.swift
+++ b/Sources/App/Core/DocumentationVersion.swift
@@ -39,10 +39,12 @@ struct DocumentationVersionMetadata {
             .field(Repository.self, \.$ownerName)
             .all()
 
-        // Filter out non `latest` versions that are fetched by the query as there
-        // may be old major versions we want to keep in the navigation menu.
-        let versions = results.map {$0.model }.filter { $0.latest != nil }
-        let canonicalDocumentationTarget = versions.documentationTarget()
+        // This query returns `Version` objects that have nil `latest` properties as we show documentation
+        // for major package versions that are *not* latest anything. There's no need to filter these records
+        // out as they are never selected by `canonicalDocumentationTarget` but it's worth being aware that
+        // this is normal and expected.
+        let versions = results.map {$0.model }
+        let canonicalDocumentationTarget = versions.canonicalDocumentationTarget()
 
         let documentationVersions = results.map { result -> DocumentationVersion in
                 .init(reference: result.model.reference,

--- a/Sources/App/Core/DocumentationVersion.swift
+++ b/Sources/App/Core/DocumentationVersion.swift
@@ -17,7 +17,7 @@ import Foundation
 import Fluent
 import SemanticVersion
 
-struct DocumentationVersionMetadata {
+struct DocumentationMetadata {
     var canonicalTarget: DocumentationTarget?
     var versions: [DocumentationVersion]
 

--- a/Sources/App/Core/Extensions/Array+Version.swift
+++ b/Sources/App/Core/Extensions/Array+Version.swift
@@ -18,56 +18,36 @@ extension [Version] {
     var preReleaseVersion: Version? { filter { $0.latest == .preRelease}.first }
     var releaseVersion: Version? { filter { $0.latest == .release}.first }
 
-    private func defaultDocumentationVersionAndTarget() -> (version: Version, docTarget: DocumentationTarget)? {
+    func canonicalDocumentationTarget() -> DocumentationTarget? {
         // External documentation links have priority over generated documentation.
-        if let version = defaultBranchVersion,
-           let spiManifest = defaultBranchVersion?.spiManifest,
+        if let spiManifest = defaultBranchVersion?.spiManifest,
            let documentation = spiManifest.externalLinks?.documentation {
-            return (version: version,
-                    docTarget: .external(url: documentation))
+            return .external(url: documentation)
         }
 
         // Ideal case is that we have a stable release documentation.
         if let version = releaseVersion,
            let archive = version.docArchives?.first?.name {
-            return (version: version,
-                    docTarget: .internal(reference: "\(version.reference)", archive: archive))
+            return .internal(reference: "\(version.reference)", archive: archive)
         }
 
         // Then a pre-release is second best.
         if let version = preReleaseVersion,
            let archive = version.docArchives?.first?.name {
-            return (version: version,
-                    docTarget: .internal(reference: "\(version.reference)", archive: archive))
+            return .internal(reference: "\(version.reference)", archive: archive)
         }
 
         // Finally, fallback to the default branch documentation.
         if let version = defaultBranchVersion,
            let archive = version.docArchives?.first?.name {
-            return (version: version,
-                    docTarget: .internal(reference: "\(version.reference)", archive: archive))
+            return .internal(reference: "\(version.reference)", archive: archive)
         }
 
         // There is no default dodcumentation.
         return nil
     }
 
-    func documentationTarget() -> DocumentationTarget? {
-        defaultDocumentationVersionAndTarget()?.docTarget
-    }
-
-    func canonicalDocumentationVersion() -> Version? {
-        switch defaultDocumentationVersionAndTarget() {
-            case .some((_, .external)), .some((_, .universal)):
-                return nil
-            case let .some((version, .internal)):
-                return version
-            case .none:
-                return nil
-        }
-    }
-
-    func hasDocumentation() -> Bool { documentationTarget() != nil }
+    func hasDocumentation() -> Bool { canonicalDocumentationTarget() != nil }
 }
 
 

--- a/Sources/App/Core/Extensions/String+ext.swift
+++ b/Sources/App/Core/Extensions/String+ext.swift
@@ -30,6 +30,14 @@ extension String {
         return self
     }
 
+    func removingSuffix(_ suffix: String) -> String {
+        if self.hasSuffix(suffix) {
+            return String(self.dropLast(suffix.count))
+        }
+        return self
+    }
+
+
     var trimmed: String? {
         let trimmedString = trimmingCharacters(in: .whitespaces)
         if trimmedString.isEmpty { return nil }

--- a/Sources/App/Core/Extensions/String+ext.swift
+++ b/Sources/App/Core/Extensions/String+ext.swift
@@ -31,7 +31,7 @@ extension String {
     }
 
     func removingSuffix(_ suffix: String) -> String {
-        if self.hasSuffix(suffix) {
+        if lowercased().hasSuffix(suffix.lowercased()) {
             return String(self.dropLast(suffix.count))
         }
         return self

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -25,6 +25,7 @@ struct DocumentationPageProcessor {
     let reference: String
     let referenceLatest: Version.Kind?
     let referenceKind: Version.Kind
+    let canonicalUrl: String?
     let availableArchives: [AvailableArchive]
     let availableVersions: [AvailableDocumentationVersion]
     let updatedAt: Date
@@ -51,6 +52,7 @@ struct DocumentationPageProcessor {
           reference: String,
           referenceLatest: Version.Kind?,
           referenceKind: Version.Kind,
+          canonicalUrl: String?,
           availableArchives: [AvailableArchive],
           availableVersions: [AvailableDocumentationVersion],
           updatedAt: Date,
@@ -62,6 +64,7 @@ struct DocumentationPageProcessor {
         self.reference = reference
         self.referenceLatest = referenceLatest
         self.referenceKind = referenceKind
+        self.canonicalUrl = canonicalUrl
         self.availableArchives = availableArchives
         self.availableVersions = availableVersions
         self.updatedAt = updatedAt
@@ -69,6 +72,14 @@ struct DocumentationPageProcessor {
         do {
             document = try SwiftSoup.parse(rawHtml)
             try document.head()?.append(self.stylesheetLink)
+            if let canonicalUrl = self.canonicalUrl {
+                try document.head()?.append(
+                    Plot.Node.link(
+                        .rel(.canonical),
+                        .href(canonicalUrl)
+                    ).render()
+                )
+            }
             try document.body()?.prepend(self.header)
             try document.body()?.append(self.footer)
             if let analyticsScript = self.analyticsScript {

--- a/Tests/AppTests/ArrayExtensionTests.swift
+++ b/Tests/AppTests/ArrayExtensionTests.swift
@@ -133,7 +133,7 @@ class ArrayExtensionTests: XCTestCase {
             [
                 Version(id: .id0, latest: .release),
                 Version(id: .id1, latest: .defaultBranch, spiManifest: .withExternalDocLink("link")),
-            ].documentationTarget(),
+            ].canonicalDocumentationTarget(),
             .external(url: "link")
         )
 
@@ -144,7 +144,7 @@ class ArrayExtensionTests: XCTestCase {
                 Version(id: .id1, latest: .defaultBranch,
                         spiManifest: .withExternalDocLink("link"),
                         docArchives: [.init(name: "foo", title: "Foo")]),
-            ].documentationTarget(),
+            ].canonicalDocumentationTarget(),
             .external(url: "link")
         )
 
@@ -155,7 +155,7 @@ class ArrayExtensionTests: XCTestCase {
                         docArchives: [.init(name: "foo", title: "Foo")]),
                 Version(id: .id1, latest: .defaultBranch,
                         spiManifest: .withExternalDocLink("link")),
-            ].documentationTarget(),
+            ].canonicalDocumentationTarget(),
             .external(url: "link")
         )
     }
@@ -166,7 +166,7 @@ class ArrayExtensionTests: XCTestCase {
             [
                 Version(id: .id0, latest: .release, reference: .tag(1, 2, 3),
                         docArchives: [.init(name: "foo", title: "Foo")]),
-            ].documentationTarget(),
+            ].canonicalDocumentationTarget(),
             .internal(reference: "1.2.3", archive: "foo")
         )
 
@@ -176,7 +176,7 @@ class ArrayExtensionTests: XCTestCase {
                 Version(id: .id0, latest: .release, reference: .tag(1, 2, 3)),
                 Version(id: .id0, latest: .defaultBranch, reference: .branch("main"),
                         docArchives: [.init(name: "foo", title: "Foo")]),
-            ].documentationTarget(),
+            ].canonicalDocumentationTarget(),
             .internal(reference: "main", archive: "foo")
         )
 
@@ -184,7 +184,7 @@ class ArrayExtensionTests: XCTestCase {
         XCTAssertEqual(
             [
                 Version(id: .id0, latest: .release, reference: .tag(1, 2, 3)),
-            ].documentationTarget(),
+            ].canonicalDocumentationTarget(),
             nil
         )
 
@@ -193,12 +193,12 @@ class ArrayExtensionTests: XCTestCase {
             [
                 Version(id: .id0, latest: .release, reference: .tag(1, 2, 3)),
                 Version(id: .id0, latest: .defaultBranch, reference: .branch("main")),
-            ].documentationTarget(),
+            ].canonicalDocumentationTarget(),
             nil
         )
 
         // Or simply no versions in array at all
-        XCTAssertEqual([Version]().documentationTarget(), nil)
+        XCTAssertEqual([Version]().canonicalDocumentationTarget(), nil)
     }
 
 }

--- a/Tests/AppTests/DocumentationPageProcessorTests.swift
+++ b/Tests/AppTests/DocumentationPageProcessorTests.swift
@@ -30,6 +30,7 @@ final class DocumentationPageProcessorTests: AppTestCase {
             .init(archive: coreArchive, isCurrent: false),
             .init(archive: signerArchive, isCurrent: true)
         ]
+#warning("Fix up the canonicalUrl in this test.")
         let processor = try XCTUnwrap(
             DocumentationPageProcessor(
                 repositoryOwner: "owner",
@@ -39,6 +40,7 @@ final class DocumentationPageProcessorTests: AppTestCase {
                 reference: "main",
                 referenceLatest: .release,
                 referenceKind: .release,
+                canonicalUrl: "TODO: Fix this up",
                 availableArchives: archives,
                 availableVersions: [
                     .init(

--- a/Tests/AppTests/DocumentationPageProcessorTests.swift
+++ b/Tests/AppTests/DocumentationPageProcessorTests.swift
@@ -30,7 +30,6 @@ final class DocumentationPageProcessorTests: AppTestCase {
             .init(archive: coreArchive, isCurrent: false),
             .init(archive: signerArchive, isCurrent: true)
         ]
-#warning("Fix up the canonicalUrl in this test.")
         let processor = try XCTUnwrap(
             DocumentationPageProcessor(
                 repositoryOwner: "owner",
@@ -40,7 +39,7 @@ final class DocumentationPageProcessorTests: AppTestCase {
                 reference: "main",
                 referenceLatest: .release,
                 referenceKind: .release,
-                canonicalUrl: "TODO: Fix this up",
+                canonicalUrl: "https://example.com/owner/repo/canonical-ref",
                 availableArchives: archives,
                 availableVersions: [
                     .init(

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -239,6 +239,31 @@ class PackageController_routesTests: AppTestCase {
         )
     }
 
+    func test_canonicalDocumentationUrl() throws {
+        // There is no canonical URL for external or universal cases of the canonical target.
+        XCTAssertNil(PackageController.canonicalDocumentationUrl(from: "", owner: "", repository: "", fromReference: "",
+                                                                 toTarget: .external(url: "https://example.com")))
+
+        XCTAssertNil(PackageController.canonicalDocumentationUrl(from: "", owner: "", repository: "", fromReference: "",
+                                                                 toTarget: .universal))
+
+        // There should be no canonical URL if the package owner/repo/ref prefix doesn't match even with a valid canonical target.
+        XCTAssertNil(PackageController.canonicalDocumentationUrl(from: "/some/random/url/without/matching/prefix",
+                                                                 owner: "owner", repository: "repo", fromReference: "non-canonical-ref",
+                                                                 toTarget: .internal(reference: "canonical-ref", archive: "archive")))
+
+        // Switching a non-canonical reference for a canonical one at the root of the documentation
+        XCTAssertEqual(PackageController.canonicalDocumentationUrl(from: "/owner/repo/non-canonical-ref/documentation/archive",
+                                                                   owner: "owner", repository: "repo", fromReference: "non-canonical-ref",
+                                                                   toTarget: .internal(reference: "canonical-ref", archive: "archive")),
+                       "/owner/repo/canonical-ref/documentation/archive")
+
+        XCTAssertEqual(PackageController.canonicalDocumentationUrl(from: "/owner/repo/non-canonical-ref/documentation/archive/symbol:$-%",
+                                                                   owner: "owner", repository: "repo", fromReference: "non-canonical-ref",
+                                                                   toTarget: .internal(reference: "canonical-ref", archive: "archive")),
+                       "/owner/repo/canonical-ref/documentation/archive/symbol:$-%")
+    }
+
     func test_defaultDocumentation() throws {
         // setup
         let pkg = try savePackage(on: app.db, "1")

--- a/Tests/AppTests/StringExtTests.swift
+++ b/Tests/AppTests/StringExtTests.swift
@@ -53,4 +53,14 @@ final class StringExtTests: XCTestCase {
         XCTAssertEqual(" string ".trimmed, "string")
         XCTAssertEqual("string".trimmed, "string")
     }
+
+    func test_removingSuffix() throws {
+        XCTAssertEqual("".removingSuffix(""), "")
+        XCTAssertEqual("".removingSuffix("bob"), "")
+        XCTAssertEqual("bob".removingSuffix("bob"), "")
+        XCTAssertEqual("bobby and bob".removingSuffix("bob"), "bobby and ")
+        XCTAssertEqual("bobby and bob ".removingSuffix("bob"), "bobby and bob ")
+        XCTAssertEqual("Bobby and Bob".removingSuffix("bob"), "Bobby and ")
+        XCTAssertEqual("bobby and bob".removingSuffix("Bob"), "bobby and ")
+    }
 }

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -431,7 +431,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  reference: "main",
                                                                  referenceLatest: .release,
                                                                  referenceKind: .release,
-                                                                 canonicalUrl: "https://example.com/owner/repo/canonical-ref",
+                                                                 canonicalUrl: nil,
                                                                  availableArchives: [
                                                                     .init(archive: archive, isCurrent: true)
                                                                  ],

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -424,6 +424,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         let doccTemplatePath = fixturesDirectory().appendingPathComponent("docc-template.html").path
         let doccHtml = try String(contentsOfFile: doccTemplatePath)
         let archive = DocArchive(name: "archive1", title: "Archive1")
+#warning("Fix up the canonicalUrl in the snapshot test.")
         let processor = try XCTUnwrap(DocumentationPageProcessor(repositoryOwner: "owner",
                                                                  repositoryOwnerName: "Owner Name",
                                                                  repositoryName: "package",
@@ -431,6 +432,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  reference: "main",
                                                                  referenceLatest: .release,
                                                                  referenceKind: .release,
+                                                                 canonicalUrl: "TODO: Fix this up",
                                                                  availableArchives: [
                                                                     .init(archive: archive, isCurrent: true)
                                                                  ],
@@ -450,6 +452,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         let doccTemplatePath = fixturesDirectory().appendingPathComponent("docc-template.html").path
         let doccHtml = try String(contentsOfFile: doccTemplatePath)
         let archive = DocArchive(name: "archive1", title: "Archive1")
+#warning("Fix up the canonicalUrl in the snapshot test.")
         let processor = try XCTUnwrap(DocumentationPageProcessor(repositoryOwner: "owner",
                                                                  repositoryOwnerName: "Owner Name",
                                                                  repositoryName: "package",
@@ -457,6 +460,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  reference: "1.1.0",
                                                                  referenceLatest: nil,
                                                                  referenceKind: .release,
+                                                                 canonicalUrl: "TODO: Fix this up",
                                                                  availableArchives: [
                                                                     .init(archive: archive, isCurrent: true)
                                                                  ],
@@ -481,6 +485,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         let doccHtml = try String(contentsOfFile: doccTemplatePath)
         let archive1 = DocArchive(name: "archive1", title: "Archive1")
         let archive2 = DocArchive(name: "archive2", title: "Archive2")
+#warning("Fix up the canonicalUrl in the snapshot test.")
         let processor = try XCTUnwrap(DocumentationPageProcessor(repositoryOwner: "owner",
                                                                  repositoryOwnerName: "Owner Name",
                                                                  repositoryName: "package",
@@ -488,6 +493,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  reference: "main",
                                                                  referenceLatest: .defaultBranch,
                                                                  referenceKind: .defaultBranch,
+                                                                 canonicalUrl: "TODO: Fix this up",
                                                                  availableArchives: [
                                                                     .init(archive: archive1, isCurrent: true),
                                                                     .init(archive: archive2, isCurrent: false),

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -424,7 +424,6 @@ class WebpageSnapshotTests: SnapshotTestCase {
         let doccTemplatePath = fixturesDirectory().appendingPathComponent("docc-template.html").path
         let doccHtml = try String(contentsOfFile: doccTemplatePath)
         let archive = DocArchive(name: "archive1", title: "Archive1")
-#warning("Fix up the canonicalUrl in the snapshot test.")
         let processor = try XCTUnwrap(DocumentationPageProcessor(repositoryOwner: "owner",
                                                                  repositoryOwnerName: "Owner Name",
                                                                  repositoryName: "package",
@@ -432,7 +431,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  reference: "main",
                                                                  referenceLatest: .release,
                                                                  referenceKind: .release,
-                                                                 canonicalUrl: "TODO: Fix this up",
+                                                                 canonicalUrl: "https://example.com/owner/repo/canonical-ref",
                                                                  availableArchives: [
                                                                     .init(archive: archive, isCurrent: true)
                                                                  ],
@@ -452,7 +451,6 @@ class WebpageSnapshotTests: SnapshotTestCase {
         let doccTemplatePath = fixturesDirectory().appendingPathComponent("docc-template.html").path
         let doccHtml = try String(contentsOfFile: doccTemplatePath)
         let archive = DocArchive(name: "archive1", title: "Archive1")
-#warning("Fix up the canonicalUrl in the snapshot test.")
         let processor = try XCTUnwrap(DocumentationPageProcessor(repositoryOwner: "owner",
                                                                  repositoryOwnerName: "Owner Name",
                                                                  repositoryName: "package",
@@ -460,7 +458,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  reference: "1.1.0",
                                                                  referenceLatest: nil,
                                                                  referenceKind: .release,
-                                                                 canonicalUrl: "TODO: Fix this up",
+                                                                 canonicalUrl: "https://example.com/owner/repo/canonical-ref",
                                                                  availableArchives: [
                                                                     .init(archive: archive, isCurrent: true)
                                                                  ],
@@ -485,7 +483,6 @@ class WebpageSnapshotTests: SnapshotTestCase {
         let doccHtml = try String(contentsOfFile: doccTemplatePath)
         let archive1 = DocArchive(name: "archive1", title: "Archive1")
         let archive2 = DocArchive(name: "archive2", title: "Archive2")
-#warning("Fix up the canonicalUrl in the snapshot test.")
         let processor = try XCTUnwrap(DocumentationPageProcessor(repositoryOwner: "owner",
                                                                  repositoryOwnerName: "Owner Name",
                                                                  repositoryName: "package",
@@ -493,7 +490,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
                                                                  reference: "main",
                                                                  referenceLatest: .defaultBranch,
                                                                  referenceKind: .defaultBranch,
-                                                                 canonicalUrl: "TODO: Fix this up",
+                                                                 canonicalUrl: "https://example.com/owner/repo/canonical-ref",
                                                                  availableArchives: [
                                                                     .init(archive: archive1, isCurrent: true),
                                                                     .init(archive: archive2, isCurrent: false),

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
+  <link rel="canonical" href="TODO: Fix this up">
  </head> 
  <body>
   <header class="spi">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
@@ -7,7 +7,6 @@
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
-  <link rel="canonical" href="https://example.com/owner/repo/canonical-ref">
  </head> 
  <body>
   <header class="spi">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
-  <link rel="canonical" href="TODO: Fix this up">
+  <link rel="canonical" href="https://example.com/owner/repo/canonical-ref">
  </head> 
  <body>
   <header class="spi">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
+  <link rel="canonical" href="TODO: Fix this up">
  </head> 
  <body>
   <header class="spi">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
-  <link rel="canonical" href="TODO: Fix this up">
+  <link rel="canonical" href="https://example.com/owner/repo/canonical-ref">
  </head> 
  <body>
   <header class="spi">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
+  <link rel="canonical" href="TODO: Fix this up">
  </head> 
  <body>
   <header class="spi">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
-  <link rel="canonical" href="TODO: Fix this up">
+  <link rel="canonical" href="https://example.com/owner/repo/canonical-ref">
  </head> 
  <body>
   <header class="spi">


### PR DESCRIPTION
This is WIP as it still needs the remainder of the path appended on the end of the canonical URL but I wanted to open the PR now as I feel like the back of it is broken now 😅