### PR TITLE
Run git revision info with GNUTLS_CPUID_OVERRIDE=0x1

### DIFF
--- a/Sources/App/Core/Extensions/ShellOutCommand+ext.swift
+++ b/Sources/App/Core/Extensions/ShellOutCommand+ext.swift
@@ -56,9 +56,13 @@ extension ShellOutCommand {
     }
 
     static func gitRevisionInfo(reference: Reference, separator: String = "-") -> Self {
-        .init(command: .git, arguments: ["log", "-n1",
-                                         #"--format=format:"%H\#(separator.quoted)%ct""#.verbatim,
-                                         "\(reference)".quoted])
+        .init(command: .env,
+              arguments: [
+                "GNUTLS_CPUID_OVERRIDE=0x1".verbatim,
+                "git", "log", "-n1",
+                #"--format=format:"%H\#(separator.quoted)%ct""#.verbatim,
+                "\(reference)".quoted
+              ])
 
     }
 
@@ -87,6 +91,7 @@ extension ShellOutCommand {
 
 
 extension SafeString {
+    static let env = "env".unchecked
     static let git = "git".unchecked
     static let swift = "swift".unchecked
 }

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -1206,7 +1206,7 @@ private struct Command: CustomStringConvertible {
                 self.kind = .shortlog
             case _ where command.string.starts(with: #"git show -s --format=%ct"#):
                 self.kind = .showDate
-            case _ where command.string.starts(with: #"git log -n1 --format=format:"%H\#(separator)%ct""#):
+            case _ where command.string.starts(with: #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H\#(separator)%ct""#):
                 let ref = String(command.string.split(separator: " ").last!)
                     .trimmingCharacters(in: quotes)
                 self.kind = .revisionInfo(ref)

--- a/Tests/AppTests/GitTests.swift
+++ b/Tests/AppTests/GitTests.swift
@@ -66,7 +66,7 @@ class GitTests: XCTestCase {
 
     func test_revInfo() throws {
         Current.shell.run = { cmd, _ in
-            if cmd.string == #"git log -n1 --format=format:"%H-%ct" 2.2.1"# {
+            if cmd.string == #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H-%ct" 2.2.1"# {
                 return "63c973f3c2e632a340936c285e94d59f9ffb01d5-1536799579"
             }
             throw TestError.unknownCommand
@@ -80,7 +80,7 @@ class GitTests: XCTestCase {
         // Ensure we look up by tag name and not semver
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/139
         Current.shell.run = { cmd, _ in
-            if cmd.string == #"git log -n1 --format=format:"%H-%ct" v2.2.1"# {
+            if cmd.string == #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H-%ct" v2.2.1"# {
                 return "63c973f3c2e632a340936c285e94d59f9ffb01d5-1536799579"
             }
             throw TestError.unknownCommand

--- a/Tests/AppTests/ShellOutCommandExtensionTests.swift
+++ b/Tests/AppTests/ShellOutCommandExtensionTests.swift
@@ -61,17 +61,17 @@ class ShellOutCommandExtensionTests: XCTestCase {
         XCTAssertEqual(
             ShellOutCommand
                 .gitRevisionInfo(reference: .tag(1, 2, 3), separator: dash).string,
-            #"git log -n1 --format=format:"%H\#(dash)%ct" 1.2.3"#
+            #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H\#(dash)%ct" 1.2.3"#
         )
         XCTAssertEqual(
             ShellOutCommand
                 .gitRevisionInfo(reference: .branch("foo"), separator: dash).string,
-            #"git log -n1 --format=format:"%H\#(dash)%ct" foo"#
+            #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H\#(dash)%ct" foo"#
         )
         XCTAssertEqual(
             ShellOutCommand
                 .gitRevisionInfo(reference: .branch("ba\nd"), separator: dash).string,
-            "git log -n1 --format=format:\"%H\(dash)%ct\" 'ba\nd'"
+            "env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:\"%H\(dash)%ct\" 'ba\nd'"
         )
     }
 
@@ -91,7 +91,7 @@ class ShellOutCommandExtensionTests: XCTestCase {
         )
         XCTAssertEqual(
             ShellOutCommand.gitRevisionInfo(reference: .branch("foo ; rm *")).string,
-            #"git log -n1 --format=format:"%H-%ct" 'foo ; rm *'"#
+            #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H-%ct" 'foo ; rm *'"#
         )
         XCTAssertEqual(
             ShellOutCommand.gitShowDate("foo ; rm *").string,


### PR DESCRIPTION
There are a number of git commands being referenced in the #2227 `signal 4` crashes (by line number):

```
Core/Git.swift:29
Core/Git.swift:45
Core/Git.swift:53
Core/Git.swift:70 // revision info
Core/Git.swift:81
```

Line 70 is revision info, which this PR prefixes with `env GNUTLS_CPUID_OVERRIDE=0x1` in an attempt to address it. If this works, this source (actually the most common one it seems) should disappear from the logs after deployment.

We can then look into addressing the others.