### PR TITLE
Use `.url` instead of manually adding a `.link` for the canonical URL

### DIFF
--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -74,10 +74,7 @@ struct DocumentationPageProcessor {
             try document.head()?.append(self.stylesheetLink)
             if let canonicalUrl = self.canonicalUrl {
                 try document.head()?.append(
-                    Plot.Node.link(
-                        .rel(.canonical),
-                        .href(canonicalUrl)
-                    ).render()
+                    Plot.Node<HTML.HeadContext>.url(canonicalUrl).render()
                 )
             }
             try document.body()?.prepend(self.header)

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
@@ -8,6 +8,8 @@
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
   <link rel="canonical" href="https://example.com/owner/repo/canonical-ref">
+  <meta name="twitter:url" content="https://example.com/owner/repo/canonical-ref">
+  <meta property="og:url" content="https://example.com/owner/repo/canonical-ref">
  </head> 
  <body>
   <header class="spi">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
@@ -8,6 +8,8 @@
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
   <link rel="canonical" href="https://example.com/owner/repo/canonical-ref">
+  <meta name="twitter:url" content="https://example.com/owner/repo/canonical-ref">
+  <meta property="og:url" content="https://example.com/owner/repo/canonical-ref">
  </head> 
  <body>
   <header class="spi">


### PR DESCRIPTION
On documentation pages, we should use `.url`  instead of `.link` and manually constructing a `<link rel="canonical" />` element. This matches the behaviour of the `PublicPage` model for other static pages served by the site.