### PR TITLE
Fix up /api/package-collections body ambiguity

### DIFF
--- a/Sources/App/Controllers/API/Types+WithExample.swift
+++ b/Sources/App/Controllers/API/Types+WithExample.swift
@@ -76,15 +76,12 @@ extension SignificantBuilds: WithExample {
 import PackageCollectionsModel
 
 
-extension API.PostPackageCollectionOwnerDTO: WithExample {
+extension API.PostPackageCollectionDTO: WithExample {
     static var example: Self {
-        .init(owner: "mona")
-    }
-}
-
-extension API.PostPackageCollectionPackageUrlsDTO: WithExample {
-    static var example: Self {
-        .init(packageUrls: ["https://github.com/mona/LinkedList.git"])
+        .init(selection: .packageURLs(["https://github.com/mona/LinkedList.git"]),
+              collectionName: "LinkedList collection",
+              overview: "This is a package collection created for demonstration purposes.",
+              revision: 3)
     }
 }
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -214,9 +214,7 @@ func routes(_ app: Application) throws {
             .openAPI(
                 summary: "/api/package-collections",
                 description: "Generate a signed package collection.",
-                body: API.PostPackageCollectionOwnerDTO.example,
-                // TODO: fix/improve API or fix the annotation. We accept two different post body types but the annotation doesn't allow us to express that.
-                //  body: API.PostPackageCollectionPackageUrlsDTO.example,
+                body: API.PostPackageCollectionDTO.example,
                 response: SignedCollection.example,
                 responseType: .application(.json),
                 errorDescriptions: [

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -622,11 +622,15 @@ class ApiTests: AppTestCase {
                 {
                   "revision": 3,
                   "authorName": "author",
-                  "owner": "foo",
                   "keywords": [
                     "a",
                     "b"
                   ],
+                  "selection": {
+                    "author": {
+                      "_0": "foo"
+                    }
+                  },
                   "collectionName": "my collection",
                   "overview": "my overview"
                 }
@@ -698,9 +702,13 @@ class ApiTests: AppTestCase {
                     "a",
                     "b"
                   ],
-                  "packageUrls": [
-                    "1"
-                  ],
+                  "selection": {
+                    "packageURLs": {
+                      "_0": [
+                        "1"
+                      ]
+                    }
+                  },
                   "collectionName": "my collection",
                   "overview": "my overview"
                 }
@@ -720,9 +728,9 @@ class ApiTests: AppTestCase {
     }
 
     func test_package_collection_packageURLs_limit() throws {
-        let dto = API.PostPackageCollectionPackageUrlsDTO(
+        let dto = API.PostPackageCollectionDTO(
             // request 21 urls - this should raise a 400
-            packageUrls: (0...20).map(String.init)
+            selection: .packageURLs((0...20).map(String.init))
         )
         let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
 


### PR DESCRIPTION
This is a dev-env-only preview API, so changes here aren't breaking anything.

We could also ditch it entirely but I believe it could be a useful API to expose at some point.