### PR TITLE
Revert #2434 after observing what DocC does with it

### DIFF
--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -74,6 +74,9 @@ struct DocumentationPageProcessor {
             try document.head()?.append(self.stylesheetLink)
             if let canonicalUrl = self.canonicalUrl {
                 try document.head()?.append(
+                    // We should not use `url` here as some of the DocC JavaScript lowercases
+                    // both the `og:url` and `twitter:url` properties, if present. It is better
+                    // to have no `og:url` and `twitter:url` properties than incorrect ones.
                     Plot.Node.link(
                         .rel(.canonical),
                         .href(canonicalUrl)

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -74,7 +74,10 @@ struct DocumentationPageProcessor {
             try document.head()?.append(self.stylesheetLink)
             if let canonicalUrl = self.canonicalUrl {
                 try document.head()?.append(
-                    Plot.Node<HTML.HeadContext>.url(canonicalUrl).render()
+                    Plot.Node.link(
+                        .rel(.canonical),
+                        .href(canonicalUrl)
+                    ).render()
                 )
             }
             try document.body()?.prepend(self.header)

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
@@ -8,8 +8,6 @@
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
   <link rel="canonical" href="https://example.com/owner/repo/canonical-ref">
-  <meta name="twitter:url" content="https://example.com/owner/repo/canonical-ref">
-  <meta property="og:url" content="https://example.com/owner/repo/canonical-ref">
  </head> 
  <body>
   <header class="spi">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
@@ -8,8 +8,6 @@
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">
   <link rel="canonical" href="https://example.com/owner/repo/canonical-ref">
-  <meta name="twitter:url" content="https://example.com/owner/repo/canonical-ref">
-  <meta property="og:url" content="https://example.com/owner/repo/canonical-ref">
  </head> 
  <body>
   <header class="spi">


### PR DESCRIPTION
Reverts #2434

#2434 seemed like an obvious change and was separate enough from the change we're about to push to warrant a separate pull request. Unforunately, we then discovered that once the DocC page is loaded inside the browser that it uses JavaScript to lowercase the `og:url` and `twitter:url` properties of the `head` element.

Luckily, it does not do the same for the `rel="canonical` element, which is what we were using before #2434.

Added a comment in addition to the revert so that we don't try and make this change again.