### PR TITLE
Exclude CareKit for now (bad .spi.yml)

### DIFF
--- a/restfiles/doc-test.restfile
+++ b/restfiles/doc-test.restfile
@@ -193,10 +193,11 @@ requests:
   #   url: ${base_url}/calimarkus/JDStatusBarNotification/documentation
   #   validation:
   #     status: .regex((2|3)\d\d)
-  /carekit-apple/CareKit/documentation:
-    url: ${base_url}/carekit-apple/CareKit/documentation
-    validation:
-      status: .regex((2|3)\d\d)
+  # Bad .spi.yml, PR to address here: https://github.com/carekit-apple/CareKit/pull/697
+  # /carekit-apple/CareKit/documentation:
+  #   url: ${base_url}/carekit-apple/CareKit/documentation
+  #   validation:
+  #     status: .regex((2|3)\d\d)
   /crelies/AdvancedList/documentation:
     url: ${base_url}/crelies/AdvancedList/documentation
     validation:


### PR DESCRIPTION
Validated all of them beforehand this time:


```
❯ env base_url=https://swiftpackageindex.com rester ~/Projects/SPI/spi-server/restfiles/doc-test.restfile
🚀  Resting /Users/sas/Projects/SPI/spi-server/restfiles/doc-test.restfile ...

🎬  /AudioKit/AudioKit/documentation started ...

✅  /AudioKit/AudioKit/documentation PASSED (2.188s)

...

🎬  /vapor-community/HTMLKit/documentation started ...

✅  /vapor-community/HTMLKit/documentation PASSED (0.715s)

Executed 83 tests, with 0 failures
```