### PR TITLE
Query decoding

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -188,7 +188,7 @@ extension Analyze {
                                  results: packageResults,
                                  stage: .analysis)
 
-        try await RecentPackage.refresh(on: database).get()
+        try await RecentPackage.refresh(on: database)
         try await RecentRelease.refresh(on: database).get()
         try await Search.refresh(on: database).get()
         try await Stats.refresh(on: database).get()

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -189,7 +189,7 @@ extension Analyze {
                                  stage: .analysis)
 
         try await RecentPackage.refresh(on: database)
-        try await RecentRelease.refresh(on: database).get()
+        try await RecentRelease.refresh(on: database)
         try await Search.refresh(on: database).get()
         try await Stats.refresh(on: database).get()
         try await WeightedKeyword.refresh(on: database).get()

--- a/Sources/App/Core/Extensions/RSS+ResponseEncodable.swift
+++ b/Sources/App/Core/Extensions/RSS+ResponseEncodable.swift
@@ -16,10 +16,10 @@ import Plot
 import Vapor
 
 
-extension RSS: ResponseEncodable {
-    public func encodeResponse(for request: Request) -> EventLoopFuture<Response> {
+extension RSS: AsyncResponseEncodable {
+    public func encodeResponse(for request: Vapor.Request) async throws -> Vapor.Response {
         let res = Response(status: .ok, body: .init(string: self.render()))
         res.headers.add(name: "Content-Type", value: "application/rss+xml; charset=utf-8")
-        return request.eventLoop.makeSucceededFuture(res)
+        return res
     }
 }

--- a/Sources/App/Core/Extensions/RSS+ResponseEncodable.swift
+++ b/Sources/App/Core/Extensions/RSS+ResponseEncodable.swift
@@ -17,7 +17,7 @@ import Vapor
 
 
 extension RSS: AsyncResponseEncodable {
-    public func encodeResponse(for request: Vapor.Request) async throws -> Vapor.Response {
+    public func encodeResponse(for request: Request) async throws -> Response {
         let res = Response(status: .ok, body: .init(string: self.render()))
         res.headers.add(name: "Content-Type", value: "application/rss+xml; charset=utf-8")
         return res

--- a/Sources/App/Core/RSS.swift
+++ b/Sources/App/Core/RSS.swift
@@ -73,7 +73,6 @@ extension RSSFeed {
     static func recentPackages(on database: Database,
                                limit: Int = Constants.rssFeedMaxItemCount) async throws -> Self {
         let items = try await RecentPackage.fetch(on: database, limit: limit)
-            .get()
             .map(\.rssItem)
         return RSSFeed(title: "Swift Package Index – Recently Added",
                         description: "List of recently added Swift packages",

--- a/Sources/App/Core/RSS.swift
+++ b/Sources/App/Core/RSS.swift
@@ -84,7 +84,6 @@ extension RSSFeed {
                                limit: Int = Constants.rssFeedMaxItemCount,
                                filter: RecentRelease.Filter = .all) async throws -> Self {
         let items = try await RecentRelease.fetch(on: database, limit: limit, filter: filter)
-            .get()
             .map(\.rssItem)
         return RSSFeed(title: "Swift Package Index – Recent Releases",
                        description: "List of recent Swift packages releases",

--- a/Sources/App/Core/RecentPackage.swift
+++ b/Sources/App/Core/RecentPackage.swift
@@ -48,11 +48,11 @@ extension RecentPackage {
 
 
     static func fetch(on database: Database,
-                      limit: Int = Constants.recentPackagesLimit) -> EventLoopFuture<[RecentPackage]> {
+                      limit: Int = Constants.recentPackagesLimit) async throws -> [RecentPackage] {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
-        return db.raw("SELECT * FROM \(raw: Self.schema) ORDER BY created_at DESC LIMIT \(bind: limit)")
+        return try await db.raw("SELECT * FROM \(raw: Self.schema) ORDER BY created_at DESC LIMIT \(bind: limit)")
             .all(decoding: RecentPackage.self)
     }
 }

--- a/Sources/App/Core/RecentPackage.swift
+++ b/Sources/App/Core/RecentPackage.swift
@@ -39,11 +39,11 @@ struct RecentPackage: Decodable, Equatable {
 }
 
 extension RecentPackage {
-    static func refresh(on database: Database) -> EventLoopFuture<Void> {
+    static func refresh(on database: Database) async throws {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
-        return db.raw("REFRESH MATERIALIZED VIEW \(raw: Self.schema)").run()
+        try await db.raw("REFRESH MATERIALIZED VIEW \(raw: Self.schema)").run()
     }
 
 

--- a/Sources/App/Core/RecentRelease.swift
+++ b/Sources/App/Core/RecentRelease.swift
@@ -53,19 +53,6 @@ extension RecentRelease {
         try await db.raw("REFRESH MATERIALIZED VIEW \(raw: Self.schema)").run()
     }
 
-    @available(*, deprecated)
-    static func filterReleases(_ releases: [RecentRelease], by filter: Filter) -> [RecentRelease] {
-        if filter == .all { return releases }
-        return releases.filter { recent in
-            guard let version = SemanticVersion(recent.version) else { return false }
-            if filter.contains(.major) && version.isMajorRelease { return true }
-            if filter.contains(.minor) && version.isMinorRelease { return true }
-            if filter.contains(.patch) && version.isPatchRelease { return true }
-            if filter.contains(.pre) && version.isPreRelease { return true }
-            return false
-        }
-    }
-
     static func fetch(on database: Database,
                       limit: Int = Constants.recentReleasesLimit,
                       filter: Filter = .all) async throws -> [RecentRelease] {

--- a/Sources/App/Core/RecentRelease.swift
+++ b/Sources/App/Core/RecentRelease.swift
@@ -90,21 +90,3 @@ extension RecentRelease {
         static var all: Self { [.major, .minor, .patch, .pre] }
     }
 }
-
-
-extension RecentRelease.Filter {
-    init(_ string: String) {
-        switch string.lowercased() {
-            case "major":
-                self = .major
-            case "minor":
-                self = .minor
-            case "patch":
-                self = .patch
-            case "pre":
-                self = .pre
-            default:
-                self = [.major, .minor, .patch, .pre]
-        }
-    }
-}

--- a/Sources/App/Core/RecentRelease.swift
+++ b/Sources/App/Core/RecentRelease.swift
@@ -46,11 +46,11 @@ struct RecentRelease: Decodable, Equatable {
 }
 
 extension RecentRelease {
-    static func refresh(on database: Database) -> EventLoopFuture<Void> {
+    static func refresh(on database: Database) async throws {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
-        return db.raw("REFRESH MATERIALIZED VIEW \(raw: Self.schema)").run()
+        try await db.raw("REFRESH MATERIALIZED VIEW \(raw: Self.schema)").run()
     }
 
     static func filterReleases(_ releases: [RecentRelease], by filter: Filter) -> [RecentRelease] {

--- a/Sources/App/Views/Home/HomeIndex+Query.swift
+++ b/Sources/App/Views/Home/HomeIndex+Query.swift
@@ -21,7 +21,6 @@ extension HomeIndex.Model {
         let stats = try await Stats.fetch(on: database).get()
         let packages = try await RecentPackage.fetch(on: database).map(makeDateLink)
         let releases = try await RecentRelease.fetch(on: database)
-            .get()
             .map(Release.init(recent:))
         return .init(stats: stats, recentPackages: packages, recentReleases: releases)
     }

--- a/Sources/App/Views/Home/HomeIndex+Query.swift
+++ b/Sources/App/Views/Home/HomeIndex+Query.swift
@@ -17,13 +17,13 @@ import Plot
 
 
 extension HomeIndex.Model {
-    static func query(database: Database) -> EventLoopFuture<Self> {
-        let stats = Stats.fetch(on: database)
-        let packages = RecentPackage.fetch(on: database).mapEach(makeDateLink)
-        let releases = RecentRelease.fetch(on: database).mapEach(Release.init(recent:))
-        return stats.and(packages).and(releases)
-            .map { ($0.0, $0.1, $1) }
-            .map(Self.init)
+    static func query(database: Database) async throws -> Self {
+        let stats = try await Stats.fetch(on: database).get()
+        let packages = try await RecentPackage.fetch(on: database).map(makeDateLink)
+        let releases = try await RecentRelease.fetch(on: database)
+            .get()
+            .map(Release.init(recent:))
+        return .init(stats: stats, recentPackages: packages, recentReleases: releases)
     }
 }
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -280,24 +280,11 @@ func routes(_ app: Application) throws {
     }
 
     do {  // RSS + Sitemap
-        app.get(SiteURL.rssPackages.pathComponents) { req in
-            RSSFeed.recentPackages(on: req.db, limit: Constants.rssFeedMaxItemCount)
-                .map { $0.rss }
-        }.excludeFromOpenAPI()
+        app.get(SiteURL.rssPackages.pathComponents, use: RSSFeed.showPackages)
+            .excludeFromOpenAPI()
 
-        app.get(SiteURL.rssReleases.pathComponents) { req -> EventLoopFuture<RSS> in
-            var filter: RecentRelease.Filter = []
-            for param in ["major", "minor", "patch", "pre"] {
-                if let value = req.query[Bool.self, at: param], value == true {
-                    filter.insert(.init(param))
-                }
-            }
-            if filter.isEmpty { filter = .all }
-            return RSSFeed.recentReleases(on: req.db,
-                                          limit: Constants.rssFeedMaxItemCount,
-                                          filter: filter)
-                .map { $0.rss }
-        }.excludeFromOpenAPI()
+        app.get(SiteURL.rssReleases.pathComponents, use: RSSFeed.showReleases)
+            .excludeFromOpenAPI()
 
         app.get(SiteURL.siteMap.pathComponents) { req in
             SiteMap.fetchPackages(req.db)

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -23,9 +23,8 @@ import VaporToOpenAPI
 func routes(_ app: Application) throws {
     do {  // home page
         app.get { req in
-            HomeIndex.Model.query(database: req.db).map {
-                HomeIndex.View(path: req.url.path, model: $0).document()
-            }
+            let model = try await HomeIndex.Model.query(database: req.db)
+            return HomeIndex.View(path: req.url.path, model: model).document()
         }.excludeFromOpenAPI()
     }
 

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -214,9 +214,9 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(pkg2.score, 45)
 
         // ensure stats, recent packages, and releases are refreshed
-        XCTAssertEqual(try Stats.fetch(on: app.db).wait(), .init(packageCount: 2))
-        XCTAssertEqual(try RecentPackage.fetch(on: app.db).wait().count, 2)
-        XCTAssertEqual(try RecentRelease.fetch(on: app.db).wait().count, 2)
+        try await XCTAssertEqualAsync(try await Stats.fetch(on: app.db).get(), .init(packageCount: 2))
+        try await XCTAssertEqualAsync(try await RecentPackage.fetch(on: app.db).count, 2)
+        try await XCTAssertEqualAsync(try await RecentRelease.fetch(on: app.db).get().count, 2)
     }
 
     func test_analyze_version_update() async throws {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -216,7 +216,7 @@ class AnalyzerTests: AppTestCase {
         // ensure stats, recent packages, and releases are refreshed
         try await XCTAssertEqualAsync(try await Stats.fetch(on: app.db).get(), .init(packageCount: 2))
         try await XCTAssertEqualAsync(try await RecentPackage.fetch(on: app.db).count, 2)
-        try await XCTAssertEqualAsync(try await RecentRelease.fetch(on: app.db).get().count, 2)
+        try await XCTAssertEqualAsync(try await RecentRelease.fetch(on: app.db).count, 2)
     }
 
     func test_analyze_version_update() async throws {

--- a/Tests/AppTests/HomeIndexModelTests.swift
+++ b/Tests/AppTests/HomeIndexModelTests.swift
@@ -32,7 +32,7 @@ class HomeIndexModelTests: AppTestCase {
                               packageName: "Package",
                               reference: .tag(.init(1, 2, 3))).save(on: app.db)
         try await RecentPackage.refresh(on: app.db)
-        try await RecentRelease.refresh(on: app.db).get()
+        try await RecentRelease.refresh(on: app.db)
 
         // MUT
         let m = try await HomeIndex.Model.query(database: app.db)

--- a/Tests/AppTests/HomeIndexModelTests.swift
+++ b/Tests/AppTests/HomeIndexModelTests.swift
@@ -19,23 +19,23 @@ import XCTVapor
 
 class HomeIndexModelTests: AppTestCase {
 
-    func test_query() throws {
+    func test_query() async throws {
         // setup
         let pkgId = UUID()
         let pkg = Package(id: pkgId, url: "1".url)
-        try pkg.save(on: app.db).wait()
-        try Repository(package: pkg,
-                       name: "1",
-                       owner: "foo").save(on: app.db).wait()
-        try App.Version(package: pkg,
-                        commitDate: Date(timeIntervalSince1970: 0),
-                        packageName: "Package",
-                        reference: .tag(.init(1, 2, 3))).save(on: app.db).wait()
-        try RecentPackage.refresh(on: app.db).wait()
-        try RecentRelease.refresh(on: app.db).wait()
+        try await pkg.save(on: app.db)
+        try await Repository(package: pkg,
+                             name: "1",
+                             owner: "foo").save(on: app.db)
+        try await App.Version(package: pkg,
+                              commitDate: Date(timeIntervalSince1970: 0),
+                              packageName: "Package",
+                              reference: .tag(.init(1, 2, 3))).save(on: app.db)
+        try await RecentPackage.refresh(on: app.db)
+        try await RecentRelease.refresh(on: app.db).get()
 
         // MUT
-        let m = try HomeIndex.Model.query(database: app.db).wait()
+        let m = try await HomeIndex.Model.query(database: app.db).get()
 
         // validate
         let createdAt = try XCTUnwrap(pkg.createdAt)

--- a/Tests/AppTests/HomeIndexModelTests.swift
+++ b/Tests/AppTests/HomeIndexModelTests.swift
@@ -35,7 +35,7 @@ class HomeIndexModelTests: AppTestCase {
         try await RecentRelease.refresh(on: app.db).get()
 
         // MUT
-        let m = try await HomeIndex.Model.query(database: app.db).get()
+        let m = try await HomeIndex.Model.query(database: app.db)
 
         // validate
         let createdAt = try XCTUnwrap(pkg.createdAt)

--- a/Tests/AppTests/RSSTests.swift
+++ b/Tests/AppTests/RSSTests.swift
@@ -18,6 +18,7 @@ import SnapshotTesting
 import XCTVapor
 
 
+@MainActor
 class RSSTests: SnapshotTestCase {
 
     func test_recentPackage_rssGuid() throws {

--- a/Tests/AppTests/RSSTests.swift
+++ b/Tests/AppTests/RSSTests.swift
@@ -89,6 +89,17 @@ class RSSTests: SnapshotTestCase {
                        as: .init(pathExtension: "xml", diffing: .lines))
     }
 
+    func test_Query_RecentRelease_filter() throws {
+        do {
+            let query = RSSFeed.Query(major: true, minor: nil, patch: false, pre: nil)
+            XCTAssertEqual(query.filter, [.major])
+        }
+        do {
+            let query = RSSFeed.Query(major: nil, minor: nil, patch: false, pre: nil)
+            XCTAssertEqual(query.filter, .all)
+        }
+    }
+
     func test_recentReleases() throws {
         // setup
         try (1...10).forEach {

--- a/Tests/AppTests/RSSTests.swift
+++ b/Tests/AppTests/RSSTests.swift
@@ -18,7 +18,6 @@ import SnapshotTesting
 import XCTVapor
 
 
-@MainActor
 class RSSTests: SnapshotTestCase {
 
     func test_recentPackage_rssGuid() throws {
@@ -65,6 +64,7 @@ class RSSTests: SnapshotTestCase {
                        as: .init(pathExtension: "xml", diffing: .lines))
     }
 
+    @MainActor
     func test_recentPackages() async throws {
         // setup
         for idx in 1...10 {

--- a/Tests/AppTests/RSSTests.swift
+++ b/Tests/AppTests/RSSTests.swift
@@ -80,7 +80,7 @@ class RSSTests: SnapshotTestCase {
             try await Version(package: pkg, packageName: "pkg-\(idx)").save(on: app.db)
         }
         // make sure to refresh the materialized view
-        try await RecentPackage.refresh(on: app.db).get()
+        try await RecentPackage.refresh(on: app.db)
 
         // MUT
         let feed = try await RSSFeed.recentPackages(on: app.db, limit: 8)

--- a/Tests/AppTests/RSSTests.swift
+++ b/Tests/AppTests/RSSTests.swift
@@ -101,6 +101,7 @@ class RSSTests: SnapshotTestCase {
         }
     }
 
+    @MainActor
     func test_recentReleases() async throws {
         // setup
         for idx in 1...10 {
@@ -120,7 +121,7 @@ class RSSTests: SnapshotTestCase {
             .save(on: app.db)
         }
         // make sure to refresh the materialized view
-        try await RecentRelease.refresh(on: app.db).get()
+        try await RecentRelease.refresh(on: app.db)
 
         // MUT
         let feed = try await RSSFeed.recentReleases(on: app.db, limit: 8)
@@ -139,30 +140,31 @@ class RSSTests: SnapshotTestCase {
         })
     }
 
-    func test_recentReleases_route_all() throws {
+    @MainActor
+    func test_recentReleases_route_all() async throws {
         // Test request handler - without parameters (all)
         // setup
         // see RecentViewsTests.test_recentReleases_filter for filter results
-        try (1...10).forEach {
-            let major = $0 / 3  // 0, 0, 1, 1, 1, 2, 2, 2, 3, 3
-            let minor = $0 % 3  // 1, 2, 0, 1, 2, 0, 1, 2, 0, 1
-            let patch = $0 % 2  // 1, 0, 1, 0, 1, 0, 1, 0, 1, 0
-            let pkg = Package(id: UUID(), url: "\($0)".asGithubUrl.url)
-            try pkg.save(on: app.db).wait()
-            try Repository(package: pkg,
-                           name: "pkg-\($0)",
-                           owner: "owner-\($0)",
-                           summary: "Summary")
-                .create(on: app.db).wait()
-            try Version(package: pkg,
-                        commitDate: Date(timeIntervalSince1970: TimeInterval($0)),
-                        packageName: "pkg-\($0)",
-                        reference: .tag(.init(major, minor, patch)),
-                        url: "https://example.com/release-url")
-                .save(on: app.db).wait()
+        for idx in 1...10 {
+            let major = idx / 3  // 0, 0, 1, 1, 1, 2, 2, 2, 3, 3
+            let minor = idx % 3  // 1, 2, 0, 1, 2, 0, 1, 2, 0, 1
+            let patch = idx % 2  // 1, 0, 1, 0, 1, 0, 1, 0, 1, 0
+            let pkg = Package(id: UUID(), url: "\(idx)".asGithubUrl.url)
+            try await pkg.save(on: app.db)
+            try await Repository(package: pkg,
+                                 name: "pkg-\(idx)",
+                                 owner: "owner-\(idx)",
+                                 summary: "Summary")
+            .create(on: app.db)
+            try await Version(package: pkg,
+                              commitDate: Date(timeIntervalSince1970: TimeInterval(idx)),
+                              packageName: "pkg-\(idx)",
+                              reference: .tag(.init(major, minor, patch)),
+                              url: "https://example.com/release-url")
+            .save(on: app.db)
         }
         // make sure to refresh the materialized view
-        try RecentRelease.refresh(on: app.db).wait()
+        try await RecentRelease.refresh(on: app.db)
 
         // MUT
         try app.test(.GET, "releases.rss", afterResponse:  { res in
@@ -175,30 +177,31 @@ class RSSTests: SnapshotTestCase {
         })
     }
 
-    func test_recentReleases_route_major() throws {
+    @MainActor
+    func test_recentReleases_route_major() async throws {
         // Test request handler - major releases only
         // setup
         // see RecentViewsTests.test_recentReleases_filter for filter results
-        try (1...10).forEach {
-            let major = $0 / 3  // 0, 0, 1, 1, 1, 2, 2, 2, 3, 3
-            let minor = $0 % 3  // 1, 2, 0, 1, 2, 0, 1, 2, 0, 1
-            let patch = $0 % 2  // 1, 0, 1, 0, 1, 0, 1, 0, 1, 0
-            let pkg = Package(id: UUID(), url: "\($0)".asGithubUrl.url)
-            try pkg.save(on: app.db).wait()
-            try Repository(package: pkg,
-                           name: "pkg-\($0)",
-                           owner: "owner-\($0)",
-                           summary: "Summary")
-                .create(on: app.db).wait()
-            try Version(package: pkg,
-                        commitDate: Date(timeIntervalSince1970: TimeInterval($0)),
-                        packageName: "pkg-\($0)",
-                        reference: .tag(.init(major, minor, patch)),
-                        url: "https://example.com/release-url")
-                .save(on: app.db).wait()
+        for idx in 1...10 {
+            let major = idx / 3  // 0, 0, 1, 1, 1, 2, 2, 2, 3, 3
+            let minor = idx % 3  // 1, 2, 0, 1, 2, 0, 1, 2, 0, 1
+            let patch = idx % 2  // 1, 0, 1, 0, 1, 0, 1, 0, 1, 0
+            let pkg = Package(id: UUID(), url: "\(idx)".asGithubUrl.url)
+            try await pkg.save(on: app.db)
+            try await Repository(package: pkg,
+                                 name: "pkg-\(idx)",
+                                 owner: "owner-\(idx)",
+                                 summary: "Summary")
+            .create(on: app.db)
+            try await Version(package: pkg,
+                              commitDate: Date(timeIntervalSince1970: TimeInterval(idx)),
+                              packageName: "pkg-\(idx)",
+                              reference: .tag(.init(major, minor, patch)),
+                              url: "https://example.com/release-url")
+            .save(on: app.db)
         }
         // make sure to refresh the materialized view
-        try RecentRelease.refresh(on: app.db).wait()
+        try await RecentRelease.refresh(on: app.db)
 
         // MUT
         try app.test(.GET, "releases.rss?major=true", afterResponse: { res in
@@ -211,30 +214,31 @@ class RSSTests: SnapshotTestCase {
         })
     }
 
-    func test_recentReleases_route_majorMinor() throws {
+    @MainActor
+    func test_recentReleases_route_majorMinor() async throws {
         // Test request handler - major & minor releases only
         // setup
         // see RecentViewsTests.test_recentReleases_filter for filter results
-        try (1...10).forEach {
-            let major = $0 / 3  // 0, 0, 1, 1, 1, 2, 2, 2, 3, 3
-            let minor = $0 % 3  // 1, 2, 0, 1, 2, 0, 1, 2, 0, 1
-            let patch = $0 % 2  // 1, 0, 1, 0, 1, 0, 1, 0, 1, 0
-            let pkg = Package(id: UUID(), url: "\($0)".asGithubUrl.url)
-            try pkg.save(on: app.db).wait()
-            try Repository(package: pkg,
-                           name: "pkg-\($0)",
-                           owner: "owner-\($0)",
+        for idx in 1...10 {
+            let major = idx / 3  // 0, 0, 1, 1, 1, 2, 2, 2, 3, 3
+            let minor = idx % 3  // 1, 2, 0, 1, 2, 0, 1, 2, 0, 1
+            let patch = idx % 2  // 1, 0, 1, 0, 1, 0, 1, 0, 1, 0
+            let pkg = Package(id: UUID(), url: "\(idx)".asGithubUrl.url)
+            try await pkg.save(on: app.db)
+            try await Repository(package: pkg,
+                           name: "pkg-\(idx)",
+                           owner: "owner-\(idx)",
                            summary: "Summary")
-                .create(on: app.db).wait()
-            try Version(package: pkg,
-                        commitDate: Date(timeIntervalSince1970: TimeInterval($0)),
-                        packageName: "pkg-\($0)",
+                .create(on: app.db)
+            try await Version(package: pkg,
+                        commitDate: Date(timeIntervalSince1970: TimeInterval(idx)),
+                        packageName: "pkg-\(idx)",
                         reference: .tag(.init(major, minor, patch)),
                         url: "https://example.com/release-url")
-                .save(on: app.db).wait()
+                .save(on: app.db)
         }
         // make sure to refresh the materialized view
-        try RecentRelease.refresh(on: app.db).wait()
+        try await RecentRelease.refresh(on: app.db)
 
         // MUT
         try app.test(.GET, "releases.rss?major=true&minor=true", afterResponse: { res in
@@ -247,31 +251,32 @@ class RSSTests: SnapshotTestCase {
         })
     }
 
-    func test_recentReleases_route_preRelease() throws {
+    @MainActor
+    func test_recentReleases_route_preRelease() async throws {
         // Test request handler - pre-releases only
         // setup
         // see RecentViewsTests.test_recentReleases_filter for filter results
-        try (1...12).forEach {
-            let major = $0 / 3  // 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4
-            let minor = $0 % 3  // 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0
-            let patch = $0 % 2  // 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0
-            let pre = $0 <= 10 ? "" : "b1"
-            let pkg = Package(id: UUID(), url: "\($0)".asGithubUrl.url)
-            try pkg.save(on: app.db).wait()
-            try Repository(package: pkg,
-                           name: "pkg-\($0)",
-                           owner: "owner-\($0)",
+        for idx in 1...12 {
+            let major = idx / 3  // 0, 0, 1, 1, 1, 2, 2, 2, 3, 3, 3, 4
+            let minor = idx % 3  // 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2, 0
+            let patch = idx % 2  // 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0
+            let pre = idx <= 10 ? "" : "b1"
+            let pkg = Package(id: UUID(), url: "\(idx)".asGithubUrl.url)
+            try await pkg.save(on: app.db)
+            try await Repository(package: pkg,
+                           name: "pkg-\(idx)",
+                           owner: "owner-\(idx)",
                            summary: "Summary")
-                .create(on: app.db).wait()
-            try Version(package: pkg,
-                        commitDate: Date(timeIntervalSince1970: TimeInterval($0)),
-                        packageName: "pkg-\($0)",
+                .create(on: app.db)
+            try await Version(package: pkg,
+                        commitDate: Date(timeIntervalSince1970: TimeInterval(idx)),
+                        packageName: "pkg-\(idx)",
                         reference: .tag(.init(major, minor, patch, pre)),
                         url: "https://example.com/release-url")
-                .save(on: app.db).wait()
+                .save(on: app.db)
         }
         // make sure to refresh the materialized view
-        try RecentRelease.refresh(on: app.db).wait()
+        try await RecentRelease.refresh(on: app.db)
 
         // MUT
         try app.test(.GET, "releases.rss?pre=true", afterResponse: { res in

--- a/Tests/AppTests/RecentViewsTests.swift
+++ b/Tests/AppTests/RecentViewsTests.swift
@@ -142,7 +142,7 @@ class RecentViewsTests: AppTestCase {
         XCTAssertEqual(res.map(\.releaseUrl), ["5/release/2.0.0", "1/release/1.2.3"])
     }
 
-    func test_recentReleases_filter() throws {
+    func test_Array_RecentReleases_filter() throws {
         // List only major releases
         // setup
         let releases: [RecentRelease] = (1...12).map {
@@ -161,11 +161,11 @@ class RecentViewsTests: AppTestCase {
         }
 
         // MUT
-        let all = RecentRelease.filterReleases(releases, by: .all)
-        let majorOnly = RecentRelease.filterReleases(releases, by: .major)
-        let minorOnly = RecentRelease.filterReleases(releases, by: .minor)
-        let majorMinor = RecentRelease.filterReleases(releases, by: [.major, .minor])
-        let pre = RecentRelease.filterReleases(releases, by: [.pre])
+        let all = releases.filter(by: .all)
+        let majorOnly = releases.filter(by: .major)
+        let minorOnly = releases.filter(by: .minor)
+        let majorMinor = releases.filter(by: [.major, .minor])
+        let pre = releases.filter(by: [.pre])
 
         // validate
         XCTAssertEqual(

--- a/Tests/AppTests/RecentViewsTests.swift
+++ b/Tests/AppTests/RecentViewsTests.swift
@@ -52,7 +52,7 @@ class RecentViewsTests: AppTestCase {
         try await RecentPackage.refresh(on: app.db)
 
         // MUT
-        let res = try await RecentPackage.fetch(on: app.db).get()
+        let res = try await RecentPackage.fetch(on: app.db)
 
         // validate
         XCTAssertEqual(res.map(\.packageName), ["3", "1"])
@@ -202,7 +202,7 @@ class RecentViewsTests: AppTestCase {
         try await RecentPackage.refresh(on: app.db)
 
         // MUT
-        let res = try await RecentPackage.fetch(on: app.db).get()
+        let res = try await RecentPackage.fetch(on: app.db)
 
         // validate
         XCTAssertEqual(res.map(\.packageName), ["pkg-bar-updated"])

--- a/Tests/AppTests/RecentViewsTests.swift
+++ b/Tests/AppTests/RecentViewsTests.swift
@@ -142,14 +142,6 @@ class RecentViewsTests: AppTestCase {
         XCTAssertEqual(res.map(\.releaseUrl), ["5/release/2.0.0", "1/release/1.2.3"])
     }
 
-    func test_recentReleases_Filter() throws {
-        XCTAssertTrue(RecentRelease.Filter.minor == .init("minor"))
-        XCTAssertTrue(RecentRelease.Filter.major == .init("major"))
-        XCTAssertTrue(RecentRelease.Filter.patch == .init("patch"))
-        XCTAssertTrue(RecentRelease.Filter.all == [.init("minor"), .init("major"), .init("patch"), .init("pre")])
-        XCTAssertTrue(RecentRelease.Filter.all == .init("nonsensical defaults to all"))
-    }
-
     func test_recentReleases_filter() throws {
         // List only major releases
         // setup

--- a/Tests/AppTests/RecentViewsTests.swift
+++ b/Tests/AppTests/RecentViewsTests.swift
@@ -133,7 +133,7 @@ class RecentViewsTests: AppTestCase {
         try await RecentRelease.refresh(on: app.db)
 
         // MUT
-        let res = try await RecentRelease.fetch(on: app.db).get()
+        let res = try await RecentRelease.fetch(on: app.db)
 
         // validate
         XCTAssertEqual(res.map(\.packageName), ["5", "1"])
@@ -229,7 +229,7 @@ class RecentViewsTests: AppTestCase {
         try await RecentRelease.refresh(on: app.db)
 
         // MUT
-        let res = try await RecentRelease.fetch(on: app.db).get()
+        let res = try await RecentRelease.fetch(on: app.db)
 
         // validate
         XCTAssertEqual(res.map(\.packageName), ["pkg-bar-updated"])

--- a/Tests/AppTests/SnapshotTestCase.swift
+++ b/Tests/AppTests/SnapshotTestCase.swift
@@ -18,7 +18,6 @@ import Foundation
 import SnapshotTesting
 
 
-@MainActor
 class SnapshotTestCase: AppTestCase {
 
     override func setUp() {

--- a/Tests/AppTests/SnapshotTestCase.swift
+++ b/Tests/AppTests/SnapshotTestCase.swift
@@ -17,6 +17,8 @@
 import Foundation
 import SnapshotTesting
 
+
+@MainActor
 class SnapshotTestCase: AppTestCase {
 
     override func setUp() {


### PR DESCRIPTION
Follow-up to API work: Migrate `req.query[Int.self, at: "page"]` decoding to strongly typed `req.query.decode(Query.self).page` decoding (`KeywordController.show` and `RSSFeed.showReleases`).

Also converted a handful of related functions to async/await.