### PR TITLE
Revert "Merge pull request #2380 from SwiftPackageIndex/issue-2227-signal-4

### DIFF
--- a/Sources/App/Core/Extensions/ShellOutCommand+ext.swift
+++ b/Sources/App/Core/Extensions/ShellOutCommand+ext.swift
@@ -56,13 +56,9 @@ extension ShellOutCommand {
     }
 
     static func gitRevisionInfo(reference: Reference, separator: String = "-") -> Self {
-        .init(command: .env,
-              arguments: [
-                "GNUTLS_CPUID_OVERRIDE=0x1".verbatim,
-                "git", "log", "-n1",
-                #"--format=format:"%H\#(separator.quoted)%ct""#.verbatim,
-                "\(reference)".quoted
-              ])
+        .init(command: .git, arguments: ["log", "-n1",
+                                         #"--format=format:"%H\#(separator.quoted)%ct""#.verbatim,
+                                         "\(reference)".quoted])
 
     }
 
@@ -91,7 +87,6 @@ extension ShellOutCommand {
 
 
 extension SafeString {
-    static let env = "env".unchecked
     static let git = "git".unchecked
     static let swift = "swift".unchecked
 }

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -1206,7 +1206,7 @@ private struct Command: CustomStringConvertible {
                 self.kind = .shortlog
             case _ where command.string.starts(with: #"git show -s --format=%ct"#):
                 self.kind = .showDate
-            case _ where command.string.starts(with: #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H\#(separator)%ct""#):
+            case _ where command.string.starts(with: #"git log -n1 --format=format:"%H\#(separator)%ct""#):
                 let ref = String(command.string.split(separator: " ").last!)
                     .trimmingCharacters(in: quotes)
                 self.kind = .revisionInfo(ref)

--- a/Tests/AppTests/GitTests.swift
+++ b/Tests/AppTests/GitTests.swift
@@ -66,7 +66,7 @@ class GitTests: XCTestCase {
 
     func test_revInfo() throws {
         Current.shell.run = { cmd, _ in
-            if cmd.string == #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H-%ct" 2.2.1"# {
+            if cmd.string == #"git log -n1 --format=format:"%H-%ct" 2.2.1"# {
                 return "63c973f3c2e632a340936c285e94d59f9ffb01d5-1536799579"
             }
             throw TestError.unknownCommand
@@ -80,7 +80,7 @@ class GitTests: XCTestCase {
         // Ensure we look up by tag name and not semver
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/139
         Current.shell.run = { cmd, _ in
-            if cmd.string == #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H-%ct" v2.2.1"# {
+            if cmd.string == #"git log -n1 --format=format:"%H-%ct" v2.2.1"# {
                 return "63c973f3c2e632a340936c285e94d59f9ffb01d5-1536799579"
             }
             throw TestError.unknownCommand

--- a/Tests/AppTests/ShellOutCommandExtensionTests.swift
+++ b/Tests/AppTests/ShellOutCommandExtensionTests.swift
@@ -61,17 +61,17 @@ class ShellOutCommandExtensionTests: XCTestCase {
         XCTAssertEqual(
             ShellOutCommand
                 .gitRevisionInfo(reference: .tag(1, 2, 3), separator: dash).string,
-            #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H\#(dash)%ct" 1.2.3"#
+            #"git log -n1 --format=format:"%H\#(dash)%ct" 1.2.3"#
         )
         XCTAssertEqual(
             ShellOutCommand
                 .gitRevisionInfo(reference: .branch("foo"), separator: dash).string,
-            #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H\#(dash)%ct" foo"#
+            #"git log -n1 --format=format:"%H\#(dash)%ct" foo"#
         )
         XCTAssertEqual(
             ShellOutCommand
                 .gitRevisionInfo(reference: .branch("ba\nd"), separator: dash).string,
-            "env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:\"%H\(dash)%ct\" 'ba\nd'"
+            "git log -n1 --format=format:\"%H\(dash)%ct\" 'ba\nd'"
         )
     }
 
@@ -91,7 +91,7 @@ class ShellOutCommandExtensionTests: XCTestCase {
         )
         XCTAssertEqual(
             ShellOutCommand.gitRevisionInfo(reference: .branch("foo ; rm *")).string,
-            #"env GNUTLS_CPUID_OVERRIDE=0x1 git log -n1 --format=format:"%H-%ct" 'foo ; rm *'"#
+            #"git log -n1 --format=format:"%H-%ct" 'foo ; rm *'"#
         )
         XCTAssertEqual(
             ShellOutCommand.gitShowDate("foo ; rm *").string,


### PR DESCRIPTION
This reverts commit 3f51d4e8eed4bdf07dc3e954e700b41fa3461d9a, reversing changes made to fbcae7ac09cded7c6033c5422b49756d391b3f05.

`.../Core/Git.swift:70` still appearing among the crashes, this env variable does nothing. Was worth a shot.

```
2023-05-10T15:06:06.726525885Z Received signal 4. Backtrace:
2023-05-10T15:06:06.961157364Z 0x5629cd0c9292, Backtrace.(printBacktrace in _B82A8C0ED7C904841114FDF244F9E58E)(signal: Swift.Int32) -> () at /build/.build/checkouts/swift-backtrace/Sources/Backtrace/Backtrace.swift:66
2023-05-10T15:06:06.961242766Z 0x5629cd0c9507, closure #1 (Swift.Int32) -> () in static Backtrace.Backtrace.install(signals: Swift.Array<Swift.Int32>) -> () at /build/.build/checkouts/swift-backtrace/Sources/Backtrace/Backtrace.swift:80
2023-05-10T15:06:06.961252166Z 0x5629cd0c9507, @objc closure #1 (Swift.Int32) -> () in static Backtrace.Backtrace.install(signals: Swift.Array<Swift.Int32>) -> () at /build/<compiler-generated>:79
2023-05-10T15:06:06.961267867Z 0x7f3ac156441f
2023-05-10T15:06:06.961271367Z 0x5629ce0e59d1
2023-05-10T15:06:06.961802978Z 0x5629cdb07be9, closure #4 () throws -> Swift.String in (extension in ShellOut):Foundation.Process.(launchBash in _839723A297212BDF262C1834C3E29C1F)(with: Swift.String, outputHandle: Swift.Optional<Foundation.FileHand
le>, errorHandle: Swift.Optional<Foundation.FileHandle>, environment: Swift.Optional<Swift.Dictionary<Swift.String, Swift.String>>) throws -> Swift.String at /build/.build/checkouts/ShellOut/Sources/ShellOut.swift:476
2023-05-10T15:06:06.961823278Z 0x5629cdb08a01, partial apply forwarder for closure #4 () throws -> Swift.String in (extension in ShellOut):Foundation.Process.(launchBash in _839723A297212BDF262C1834C3E29C1F)(with: Swift.String, outputHandle: Swift.
Optional<Foundation.FileHandle>, errorHandle: Swift.Optional<Foundation.FileHandle>, environment: Swift.Optional<Swift.Dictionary<Swift.String, Swift.String>>) throws -> Swift.String at /build/<compiler-generated>:0
2023-05-10T15:06:06.961865579Z 0x5629cdefd4bb
2023-05-10T15:06:06.961871880Z 0x5629cdefc2e5
2023-05-10T15:06:06.961876080Z 0x5629cdf0063b
2023-05-10T15:06:06.961879380Z 0x5629cdef7068
2023-05-10T15:06:06.961882680Z 0x5629cdf142e9
2023-05-10T15:06:06.961886080Z 0x5629cdf000c1
2023-05-10T15:06:06.961889280Z 0x5629cdefc1ab
2023-05-10T15:06:06.961892680Z 0x5629cdefc5f4
2023-05-10T15:06:06.961895980Z 0x5629cdb04b1e, (extension in ShellOut):Foundation.Process.(launchBash in _839723A297212BDF262C1834C3E29C1F)(with: Swift.String, outputHandle: Swift.Optional<Foundation.FileHandle>, errorHandle: Swift.Optional<Foundat
ion.FileHandle>, environment: Swift.Optional<Swift.Dictionary<Swift.String, Swift.String>>) throws -> Swift.String at /build/.build/checkouts/ShellOut/Sources/ShellOut.swift:475
2023-05-10T15:06:06.961900680Z 0x5629cdb04d92, ShellOut.shellOut(to: ShellOut.SafeString, arguments: Swift.Array<ShellOut.Argument>, at: Swift.String, process: Foundation.Process, outputHandle: Swift.Optional<Foundation.FileHandle>, errorHandle: Sw
ift.Optional<Foundation.FileHandle>, environment: Swift.Optional<Swift.Dictionary<Swift.String, Swift.String>>) throws -> Swift.String at /build/.build/checkouts/ShellOut/Sources/ShellOut.swift:42
2023-05-10T15:06:06.961904980Z 0x5629cdb04d92, ShellOut.shellOut(to: ShellOut.ShellOutCommand, at: Swift.String, process: Foundation.Process, outputHandle: Swift.Optional<Foundation.FileHandle>, errorHandle: Swift.Optional<Foundation.FileHandle>, e
nvironment: Swift.Optional<Swift.Dictionary<Swift.String, Swift.String>>) throws -> Swift.String at /build/.build/checkouts/ShellOut/Sources/ShellOut.swift:76
2023-05-10T15:06:06.962248688Z 0x5629ccd5ee87, closure #1 (ShellOut.ShellOutCommand, Swift.String) throws -> Swift.String in variable initialization expression of static App.Shell.live : App.Shell at /build/Sources/App/Core/AppEnvironment.swift:282
2023-05-10T15:06:06.962440092Z 0x5629ccd8aec4, App.Shell.run(command: ShellOut.ShellOutCommand, at: Swift.String) throws -> Swift.String at Sources/App/Core/AppEnvironment.swift:274
2023-05-10T15:06:06.962488993Z 0x5629ccd8aec4, function signature specialization <Arg[2] = Dead> of static App.Git.revisionInfo(_: App.Reference, at: Swift.String) throws -> App.Git.RevisionInfo at /build/Sources/App/Core/Git.swift:70
2023-05-10T15:06:06.962503393Z 0x5629ccd5edf5, static App.Git.revisionInfo(_: App.Reference, at: Swift.String) throws -> App.Git.RevisionInfo at /build/Sources/App/Core/AppEnvironment.swift:0
2023-05-10T15:06:06.962507193Z 0x5629ccd5edf5, implicit closure #6 (App.Reference, Swift.String) throws -> App.Git.RevisionInfo in variable initialization expression of static App.Git.live : App.Git at /build/Sources/App/Core/AppEnvironment.swift:262
2023-05-10T15:06:06.963991825Z 0x5629ccce8e63, closure #3 (App.Reference) throws -> App.Version in static App.Analyze.getIncomingVersions(client: Vapor.Client, logger: Logging.Logger, package: App.Joined<App.Package, App.Repository>) async throws -> Swift.Array<App.Version> at /build/Sources/App/Commands/Analyze.swift:421
2023-05-10T15:06:06.964052826Z 0x5629ccce8e63, function signature specialization <Arg[1] = Owned To Guaranteed, Arg[2] = Owned To Guaranteed> of function signature specialization <Arg[0] = [Closure Propagated : closure #3 (App.Reference) throws -> App.Version in static App.Analyze.getIncomingVersions(client: Vapor.Client, logger: Logging.Logger, package: App.Joined<App.Package, App.Repository>) async throws -> Swift.Array<App.Version>, Argument Types : [Swift.StringApp.Joined<App.Package, App.Repository>]> of generic specialization <Swift.Array<App.Reference>, App.Version> of (extension in Swift):Swift.Collection.map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1> at /build/<compiler-generated>:0
2023-05-10T15:06:06.964061526Z 0x5629cccec28f, function signature specialization <Arg[0] = [Closure Propagated : closure #3 (App.Reference) throws -> App.Version in static App.Analyze.getIncomingVersions(client: Vapor.Client, logger: Logging.Logger, package: App.Joined<App.Package, App.Repository>) async throws -> Swift.Array<App.Version>, Argument Types : [Swift.StringApp.Joined<App.Package, App.Repository>]> of generic specialization <Swift.Array<App.Reference>, App.Version> of (extension in Swift):Swift.Collection.map<A>((A.Element) throws -> A1) throws -> Swift.Array<A1> at /build/<compiler-generated>:0
2023-05-10T15:06:06.964085227Z 0x5629cccec28f, (1) suspend resume partial function for function signature specialization <Arg[3] = Dead> of static App.Analyze.getIncomingVersions(client: Vapor.Client, logger: Logging.Logger, package: App.Joined<App.Package, App.Repository>) async throws -> Swift.Array<App.Version> at /build/Sources/App/Commands/Analyze.swift:420
```