### PR TITLE
Use the canonical owner and repository capitalisation for documentation canonical URLs

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -228,10 +228,14 @@ enum PackageController {
         }
 
         let canonicalUrl: String? = {
-            guard let canonicalTarget = documentationMetadata.canonicalTarget else { return nil }
+            guard let canonicalOwner = documentationMetadata.owner,
+                  let canonicalRepository = documentationMetadata.repository,
+                  let canonicalTarget = documentationMetadata.canonicalTarget
+            else { return nil }
+            
             return Self.canonicalDocumentationUrl(from: "\(req.url)",
-                                                  owner: owner,
-                                                  repository: repository,
+                                                  owner: canonicalOwner,
+                                                  repository: canonicalRepository,
                                                   fromReference: reference,
                                                   toTarget: canonicalTarget)
         }()

--- a/Sources/App/Core/DocumentationVersion.swift
+++ b/Sources/App/Core/DocumentationVersion.swift
@@ -18,6 +18,8 @@ import Fluent
 import SemanticVersion
 
 struct DocumentationMetadata {
+    var owner: String?
+    var repository: String?
     var canonicalTarget: DocumentationTarget?
     var versions: [DocumentationVersion]
 
@@ -36,6 +38,8 @@ struct DocumentationMetadata {
             .field(Version.self, \.$commitDate)
             .field(Version.self, \.$publishedAt)
             .field(Version.self, \.$spiManifest)
+            .field(Repository.self, \.$owner)
+            .field(Repository.self, \.$name)
             .field(Repository.self, \.$ownerName)
             .all()
 
@@ -55,7 +59,9 @@ struct DocumentationMetadata {
                       updatedAt: result.model.publishedAt ?? result.model.commitDate)
         }
 
-        return .init(canonicalTarget: canonicalDocumentationTarget,
+        return .init(owner: results.first?.relation2?.owner,
+                     repository: results.first?.relation2?.name,
+                     canonicalTarget: canonicalDocumentationTarget,
                      versions: documentationVersions)
     }
 }


### PR DESCRIPTION
Merge After #2435

Documentation pages should use the canonical owner and repository capitalisation from the database, as the canonical URLs must not change when the page is loaded with a different case owner or repository.