### PR TITLE
Xcode 15 / Swift 5.9

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/finestructure/spi-base:0.10.0
+FROM registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39
 
 # Install SPM build dependencies
 RUN apt-get update && apt-get install -y curl git make unzip \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39
+FROM registry.gitlab.com/finestructure/spi-base:0.11.0
 
 # Install SPM build dependencies
 RUN apt-get update && apt-get install -y curl git make unzip \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:0.10.0
+      image: registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39
     services:
       postgres:
         image: postgres:13.8-alpine

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39
+      image: registry.gitlab.com/finestructure/spi-base:0.11.0
     services:
       postgres:
         image: postgres:13.8-alpine

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39
+      image: registry.gitlab.com/finestructure/spi-base:0.11.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: registry.gitlab.com/finestructure/spi-base:0.10.0
+      image: registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # ================================
 # Build image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39 as build
+FROM registry.gitlab.com/finestructure/spi-base:0.11.0 as build
 
 # Set up a build area
 WORKDIR /build
@@ -54,7 +54,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39
+FROM registry.gitlab.com/finestructure/spi-base:0.11.0
 
 # NB sas 2022-09-23: We're not using a dedicated `vapor` user to run the executable, because it
 # makes managing the data in the checkouts volume difficult. See

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # ================================
 # Build image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:0.10.0 as build
+FROM registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39 as build
 
 # Set up a build area
 WORKDIR /build
@@ -54,7 +54,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:0.10.0
+FROM registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39
 
 # NB sas 2022-09-23: We're not using a dedicated `vapor` user to run the executable, because it
 # makes managing the data in the checkouts volume difficult. See

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -176,7 +176,7 @@ The trickiest part of this is to ensure the test or app container can connect to
 So, in order to run the tests in a Linux container run:
 
 ```
-docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39 swift test
+docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:0.11.0 swift test
 ```
 
 Make sure you use the most recent `spi-base` image. You can find the latest image name in the `test-docker` target, which also provides a convenient way to run all all tests in a docker container.

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -176,7 +176,7 @@ The trickiest part of this is to ensure the test or app container can connect to
 So, in order to run the tests in a Linux container run:
 
 ```
-docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:0.10.0 swift test
+docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39 swift test
 ```
 
 Make sure you use the most recent `spi-base` image. You can find the latest image name in the `test-docker` target, which also provides a convenient way to run all all tests in a docker container.

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-docker:
 	@# run tests inside a docker container
 	docker run --rm -v "$(PWD)":/host -w /host \
 	  --add-host=host.docker.internal:host-gateway \
-	  registry.gitlab.com/finestructure/spi-base:0.10.0 \
+	  registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39 \
 	  make test
 
 test-e2e: db-reset reconcile ingest analyze

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-docker:
 	@# run tests inside a docker container
 	docker run --rm -v "$(PWD)":/host -w /host \
 	  --add-host=host.docker.internal:host-gateway \
-	  registry.gitlab.com/finestructure/spi-base:1240dfbcf393af3cd68754d7aeb95260541cfa39 \
+	  registry.gitlab.com/finestructure/spi-base:0.11.0 \
 	  make test
 
 test-e2e: db-reset reconcile ingest analyze

--- a/Package.resolved
+++ b/Package.resolved
@@ -148,8 +148,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftPackageIndex/SPIManifest",
       "state" : {
-        "revision" : "48dba5341529d50a8433859163e75fbb4357ac13",
-        "version" : "0.17.2"
+        "revision" : "59b957c55c274ae08da9aaa36efcaac3fb7a326c",
+        "version" : "0.19.0"
       }
     },
     {

--- a/Sources/App/Controllers/API/API+PackageController+BuildInfo.swift
+++ b/Sources/App/Controllers/API/API+PackageController+BuildInfo.swift
@@ -96,17 +96,17 @@ extension API.PackageController {
                 return nil
             }
             // For each reported swift version pick major/minor version matches
-            let v5_5 = builds.filter { $0.swiftVersion.isCompatible(with: .v5_5) }
             let v5_6 = builds.filter { $0.swiftVersion.isCompatible(with: .v5_6) }
             let v5_7 = builds.filter { $0.swiftVersion.isCompatible(with: .v5_7) }
             let v5_8 = builds.filter { $0.swiftVersion.isCompatible(with: .v5_8) }
+            let v5_9 = builds.filter { $0.swiftVersion.isCompatible(with: .v5_9) }
             // ... and report the status
             return
                 .init(referenceName: referenceName,
-                      results: .init(status5_5: v5_5.buildStatus,
-                                     status5_6: v5_6.buildStatus,
+                      results: .init(status5_6: v5_6.buildStatus,
                                      status5_7: v5_7.buildStatus,
-                                     status5_8: v5_8.buildStatus)
+                                     status5_8: v5_8.buildStatus,
+                                     status5_9: v5_9.buildStatus)
                 )
         }
     }

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
@@ -248,22 +248,22 @@ extension API.PackageController.GetRoute.Model {
     }
 
     struct SwiftVersionResults: Codable, Equatable {
-        var v5_5: BuildResult<SwiftVersion>
         var v5_6: BuildResult<SwiftVersion>
         var v5_7: BuildResult<SwiftVersion>
         var v5_8: BuildResult<SwiftVersion>
+        var v5_9: BuildResult<SwiftVersion>
 
-        init(status5_5: BuildStatus,
-             status5_6: BuildStatus,
+        init(status5_6: BuildStatus,
              status5_7: BuildStatus,
-             status5_8: BuildStatus) {
-            self.v5_5 = .init(parameter: .v5_5, status: status5_5)
+             status5_8: BuildStatus,
+             status5_9: BuildStatus) {
             self.v5_6 = .init(parameter: .v5_6, status: status5_6)
             self.v5_7 = .init(parameter: .v5_7, status: status5_7)
             self.v5_8 = .init(parameter: .v5_8, status: status5_8)
+            self.v5_9 = .init(parameter: .v5_9, status: status5_9)
         }
 
-        var all: [BuildResult<SwiftVersion>] { [v5_8, v5_7, v5_6, v5_5] }
+        var all: [BuildResult<SwiftVersion>] { [v5_9, v5_8, v5_7, v5_6] }
     }
 
     struct PlatformResults: Codable, Equatable {

--- a/Sources/App/Controllers/API/Types+WithExample.swift
+++ b/Sources/App/Controllers/API/Types+WithExample.swift
@@ -168,22 +168,22 @@ extension API.PackageController.GetRoute.Model: WithExample {
               swiftVersionBuildInfo: .init(
                 stable: .init(
                     referenceName: "1.2.3",
-                    results: .init(status5_5: .incompatible,
-                                   status5_6: .incompatible,
-                                   status5_7: .unknown,
-                                   status5_8: .compatible)),
+                    results: .init(status5_6: .incompatible,
+                                   status5_7: .incompatible,
+                                   status5_8: .unknown,
+                                   status5_9: .compatible)),
                 beta: .init(
                     referenceName: "2.0.0-b1",
-                    results: .init(status5_5: .incompatible,
-                                   status5_6: .incompatible,
-                                   status5_7: .unknown,
-                                   status5_8: .compatible)),
+                    results: .init(status5_6: .incompatible,
+                                   status5_7: .incompatible,
+                                   status5_8: .unknown,
+                                   status5_9: .compatible)),
                 latest: .init(
                     referenceName: "main",
-                    results: .init(status5_5: .incompatible,
-                                   status5_6: .incompatible,
-                                   status5_7: .unknown,
-                                   status5_8: .compatible))
+                    results: .init(status5_6: .incompatible,
+                                   status5_7: .incompatible,
+                                   status5_8: .unknown,
+                                   status5_9: .compatible))
               ),
               platformBuildInfo: .init(
                 stable: .init(

--- a/Sources/App/Core/SwiftVersion+Build.swift
+++ b/Sources/App/Core/SwiftVersion+Build.swift
@@ -18,27 +18,27 @@ extension SwiftVersion {
     // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1267#issuecomment-975379966
     // Patch versions are irrelevant here but the underlying type requires one, so use 0
     // in general.
-    static let v5_5: Self = .init(5, 5, 0)
     static let v5_6: Self = .init(5, 6, 0)
     static let v5_7: Self = .init(5, 7, 0)
     static let v5_8: Self = .init(5, 8, 0)
+    static let v5_9: Self = .init(5, 9, 0)
 
     /// Currently supported swift versions for building
     static var allActive: [Self] {
-        [.v5_5, .v5_6, .v5_7, .v5_8]
+        [.v5_6, .v5_7, .v5_8, .v5_9]
     }
 
     var xcodeVersion: String? {
         // NB: this is used for display purposes and not critical for compiler selection
         switch self {
-            case .v5_5:
-                return "Xcode 13.2.1"
             case .v5_6:
                 return "Xcode 13.4.1"
             case .v5_7:
                 return "Xcode 14.2"
             case .v5_8:
                 return "Xcode 14.3"
+            case .v5_9:
+                return "Xcode 15.0b1"
             default:
                 return nil
         }

--- a/Sources/App/Core/SwiftVersion+Build.swift
+++ b/Sources/App/Core/SwiftVersion+Build.swift
@@ -32,13 +32,13 @@ extension SwiftVersion {
         // NB: this is used for display purposes and not critical for compiler selection
         switch self {
             case .v5_6:
-                return "Xcode 13.4.1"
+                return "Xcode 13.4"
             case .v5_7:
                 return "Xcode 14.2"
             case .v5_8:
                 return "Xcode 14.3"
             case .v5_9:
-                return "Xcode 15.0b1"
+                return "Xcode 15.0"
             default:
                 return nil
         }

--- a/Sources/App/Views/PackageController/SwiftVersion+BuildResultParameter.swift
+++ b/Sources/App/Views/PackageController/SwiftVersion+BuildResultParameter.swift
@@ -15,5 +15,10 @@
 extension SwiftVersion: BuildResultPresentable {
     var displayName: String { "\(major).\(minor)" }
     var longDisplayName: String { "Swift \(displayName)" }
-    var note: String? { nil }
+    var note: String? {
+        switch self {
+            case .v5_9: return "beta"
+            default: return nil
+        }
+    }
 }

--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -302,25 +302,25 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
 
         do {
             let info = BuildInfo(stable: .some(.init(referenceName: "1.2.3",
-                                                     results: Results(status5_5: .compatible,
-                                                                      status5_6: .incompatible,
-                                                                      status5_7: .unknown,
-                                                                      status5_8: .compatible))),
+                                                     results: Results(status5_6: .compatible,
+                                                                      status5_7: .incompatible,
+                                                                      status5_8: .unknown,
+                                                                      status5_9: .compatible))),
                                  beta: nil,
                                  latest: nil)
             XCTAssertEqual(info?.compatibility, [.v1, .v4])
         }
         do {
             let info = BuildInfo(stable: .some(.init(referenceName: "1.2.3",
-                                                     results: Results(status5_5: .compatible,
-                                                                      status5_6: .incompatible,
-                                                                      status5_7: .unknown,
-                                                                      status5_8: .compatible))),
+                                                     results: Results(status5_6: .compatible,
+                                                                      status5_7: .incompatible,
+                                                                      status5_8: .unknown,
+                                                                      status5_9: .compatible))),
                                  beta: .some(.init(referenceName: "1.2.3-b1",
-                                                   results: Results(status5_5: .incompatible,
-                                                                    status5_6: .incompatible,
-                                                                    status5_7: .compatible,
-                                                                    status5_8: .unknown))),
+                                                   results: Results(status5_6: .incompatible,
+                                                                    status5_7: .incompatible,
+                                                                    status5_8: .compatible,
+                                                                    status5_9: .unknown))),
                                  latest: nil)
             XCTAssertEqual(info?.compatibility, [.v1, .v3, .v4])
         }
@@ -359,18 +359,18 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
     }
 
     func test_groupBuildInfo() throws {
-        let result1: BuildResults = .init(status5_5: .compatible,
-                                          status5_6: .compatible,
+        let result1: BuildResults = .init(status5_6: .compatible,
                                           status5_7: .compatible,
-                                          status5_8: .compatible)
-        let result2: BuildResults = .init(status5_5: .compatible,
-                                          status5_6: .incompatible,
+                                          status5_8: .compatible,
+                                          status5_9: .compatible)
+        let result2: BuildResults = .init(status5_6: .compatible,
                                           status5_7: .incompatible,
-                                          status5_8: .incompatible)
-        let result3: BuildResults = .init(status5_5: .unknown,
-                                          status5_6: .unknown,
+                                          status5_8: .incompatible,
+                                          status5_9: .incompatible)
+        let result3: BuildResults = .init(status5_6: .unknown,
                                           status5_7: .unknown,
-                                          status5_8: .unknown)
+                                          status5_8: .unknown,
+                                          status5_9: .unknown)
         do {  // three distinct groups
             let buildInfo: BuildInfo = .init(stable: .init(referenceName: "1.2.3",
                                                            results: result1),

--- a/Tests/AppTests/API+PackageController.swift
+++ b/Tests/AppTests/API+PackageController.swift
@@ -233,10 +233,10 @@ class API_PackageControllerTests: AppTestCase {
 
         // validate
         XCTAssertEqual(res?.referenceName, "main")
-        XCTAssertEqual(res?.results.v5_5, .init(parameter: .v1, status: .incompatible))
-        XCTAssertEqual(res?.results.v5_6, .init(parameter: .v2, status: .unknown))
-        XCTAssertEqual(res?.results.v5_7, .init(parameter: .v3, status: .compatible))
-        XCTAssertEqual(res?.results.v5_8, .init(parameter: .v4, status: .compatible))
+        XCTAssertEqual(res?.results.v5_6, .init(parameter: .v1, status: .incompatible))
+        XCTAssertEqual(res?.results.v5_7, .init(parameter: .v2, status: .unknown))
+        XCTAssertEqual(res?.results.v5_8, .init(parameter: .v3, status: .compatible))
+        XCTAssertEqual(res?.results.v5_9, .init(parameter: .v4, status: .compatible))
     }
 
     func test_platformBuildInfo() throws {
@@ -275,13 +275,13 @@ class API_PackageControllerTests: AppTestCase {
 
         // validate
         XCTAssertEqual(res?.stable?.referenceName, "1.2.3")
-        XCTAssertEqual(res?.stable?.results.v5_5,
-                       .init(parameter: .v1, status: .unknown))
         XCTAssertEqual(res?.stable?.results.v5_6,
-                       .init(parameter: .v2, status: .incompatible))
+                       .init(parameter: .v1, status: .unknown))
         XCTAssertEqual(res?.stable?.results.v5_7,
-                       .init(parameter: .v3, status: .compatible))
+                       .init(parameter: .v2, status: .incompatible))
         XCTAssertEqual(res?.stable?.results.v5_8,
+                       .init(parameter: .v3, status: .compatible))
+        XCTAssertEqual(res?.stable?.results.v5_9,
                        .init(parameter: .v4, status: .unknown))
         XCTAssertNil(res?.beta)
         XCTAssertNil(res?.latest)
@@ -344,9 +344,9 @@ class API_PackageControllerTests: AppTestCase {
         XCTAssertEqual(res.platform?.stable?.referenceName, "1.2.3")
         XCTAssertEqual(res.platform?.beta?.referenceName, "2.0.0-b1")
         XCTAssertEqual(res.swiftVersion?.latest?.referenceName, "main")
-        XCTAssertEqual(res.swiftVersion?.latest?.results.v5_7.status, .compatible)
-        XCTAssertEqual(res.swiftVersion?.latest?.results.v5_6.status, .incompatible)
-        XCTAssertEqual(res.swiftVersion?.latest?.results.v5_5.status, .unknown)
+        XCTAssertEqual(res.swiftVersion?.latest?.results.v5_8.status, .compatible)
+        XCTAssertEqual(res.swiftVersion?.latest?.results.v5_7.status, .incompatible)
+        XCTAssertEqual(res.swiftVersion?.latest?.results.v5_6.status, .unknown)
         XCTAssertEqual(res.swiftVersion?.stable?.referenceName, "1.2.3")
         XCTAssertEqual(res.swiftVersion?.beta?.referenceName, "2.0.0-b1")
     }

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -547,7 +547,7 @@ class ApiTests: AppTestCase {
         let owner = "owner"
         let repo = "repo"
         let p = try savePackage(on: app.db, "1")
-        let v = try Version(package: p, latest: .release, reference: .tag(.init(1, 2, 3)))
+        let v = try Version(package: p, latest: .release, reference: .tag(1, 2, 3))
         try await v.save(on: app.db)
         try await Repository(package: p,
                              defaultBranch: "main",
@@ -555,9 +555,9 @@ class ApiTests: AppTestCase {
                              name: repo,
                              owner: owner).save(on: app.db)
         // add builds
-        try await Build(version: v, platform: .linux, status: .ok, swiftVersion: .init(5, 6, 0))
+        try await Build(version: v, platform: .linux, status: .ok, swiftVersion: .v2)
             .save(on: app.db)
-        try await Build(version: v, platform: .macosXcodebuild, status: .ok, swiftVersion: .init(5, 5, 2))
+        try await Build(version: v, platform: .macosXcodebuild, status: .ok, swiftVersion: .v1)
             .save(on: app.db)
 
         let event = ActorIsolated<TestEvent?>(nil)
@@ -576,7 +576,7 @@ class ApiTests: AppTestCase {
                 let badge = try res.content.decode(Badge.self)
                 XCTAssertEqual(badge.schemaVersion, 1)
                 XCTAssertEqual(badge.label, "Swift Compatibility")
-                XCTAssertEqual(badge.message, "5.6 | 5.5")
+                XCTAssertEqual(badge.message, "5.7 | 5.6")
                 XCTAssertEqual(badge.isError, false)
                 XCTAssertEqual(badge.color, "F05138")
                 XCTAssertEqual(badge.cacheSeconds, 6*3600)

--- a/Tests/AppTests/BadgeTests.swift
+++ b/Tests/AppTests/BadgeTests.swift
@@ -20,7 +20,7 @@ import XCTest
 class BadgeTests: AppTestCase {
 
     func test_badgeMessage_swiftVersions() throws {
-        XCTAssertEqual(Badge.badgeMessage(swiftVersions: [.v1, .v2, .v3]), "5.7 | 5.6 | 5.5")
+        XCTAssertEqual(Badge.badgeMessage(swiftVersions: [.v1, .v2, .v3]), "5.8 | 5.7 | 5.6")
         XCTAssertNil(Badge.badgeMessage(swiftVersions: []))
     }
 

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -190,7 +190,7 @@ class BuildTriggerTests: AppTestCase {
          // just assert what the first one actually is so we test the right thing
          XCTAssertEqual(BuildPair.all.first, .init(.ios, .v1))
          // substitute in build with a different patch version
-         let existing = allExceptFirst + [.init(.ios, .init(5, 5, 1))]
+        let existing = allExceptFirst + [.init(.ios, .v1.incrementingPatchVersion())]
 
          // MUT & validate x.y.1 is matched as an existing x.y build
          XCTAssertEqual(missingPairs(existing: existing), Set())
@@ -270,7 +270,7 @@ class BuildTriggerTests: AppTestCase {
         XCTAssertEqual(queries.count, 1)
         XCTAssertEqual(queries.value.map { $0.variables["VERSION_ID"] }, [versionId.uuidString])
         XCTAssertEqual(queries.value.map { $0.variables["BUILD_PLATFORM"] }, ["ios"])
-        XCTAssertEqual(queries.value.map { $0.variables["SWIFT_VERSION"] }, ["5.5"])
+        XCTAssertEqual(queries.value.map { $0.variables["SWIFT_VERSION"] }, ["5.6"])
 
         // ensure the Build stubs is created to prevent re-selection
         let v = try await Version.find(versionId, on: app.db)
@@ -1038,7 +1038,7 @@ class BuildTriggerTests: AppTestCase {
                             version: v,
                             platform: .ios,
                             status: .ok,
-                            swiftVersion: .init(5, 7, 1)).save(on: app.db)
+                            swiftVersion: .v1.incrementingPatchVersion()).save(on: app.db)
         }
 
         // MUT
@@ -1046,7 +1046,7 @@ class BuildTriggerTests: AppTestCase {
         XCTAssertEqual(res.count, 1)
         let triggerInfo = try XCTUnwrap(res.first)
         XCTAssertEqual(triggerInfo.pairs.count, 23)
-        XCTAssertTrue(!triggerInfo.pairs.contains(.init(.ios, .v3)))
+        XCTAssertTrue(!triggerInfo.pairs.contains(.init(.ios, .v1)))
     }
 
 }

--- a/Tests/AppTests/Helpers/SwiftVersion+ext.swift
+++ b/Tests/AppTests/Helpers/SwiftVersion+ext.swift
@@ -71,9 +71,9 @@ extension SwiftVersion {
     /// ```
     ///
     /// And then all that remains is to adjust the mapping below whenever we change the range of Swift versions.
-    static var v1: Self { .v5_5 }
-    static var v2: Self { .v5_6 }
-    static var v3: Self { .v5_7 }
-    static var v4: Self { .v5_8 }
+    static var v1: Self { .v5_6 }
+    static var v2: Self { .v5_7 }
+    static var v3: Self { .v5_8 }
+    static var v4: Self { .v5_9 }
 
 }

--- a/Tests/AppTests/Helpers/SwiftVersion+ext.swift
+++ b/Tests/AppTests/Helpers/SwiftVersion+ext.swift
@@ -76,4 +76,7 @@ extension SwiftVersion {
     static var v3: Self { .v5_8 }
     static var v4: Self { .v5_9 }
 
+    func incrementingPatchVersion(by value: Int = 1) -> Self {
+        .init(major, minor, patch + value)
+    }
 }

--- a/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
+++ b/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
@@ -40,22 +40,22 @@ extension API.PackageController.GetRoute.Model {
             swiftVersionBuildInfo: .init(
                 stable: NamedBuildResults(
                     referenceName: "5.2.3",
-                    results: .init(status5_5: .incompatible,
-                                   status5_6: .incompatible,
-                                   status5_7: .unknown,
-                                   status5_8: .compatible)),
+                    results: .init(status5_6: .incompatible,
+                                   status5_7: .incompatible,
+                                   status5_8: .unknown,
+                                   status5_9: .compatible)),
                 beta: NamedBuildResults(
                     referenceName: "6.0.0-b1",
-                    results: .init(status5_5: .incompatible,
-                                   status5_6: .compatible,
+                    results: .init(status5_6: .incompatible,
                                    status5_7: .compatible,
-                                   status5_8: .compatible)),
+                                   status5_8: .compatible,
+                                   status5_9: .compatible)),
                 latest: NamedBuildResults(
                     referenceName: "main",
-                    results: .init(status5_5: .incompatible,
-                                   status5_6: .incompatible,
-                                   status5_7: .unknown,
-                                   status5_8: .compatible))),
+                    results: .init(status5_6: .incompatible,
+                                   status5_7: .incompatible,
+                                   status5_8: .unknown,
+                                   status5_9: .compatible))),
             platformBuildInfo: .init(
                 stable: NamedBuildResults(
                     referenceName: "5.2.3",

--- a/Tests/AppTests/PackageCollectionControllerTests.swift
+++ b/Tests/AppTests/PackageCollectionControllerTests.swift
@@ -47,7 +47,7 @@ class PackageCollectionControllerTests: AppTestCase {
             try Build(version: v,
                       platform: .ios,
                       status: .ok,
-                      swiftVersion: .v2).save(on: app.db).wait()
+                      swiftVersion: .init(5, 6, 0)).save(on: app.db).wait()
             try Target(version: v, name: "t1").save(on: app.db).wait()
         }
         try Repository(package: p,

--- a/Tests/AppTests/PackageCollectionTests.swift
+++ b/Tests/AppTests/PackageCollectionTests.swift
@@ -227,8 +227,8 @@ class PackageCollectionTests: AppTestCase {
         XCTAssertEqual(res.version, "1.2.3")
         XCTAssertEqual(res.summary, "Bar")
         XCTAssertEqual(res.verifiedCompatibility, [
-            .init(platform: .init(name: "ios"), swiftVersion: .init("5.5")),
-            .init(platform: .init(name: "macos"), swiftVersion: .init("5.6")),
+            .init(platform: .init(name: "ios"), swiftVersion: .init("5.6")),
+            .init(platform: .init(name: "macos"), swiftVersion: .init("5.7")),
         ])
         XCTAssertEqual(res.license, .init(name: "MIT", url: URL(string: "https://foo/mit")!))
         XCTAssertEqual(res.createdAt, Date(timeIntervalSince1970: 0))
@@ -428,7 +428,7 @@ class PackageCollectionTests: AppTestCase {
             try Build(version: v,
                       platform: .ios,
                       status: .ok,
-                      swiftVersion: .v2).save(on: app.db).wait()
+                      swiftVersion: .init(5, 6, 0)).save(on: app.db).wait()
             try Target(version: v, name: "t1").save(on: app.db).wait()
         }
         // second package

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -191,10 +191,10 @@ class WebpageSnapshotTests: SnapshotTestCase {
         var model = API.PackageController.GetRoute.Model.mock
         do {
             let compatible = API.PackageController.GetRoute.Model.SwiftVersionResults(
-                status5_5: .compatible,
                 status5_6: .compatible,
                 status5_7: .compatible,
-                status5_8: .compatible
+                status5_8: .compatible,
+                status5_9: .compatible
             )
             model.swiftVersionBuildInfo = .init(
                 stable: .init(referenceName: "5.2.5", results: compatible),

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.html
@@ -98,7 +98,7 @@
             <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new/choose">raise an issue</a>.
           </p>
           <hr/>
-          <h3>Swift 5.8</h3>
+          <h3>Swift 5.9</h3>
           <ul class="matrix builds">
             <li class="row">
               <div class="row-labels">
@@ -264,7 +264,7 @@
             </li>
           </ul>
           <hr/>
-          <h3>Swift 5.7</h3>
+          <h3>Swift 5.8</h3>
           <ul class="matrix builds">
             <li class="row">
               <div class="row-labels">
@@ -433,7 +433,7 @@
             </li>
           </ul>
           <hr/>
-          <h3>Swift 5.6</h3>
+          <h3>Swift 5.7</h3>
           <ul class="matrix builds">
             <li class="row">
               <div class="row-labels">
@@ -599,7 +599,7 @@
             </li>
           </ul>
           <hr/>
-          <h3>Swift 5.5</h3>
+          <h3>Swift 5.6</h3>
           <ul class="matrix builds">
             <li class="row">
               <div class="row-labels">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildShow.1.html
@@ -11,9 +11,9 @@
     <title>Bar &ndash; Build Information &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Bar &ndash; Build Information &ndash; Swift Package Index"/>
     <meta property="og:title" content="Bar &ndash; Build Information &ndash; Swift Package Index"/>
-    <meta name="description" content="Compatibility information for Bar. Check compatibility with Swift 5.6 on iOS with full build logs."/>
-    <meta name="twitter:description" content="Compatibility information for Bar. Check compatibility with Swift 5.6 on iOS with full build logs."/>
-    <meta property="og:description" content="Compatibility information for Bar. Check compatibility with Swift 5.6 on iOS with full build logs."/>
+    <meta name="description" content="Compatibility information for Bar. Check compatibility with Swift 5.7 on iOS with full build logs."/>
+    <meta name="twitter:description" content="Compatibility information for Bar. Check compatibility with Swift 5.7 on iOS with full build logs."/>
+    <meta property="og:description" content="Compatibility information for Bar. Check compatibility with Swift 5.7 on iOS with full build logs."/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:image" content="http://localhost:8080/images/logo.png"/>
     <meta property="og:image" content="http://localhost:8080/images/logo.png"/>
@@ -85,7 +85,7 @@
             </a>
           </li>
           <li>
-            <span>Swift 5.6 on iOS at main</span>
+            <span>Swift 5.7 on iOS at main</span>
           </li>
         </ul>
       </div>
@@ -97,9 +97,9 @@
           <p>
             <strong class="green">Successful</strong> build of 
             <a href="/foo/bar">Bar</a> with 
-            <strong>Swift 5.6</strong> for 
+            <strong>Swift 5.7</strong> for 
             <strong>iOS</strong> using 
-            <strong>Xcode 13.4.1</strong> at 
+            <strong>Xcode 14.2</strong> at 
             <strong>main</strong>.
           </p>
           <h3>Build Command</h3>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -162,7 +162,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -181,7 +183,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -162,16 +162,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -181,16 +181,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -165,16 +165,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -184,16 +184,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -165,7 +165,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -184,7 +186,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -166,16 +166,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -185,16 +185,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -166,7 +166,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -185,7 +187,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -162,7 +162,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -181,7 +183,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -162,16 +162,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -181,16 +181,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -193,16 +193,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -212,16 +212,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -193,7 +193,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -212,7 +214,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -368,7 +368,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -387,7 +389,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -368,16 +368,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -387,16 +387,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -157,7 +157,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -176,7 +178,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -157,16 +157,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -176,16 +176,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -165,16 +165,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -184,16 +184,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -165,7 +165,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -184,7 +186,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -164,7 +164,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -183,7 +185,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -164,16 +164,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -183,16 +183,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -165,16 +165,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -184,16 +184,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -165,7 +165,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -184,7 +186,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -163,16 +163,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
                         <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.5"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -163,7 +163,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -162,7 +162,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
@@ -181,7 +183,9 @@
                         </p>
                       </div>
                       <div class="column-labels">
-                        <div>5.9</div>
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -162,16 +162,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
-                        <div class="unknown" title="No build information available for Swift 5.7"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
                         <div class="incompatible" title="Build failed with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -181,16 +181,16 @@
                         </p>
                       </div>
                       <div class="column-labels">
+                        <div>5.9</div>
                         <div>5.8</div>
                         <div>5.7</div>
                         <div>5.6</div>
-                        <div>5.5</div>
                       </div>
                       <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
                         <div class="compatible" title="Built successfully with Swift 5.8"></div>
                         <div class="compatible" title="Built successfully with Swift 5.7"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.6"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.5"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
                       </div>
                     </li>
                   </ul>


### PR DESCRIPTION
Merge after #2422

The `SwiftVersion` test simplification has made this merge diff much nicer and will help a lot with future changes, saving a good couple of hours of tedious fiddling each time.

This completes all the updates required to add support for Swift 5.9.