### PR TITLE
Package update

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -274,8 +274,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "e0cc6dd6ffa8e6a6f565938acd858b24e47902d0",
-        "version" : "2.50.0"
+        "revision" : "f7c46552983b06b0958a1a4c8bc5199406ae4c8a",
+        "version" : "2.51.0"
       }
     },
     {
@@ -301,8 +301,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl.git",
       "state" : {
-        "revision" : "9d0d5d8798a576fbf674a823734e65e15ca5f2ec",
-        "version" : "2.23.1"
+        "revision" : "e866a626e105042a6a72a870c88b4c531ba05f83",
+        "version" : "2.24.0"
       }
     },
     {
@@ -310,8 +310,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-transport-services.git",
       "state" : {
-        "revision" : "59b966415dd336db6f388bbfe3fb43cfa549b981",
-        "version" : "1.16.0"
+        "revision" : "41f4098903878418537020075a4d8a6e20a0b182",
+        "version" : "1.17.0"
       }
     },
     {

--- a/app.yml
+++ b/app.yml
@@ -118,7 +118,7 @@ services:
       - migrate
     entrypoint: ["/bin/bash"]
     command: ["-c", "--",
-      "trap : TERM INT; while true; do env LOG_LEVEL=debug ./Run analyze --env ${ENV} --limit ${ANALYZE_LIMIT:-25}; sleep ${ANALYZE_SLEEP:-20}; done"
+      "trap : TERM INT; while true; do ./Run analyze --env ${ENV} --limit ${ANALYZE_LIMIT:-25}; sleep ${ANALYZE_SLEEP:-20}; done"
     ]
     deploy:
       resources:

--- a/mon.yml
+++ b/mon.yml
@@ -20,7 +20,7 @@ services:
 
   grafana:
     # https://github.com/grafana/grafana/releases
-    image: grafana/grafana:9.4.7
+    image: grafana/grafana:9.5.1
     environment:
       GF_SECURITY_ADMIN_PASSWORD: ${GF_SECURITY_ADMIN_PASSWORD}
       GF_USERS_ALLOW_SIGN_UP: 'false'
@@ -42,7 +42,7 @@ services:
 
   loki:
     # https://github.com/grafana/loki/releases
-    image: grafana/loki:2.8.0
+    image: grafana/loki:2.8.1
     command: -config.file=/loki.yml
     configs:
       - source: loki_cfg
@@ -54,7 +54,7 @@ services:
   promtail:
     # https://github.com/grafana/loki/releases
     # (promtail is released in parallel with loki)
-    image: grafana/promtail:2.8.0
+    image: grafana/promtail:2.8.1
     command: -config.file=/promtail.yml
     configs:
       - source: promtail_cfg


### PR DESCRIPTION
3 dependencies have changed:
~ swift-nio-ssl 2.23.1 -> swift-nio-ssl 2.24.0
~ swift-nio 2.50.0 -> swift-nio 2.51.0
~ swift-nio-transport-services 1.16.0 -> swift-nio-transport-services 1.17.0

Release notes URLs (updating from):
https://github.com/apple/swift-nio-ssl/releases (2.23.1)
https://github.com/apple/swift-nio/releases (2.50.0)
https://github.com/apple/swift-nio-transport-services/releases (1.16.0)