### PR TITLE
Swapped CSS/JS test suite function names

### DIFF
--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -486,17 +486,17 @@ class PackageController_routesTests: AppTestCase {
 
         // MUT
         // test base url
-        try app.test(.GET, "/owner/package/1.2.3/js/a") {
+        try app.test(.GET, "/owner/package/1.2.3/css/a") {
             XCTAssertEqual($0.status, .ok)
-            XCTAssertEqual($0.content.contentType?.description, "application/javascript")
-            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/js/a")
+            XCTAssertEqual($0.content.contentType?.description, "text/css")
+            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/css/a")
         }
 
         // test path a/b
-        try app.test(.GET, "/owner/package/1.2.3/js/a/b") {
+        try app.test(.GET, "/owner/package/1.2.3/css/a/b") {
             XCTAssertEqual($0.status, .ok)
-            XCTAssertEqual($0.content.contentType?.description, "application/javascript")
-            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/js/a/b")
+            XCTAssertEqual($0.content.contentType?.description, "text/css")
+            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/css/a/b")
         }
     }
 
@@ -509,17 +509,17 @@ class PackageController_routesTests: AppTestCase {
 
         // MUT
         // test base url
-        try app.test(.GET, "/owner/package/1.2.3/css/a") {
+        try app.test(.GET, "/owner/package/1.2.3/js/a") {
             XCTAssertEqual($0.status, .ok)
-            XCTAssertEqual($0.content.contentType?.description, "text/css")
-            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/css/a")
+            XCTAssertEqual($0.content.contentType?.description, "application/javascript")
+            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/js/a")
         }
 
         // test path a/b
-        try app.test(.GET, "/owner/package/1.2.3/css/a/b") {
+        try app.test(.GET, "/owner/package/1.2.3/js/a/b") {
             XCTAssertEqual($0.status, .ok)
-            XCTAssertEqual($0.content.contentType?.description, "text/css")
-            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/css/a/b")
+            XCTAssertEqual($0.content.contentType?.description, "application/javascript")
+            XCTAssertEqual($0.body.asString(), "/owner/package/1.2.3/js/a/b")
         }
     }
 


### PR DESCRIPTION
I just noticed that the CSS/JS tests for documentation pages appear to have the inverse function names.

- `test_documentation_css` is testing JS related URLs.
- `test_documentation_js` is testing CSS related URLs.

I've swapped these round so they test the expected features.