### PR TITLE
Add swiftVersionCompatibility and platformCompatibility to API.PackageController.GetRoute.Model

### DIFF
--- a/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
@@ -232,12 +232,14 @@ extension API.PackageController.GetRoute.Model {
         }
     }
 
-    enum PlatformCompatibility: Codable, Comparable {
+    enum PlatformCompatibility: String, Codable, Comparable {
         case ios
         case linux
         case macos
         case tvos
         case watchos
+
+        static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
     }
 
     struct NamedBuildResults<T: Codable & Equatable>: Codable, Equatable {

--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -297,6 +297,67 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                             latest: nil))
     }
 
+    func test_BuildInfo_SwiftVersion_compatibility() throws {
+        typealias Results = API.PackageController.GetRoute.Model.SwiftVersionResults
+
+        do {
+            let info = BuildInfo(stable: .some(.init(referenceName: "1.2.3",
+                                                     results: Results(status5_5: .compatible,
+                                                                      status5_6: .incompatible,
+                                                                      status5_7: .unknown,
+                                                                      status5_8: .compatible))),
+                                 beta: nil,
+                                 latest: nil)
+            XCTAssertEqual(info?.compatibility, [.v5_5, .v5_8])
+        }
+        do {
+            let info = BuildInfo(stable: .some(.init(referenceName: "1.2.3",
+                                                     results: Results(status5_5: .compatible,
+                                                                      status5_6: .incompatible,
+                                                                      status5_7: .unknown,
+                                                                      status5_8: .compatible))),
+                                 beta: .some(.init(referenceName: "1.2.3-b1",
+                                                   results: Results(status5_5: .incompatible,
+                                                                    status5_6: .incompatible,
+                                                                    status5_7: .compatible,
+                                                                    status5_8: .unknown))),
+                                 latest: nil)
+            XCTAssertEqual(info?.compatibility, [.v5_5, .v5_7, .v5_8])
+        }
+    }
+
+    func test_BuildInfo_Platform_compatibility() throws {
+        typealias Results = API.PackageController.GetRoute.Model.PlatformResults
+
+        do {
+            let info = BuildInfo(stable: .some(.init(referenceName: "1.2.3",
+                                                     results: Results(iosStatus: .compatible,
+                                                                      linuxStatus: .incompatible,
+                                                                      macosStatus: .unknown,
+                                                                      tvosStatus: .unknown,
+                                                                      watchosStatus: .compatible))),
+                                 beta: nil,
+                                 latest: nil)
+            XCTAssertEqual(info?.compatibility, [.ios, .watchos])
+        }
+        do {
+            let info = BuildInfo(stable: .some(.init(referenceName: "1.2.3",
+                                                     results: Results(iosStatus: .compatible,
+                                                                      linuxStatus: .incompatible,
+                                                                      macosStatus: .unknown,
+                                                                      tvosStatus: .unknown,
+                                                                      watchosStatus: .compatible))),
+                                 beta: .some(.init(referenceName: "1.2.3-b1",
+                                                   results: Results(iosStatus: .compatible,
+                                                                    linuxStatus: .incompatible,
+                                                                    macosStatus: .compatible,
+                                                                    tvosStatus: .unknown,
+                                                                    watchosStatus: .unknown))),
+                                 latest: nil)
+            XCTAssertEqual(info?.compatibility, [.ios, .macos, .watchos])
+        }
+    }
+
     func test_groupBuildInfo() throws {
         let result1: BuildResults = .init(status5_5: .compatible,
                                           status5_6: .compatible,


### PR DESCRIPTION
We're currently sending the following platform build info (and the same for Swift versions):

```
"platformBuildInfo": ["stable": ["referenceName": "5.6.4", "results": ["tvos": ["status": "compatible", "parameter": ["tvos": [:]]], "ios": ["status": "compatible", "parameter": ["ios": [:]]], "macos": ["parameter": ["macos": [:]], "status": "compatible"], "watchos": ["parameter": ["watchos": [:]], "status": "compatible"], "linux": ["status": "compatible", "parameter": ["linux": [:]]]]], "latest": ["referenceName": "master", "results": ["watchos": ["parameter": ["watchos": [:]], "status": "compatible"], "ios": ["status": "compatible", "parameter": ["ios": [:]]], "macos": ["parameter": ["macos": [:]], "status": "compatible"], "tvos": ["status": "compatible", "parameter": ["tvos": [:]]], "linux": ["status": "compatible", "parameter": ["linux": [:]]]]]]
```

This is designed to drive the full package compatibility matrix.

While looking into populating the [package categories yml file](https://github.com/SwiftPackageIndex/swift-org-website/blob/packages-page/_data/packages/packages.yml) I noticed that it's quite cumbersome to derive simple, collapse compatibility info from that (like we do for badges, for instance).

This change provides additional fields `platformCompatibility` and `swiftVersionCompatiblity` which that collapsed view:

```
"platformCompatibility": ["ios", "linux", "macos", "tvos", "watchos"]
```