### PR TITLE
Change repository creation date in snapshot tests

### DIFF
--- a/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
+++ b/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
@@ -80,7 +80,7 @@ extension API.PackageController.GetRoute.Model {
                                    watchosStatus: .compatible))),
             history: .init(
                 createdAt: Calendar.current.date(byAdding: .day,
-                                                 value: -80,
+                                                 value: -70,
                                                  to: Current.date())!,
                 commitCount: 1433,
                 commitCountURL: "https://github.com/Alamofire/Alamofire/commits/main",

--- a/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
+++ b/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
@@ -80,7 +80,7 @@ extension API.PackageController.GetRoute.Model {
                                    watchosStatus: .compatible))),
             history: .init(
                 createdAt: Calendar.current.date(byAdding: .day,
-                                                 value: -365*5,
+                                                 value: -80,
                                                  to: Current.date())!,
                 commitCount: 1433,
                 commitCountURL: "https://github.com/Alamofire/Alamofire/commits/main",

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -133,7 +133,7 @@
                   <strong>This package includes binary-only targets </strong>where source code may not be available. There may be more info available in the 
                   <a href="#readme" title="README">README</a>.
                 </li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -133,7 +133,7 @@
                   <strong>This package includes binary-only targets </strong>where source code may not be available. There may be more info available in the 
                   <a href="#readme" title="README">README</a>.
                 </li>
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -128,7 +128,7 @@
           <section>
             <section>
               <ul class="main-metadata">
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -128,7 +128,7 @@
           <section>
             <section>
               <ul class="main-metadata">
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 4 years, with 
+                <li class="history">In development for 2 months, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -129,7 +129,7 @@
             <section>
               <ul class="main-metadata">
                 <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
-                <li class="history">In development for 5 years, with 
+                <li class="history">In development for 4 years, with 
                   <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
                   <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
                 </li>


### PR DESCRIPTION
This is more interesting than I originally thought. I'm honestly not sure why these changed today, or why they have different results when run on Linux today.

Changed to not span a year boundary for now, but this is odd.