### PR TITLE
Added `noindex` to documentation pages in dev/staging environment.

### DIFF
--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -71,6 +71,9 @@ struct DocumentationPageProcessor {
 
         do {
             document = try SwiftSoup.parse(rawHtml)
+            if let metaNoIndex = self.metaNoIndex {
+                try document.head()?.prepend(metaNoIndex)
+            }
             try document.head()?.append(self.stylesheetLink)
             if let canonicalUrl = self.canonicalUrl {
                 try document.head()?.append(
@@ -91,6 +94,14 @@ struct DocumentationPageProcessor {
         } catch {
             return nil
         }
+    }
+
+    var metaNoIndex: String? {
+        guard Environment.current != .production else { return nil }
+        return Plot.Node.meta(
+            .name("robots"),
+            .content("noindex")
+        ).render()
     }
 
     var stylesheetLink: String {

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
- <head> 
+ <head>
+  <meta name="robots" content="noindex"> 
   <meta charset="UTF-8"> 
   <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
   <title>DocC Template Page</title> 

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
- <head> 
+ <head>
+  <meta name="robots" content="noindex"> 
   <meta charset="UTF-8"> 
   <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
   <title>DocC Template Page</title> 

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
- <head> 
+ <head>
+  <meta name="robots" content="noindex"> 
   <meta charset="UTF-8"> 
   <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
   <title>DocC Template Page</title> 


### PR DESCRIPTION
It's a good job I checked this as part of #2442!

I've not seen *any* staging URLs in the search console, because the pages that link to staging documentation pages are already `noindex`ed, so I don't believe this has done any harm, but it's good to fix it!