### PR TITLE
Package pages should use the canonical capitalisation for URLs from the database

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -30,6 +30,10 @@ extension PackageShow {
             self.packageSchema = packageSchema
             super.init(path: path)
         }
+        
+        override func pageCanonicalURL() -> String? {
+            SiteURL.package(.value(model.repositoryOwner), .value(model.repositoryName), .none).absoluteURL()
+        }
 
         override func pageTitle() -> String? {
             model.title

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -44,7 +44,7 @@ class PublicPage {
             .viewport(.accordingToDevice, initialScale: 1),
             .meta(.charset(.utf8)),
             .siteName("The Swift Package Index"),
-            .url(SiteURL.absoluteURL(path)),
+            .url(canonicalURL()),
             .title(title()),
             .description(description()),
             .twitterCardType(.summary),
@@ -115,6 +115,21 @@ class PublicPage {
         <script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
         <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
         """
+    }
+    
+    /// The canonical URL for the current page, as determined by the page's `path`.
+    /// - Returns: A string indicating the canonical URL for the current page.
+    final func canonicalURL() -> String {
+        guard let pageCanonicalURL = pageCanonicalURL()
+        else { return SiteURL.absoluteURL(path) }
+        
+        return pageCanonicalURL
+    }
+    
+    /// The canonical URL for the current page, as determined by the page.
+    /// - Returns: A string indicating the canonical URL for the current page.
+    func pageCanonicalURL() -> String? {
+        nil
     }
 
     /// The full page title, including the site name.

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -231,6 +231,17 @@ class WebpageSnapshotTests: SnapshotTestCase {
         assertSnapshot(matching: page, as: .html)
     }
 
+    func test_PackageShowView_canonicalURL_noImageSnapshots() throws {
+        // In production, the owner and repository name in the view model are fetched from
+        // the database and have canonical capitalisation.
+        var model = API.PackageController.GetRoute.Model.mock
+        model.repositoryOwner = "owner"
+        model.repositoryName = "repo"
+        let page = { PackageShow.View(path: "/OWNER/Repo", model: model, packageSchema: .mock).document() }
+        
+        assertSnapshot(matching: page, as: .html)
+    }
+    
     func test_PackageShowView_missingPackage() throws {
         let page = { MissingPackage.View(path: "", model: .mock).document() }
         assertSnapshot(matching: page, as: .html)

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
@@ -1,0 +1,402 @@
+<!DOCTYPE html>
+<html lang="en"><!--Version: test--><!--DB Id: db-id-->
+  <head>
+    <meta name="robots" content="noindex"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="UTF-8"/>
+    <meta property="og:site_name" content="The Swift Package Index"/>
+    <link rel="canonical" href="http://localhost:8080/owner/repo"/>
+    <meta name="twitter:url" content="http://localhost:8080/owner/repo"/>
+    <meta property="og:url" content="http://localhost:8080/owner/repo"/>
+    <title>Alamofire &ndash; Swift Package Index</title>
+    <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
+    <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>
+    <meta name="description" content="Alamofire by Alamofire on the Swift Package Index – Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. V…"/>
+    <meta name="twitter:description" content="Alamofire by Alamofire on the Swift Package Index – Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. V…"/>
+    <meta property="og:description" content="Alamofire by Alamofire on the Swift Package Index – Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. V…"/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:image" content="http://localhost:8080/images/logo.png"/>
+    <meta property="og:image" content="http://localhost:8080/images/logo.png"/>
+    <link rel="shortcut icon" href="/images/logo-small.png" type="image/png"/>
+    <link rel="stylesheet" href="/main.css?test" data-turbolinks-track="reload"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added" href="http://localhost:8080/packages.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Releases" href="http://localhost:8080/releases.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Releases" href="http://localhost:8080/releases.rss?major=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
+    <script src="/main.js?test" data-turbolinks-track="reload" defer></script>
+  </head>
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE--><!--10-->
+    <div class="staging">Staging / Development</div>
+    <header>
+      <div class="inner">
+        <a href="/">
+          <h1>
+            <img alt="The Swift Package Index logo." src="/images/logo.svg"/>Swift Package Index
+          </h1>
+        </a>
+        <nav>
+          <ul>
+            <li>
+              <a class="supporters" href="/supporters">Supporters</a>
+            </li>
+            <li>
+              <a href="/add-a-package">Add a Package</a>
+            </li>
+            <li>
+              <a href="https://blog.swiftpackageindex.com">Blog</a>
+            </li>
+            <li>
+              <a href="/faq">FAQ</a>
+            </li>
+            <li class="search">
+              <form action="/search">
+                <input id="query" name="query" type="search" placeholder="Search" spellcheck="false" autocomplete="off" data-gramm="false" data-focus="false"/>
+                <button type="submit">
+                  <div title="Search"></div>
+                </button>
+              </form>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <nav class="breadcrumbs">
+      <div class="inner">
+        <ul>
+          <li>
+            <a href="/">
+              <span>Home</span>
+            </a>
+          </li>
+          <li>
+            <a href="/owner">
+              <span>Alamofire</span>
+            </a>
+          </li>
+          <li>
+            <span>Alamofire</span>
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <main>
+      <div class="inner">
+        <div class="two-column v-end">
+          <div class="package-title">
+            <h2>Alamofire</h2>
+            <small>
+              <a href="https://github.com/owner">owner</a>
+              <span>/</span>
+              <a href="https://github.com/owner/repo">repo</a>
+            </small>
+          </div>
+          <div data-controller="modal-panel">
+            <button data-modal-panel-target="button" data-action="click->modal-panel#show">Use this Package</button>
+            <section data-modal-panel-target="panel">
+              <button class="close" data-action="click->modal-panel#hide">&times;</button>
+              <p>How you add this package to your project depends on what kind of project you're developing.</p>
+              <h4>When working with an Xcode project:</h4>
+              <form class="copyable-input">
+                <input type="text" data-button-name="Copy Package URL" data-event-name="Copy Xcodeproj Package URL Button" value="https://github.com/Alamofire/Alamofire.git" readonly/>
+              </form>
+              <h4>When working with a Swift Package Manager manifest:</h4>
+              <p>
+                <span class="stable">5.2.0</span>
+              </p>
+              <form class="copyable-input">
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, from: &quot;5.2.0&quot;)" readonly/>
+              </form>
+              <p>
+                <span class="beta">5.3.0-beta.1</span>
+              </p>
+              <form class="copyable-input">
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, from: &quot;5.3.0-beta.1&quot;)" readonly/>
+              </form>
+              <p>
+                <span class="branch">main</span>
+              </p>
+              <form class="copyable-input">
+                <input type="text" data-button-name="Copy Code Snippet" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
+              </form>
+            </section>
+          </div>
+        </div>
+        <hr class="tight"/>
+        <p class="summary">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. Vivamus vehicula urna eget ipsum laoreet, sed porttitor sapien malesuada. Mauris faucibus tellus at augue vehicula, vitae aliquet felis ullamcorper. Praesent vitae leo rhoncus, egestas elit id, porttitor lacus. Cras ac bibendum mauris. Praesent luctus quis nulla sit amet tempus. Ut pharetra non augue sed pellentesque.</p>
+        <article class="details two-column">
+          <section>
+            <section>
+              <ul class="main-metadata">
+                <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
+                <li class="history">In development for 2 months, with 
+                  <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
+                  <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
+                </li>
+                <li class="activity">There are 
+                  <a href="https://github.com/Alamofire/Alamofire/issues">27 open issues</a> and 
+                  <a href="https://github.com/Alamofire/Alamofire/pulls">5 open pull requests</a>. The last issue was closed 5 days ago and the last pull request was merged/closed 6 days ago.
+                </li>
+                <li class="dependencies">This package depends on 2 other packages.</li>
+                <li class="license"> licensed</li>
+                <li class="stars">17 stars</li>
+                <li class="libraries">3 libraries</li>
+                <li class="executables">1 executable</li>
+                <li class="plugins">No plugins</li>
+              </ul>
+            </section>
+            <hr class="minor"/>
+            <section class="main-compatibility">
+              <div class="two-column v-end">
+                <h3>Compatibility</h3>
+                <a href="/owner/repo/builds">Full Build Results</a>
+              </div>
+              <div class="matrices">
+                <a href="/owner/repo/builds">
+                  <ul class="matrix compatibility">
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="stable">5.2.3</span> and 
+                          <span class="branch">main</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
+                        <div>5.8</div>
+                        <div>5.7</div>
+                        <div>5.6</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="unknown" title="No build information available for Swift 5.8"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.7"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
+                      </div>
+                    </li>
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="beta">6.0.0-b1</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>5.9
+                          <small>(beta)</small>
+                        </div>
+                        <div>5.8</div>
+                        <div>5.7</div>
+                        <div>5.6</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.8"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.7"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.6"></div>
+                      </div>
+                    </li>
+                  </ul>
+                </a>
+                <a href="/owner/repo/builds">
+                  <ul class="matrix compatibility">
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="stable">5.2.3</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>iOS</div>
+                        <div>macOS</div>
+                        <div>watchOS</div>
+                        <div>tvOS</div>
+                        <div>Linux</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with iOS"></div>
+                        <div class="unknown" title="No build information available for macOS"></div>
+                        <div class="unknown" title="No build information available for watchOS"></div>
+                        <div class="unknown" title="No build information available for tvOS"></div>
+                        <div class="unknown" title="No build information available for Linux"></div>
+                      </div>
+                    </li>
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="beta">6.0.0-b1</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>iOS</div>
+                        <div>macOS</div>
+                        <div>watchOS</div>
+                        <div>tvOS</div>
+                        <div>Linux</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with iOS"></div>
+                        <div class="compatible" title="Built successfully with macOS"></div>
+                        <div class="unknown" title="No build information available for watchOS"></div>
+                        <div class="compatible" title="Built successfully with tvOS"></div>
+                        <div class="compatible" title="Built successfully with Linux"></div>
+                      </div>
+                    </li>
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="branch">main</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>iOS</div>
+                        <div>macOS</div>
+                        <div>watchOS</div>
+                        <div>tvOS</div>
+                        <div>Linux</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with iOS"></div>
+                        <div class="compatible" title="Built successfully with macOS"></div>
+                        <div class="compatible" title="Built successfully with watchOS"></div>
+                        <div class="compatible" title="Built successfully with tvOS"></div>
+                        <div class="compatible" title="Built successfully with Linux"></div>
+                      </div>
+                    </li>
+                  </ul>
+                </a>
+              </div>
+            </section>
+          </section>
+          <section>
+            <section class="sidebar-links">
+              <ul>
+                <li>
+                  <a class="github" href="https://github.com/owner/repo">View on GitHub</a>
+                </li>
+                <li class="try-in-playground">
+                  <a href="spi-playgrounds://open?dependencies=owner/repo">Try in a Playground</a>
+                  <div id="app-download-explainer" class="hidden">
+                    <strong>Launching the SPI Playgrounds app&hellip;</strong>
+                    <p>If nothing happens, you may not have the app installed. 
+                      <a href="/try-in-a-playground?dependencies=owner/repo">Download the Swift Package Index Playgrounds app</a> and try again.
+                    </p>
+                  </div>
+                </li>
+              </ul>
+            </section>
+            <hr class="minor"/>
+            <section class="sidebar-versions" aria-label="Versions">
+              <ul>
+                <li class="stable">
+                  <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
+                    <span class="stable">5.2.0</span>
+                  </a>
+                  <strong>Latest Stable Release</strong>
+                  <small>Released 12 days ago</small>
+                </li>
+                <li class="beta">
+                  <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
+                    <span class="beta">5.3.0-beta.1</span>
+                  </a>
+                  <strong>Latest Beta Release</strong>
+                  <small>Released 4 days ago</small>
+                </li>
+                <li class="branch">
+                  <a href="https://github.com/Alamofire/Alamofire">
+                    <span class="branch">main</span>
+                  </a>
+                  <strong>Default Branch</strong>
+                  <small>Modified 12 minutes ago</small>
+                </li>
+              </ul>
+            </section>
+            <hr class="minor"/>
+            <section class="sidebar-package-authors">
+              <small>
+                <strong>Do you maintain this package?</strong> Get shields.io compatibility badges and learn how to control our build system. 
+                <a href="/owner/repo/information-for-package-maintainers">Learn more</a>.
+              </small>
+            </section>
+          </section>
+        </article>
+        <section data-controller="tab-bar">
+          <nav>
+            <ul class="tab-list">
+              <li id="readme" data-tab-bar-target="tab" data-action="click->tab-bar#updateTab">README</li>
+              <li id="releases" data-tab-bar-target="tab" data-action="click->tab-bar#updateTab">Release Notes</li>
+            </ul>
+          </nav>
+          <section data-tab-bar-target="content">
+            <turbo-frame id="readme_content" src="/owner/repo/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+              <div>
+                <div class="spinner">
+                  <div class="rect1"></div>
+                  <div class="rect2"></div>
+                  <div class="rect3"></div>
+                  <div class="rect4"></div>
+                  <div class="rect5"></div>
+                </div>
+              </div>
+            </turbo-frame>
+          </section>
+          <section data-tab-bar-target="content">
+            <turbo-frame id="releases_content" src="/owner/repo/releases">
+              <div>
+                <div class="spinner">
+                  <div class="rect1"></div>
+                  <div class="rect2"></div>
+                  <div class="rect3"></div>
+                  <div class="rect4"></div>
+                  <div class="rect5"></div>
+                </div>
+              </div>
+            </turbo-frame>
+          </section>
+          <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <time datetime="2001-01-01">Last updated on 1 Jan 2001</time>
+          </p>
+        </section>
+      </div>
+    </main>
+    <footer>
+      <div class="inner">
+        <nav>
+          <ul>
+            <li>
+              <a href="https://blog.swiftpackageindex.com">Blog</a>
+            </li>
+            <li>
+              <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a>
+            </li>
+            <li>
+              <a href="/privacy">Privacy and Cookies</a>
+            </li>
+            <li>
+              <a href="https://swiftpackageindex.statuspage.io">Uptime and System Status</a>
+            </li>
+            <li>
+              <a href="/build-monitor">Build System Monitor</a>
+            </li>
+            <li>
+              <a href="https://twitter.com/swiftpackages">Twitter</a>
+            </li>
+          </ul>
+          <small>The Swift Package Index is entirely funded by community sponsorship. Thank you to 
+            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server#funding-and-sponsorship">all our sponsors for their generosity</a>.
+          </small>
+          <small>The Swift Package Index is operated by SPI Operations Limited, a company registered in the UK with company number 13466692.</small>
+          <a rel="me" href="https://mas.to/@SwiftPackageIndex"></a>
+          <a rel="me" href="https://mas.to/@SwiftPackageUpdates"></a>
+        </nav>
+      </div>
+    </footer>
+    <div class="staging">Staging / Development</div>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
+  </body>
+</html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta charset="UTF-8"/>
     <meta property="og:site_name" content="The Swift Package Index"/>
-    <link rel="canonical" href="http://localhost:8080/"/>
-    <meta name="twitter:url" content="http://localhost:8080/"/>
-    <meta property="og:url" content="http://localhost:8080/"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
     <title>Alamofire &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
     <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>


### PR DESCRIPTION
Package page URLs are case-insensitive but the canonical URL shouldn't change when only the repository owner or repository name have a different case in the URL. Instead, we should use the capitalisation from the repository owner and repository name fields stored in the database.