### PR TITLE
Add and persist target type

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -656,8 +656,8 @@ extension Analyze {
     ///   - manifest: `Manifest` data
     /// - Returns: future
     static func createTargets(on database: Database, version: Version, manifest: Manifest) -> EventLoopFuture<Void> {
-        manifest.targets.compactMap { manifestTarget in
-            try? Target(version: version, name: manifestTarget.name)
+        manifest.targets.compactMap {
+            try? Target(version: version, name: $0.name, type: .init(manifestTargetType: $0.type))
         }
         .create(on: database)
     }

--- a/Sources/App/Migrations/064/UpdateTargetAddType.swift
+++ b/Sources/App/Migrations/064/UpdateTargetAddType.swift
@@ -1,0 +1,29 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+
+struct UpdateTargetAddType: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("targets")
+            .field("type", .json)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("targets")
+            .deleteField("type")
+            .update()
+    }
+}

--- a/Sources/App/Models/Target.swift
+++ b/Sources/App/Models/Target.swift
@@ -42,15 +42,50 @@ final class Target: Model, Content {
     @Field(key: "name")
     var name: String
 
+    @Field(key: "type")
+    var type: TargetType?
+
     // initializers
 
     init() { }
 
     init(id: UUID? = nil,
          version: Version,
-         name: String) throws {
+         name: String,
+         type: TargetType? = nil) throws {
         self.id = id
         self.$version.id = try version.requireID()
         self.name = name
+        self.type = type
+    }
+}
+
+
+enum TargetType: Codable, Equatable {
+    case binary
+    case executable
+    case macro
+    case plugin
+    case regular
+    case system
+    case test
+
+    init(manifestTargetType: Manifest.TargetType) {
+        switch manifestTargetType {
+            case .binary:
+                self = .binary
+            case .executable:
+                self = .executable
+            case .macro:
+                self = .macro
+            case .plugin:
+                self = .plugin
+            case .regular:
+                self = .regular
+            case .system:
+                self = .system
+            case .test:
+                self = .test
+        }
     }
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -281,6 +281,9 @@ public func configure(_ app: Application) throws -> String {
     do { // Migration 063 - add product names to search view
         app.migrations.add(UpdateSearchAddProductNames())
     }
+    do { // Migration 064 - add type to targets
+        app.migrations.add(UpdateTargetAddType())
+    }
 
     app.commands.use(Analyze.Command(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -758,7 +758,7 @@ class AnalyzerTests: AppTestCase {
         let v = try Version(id: UUID(), package: p, packageName: "1", reference: .tag(.init(1, 0, 0)))
         let m = Manifest(name: "1",
                          products: [],
-                         targets: [.init(name: "t1", type: .regular), .init(name: "t2", type: .regular)],
+                         targets: [.init(name: "t1", type: .regular), .init(name: "t2", type: .executable)],
                          toolsVersion: .init(version: "5.0.0"))
         try p.save(on: app.db).wait()
         try v.save(on: app.db).wait()
@@ -769,6 +769,7 @@ class AnalyzerTests: AppTestCase {
         // validation
         let targets = try Target.query(on: app.db).sort(\.$createdAt).all().wait()
         XCTAssertEqual(targets.map(\.name), ["t1", "t2"])
+        XCTAssertEqual(targets.map(\.type), [.regular, .executable])
     }
 
     func test_updatePackage() async throws {


### PR DESCRIPTION
This add `Target.type` and saves it. We're not doing anything with it yet but I wanted to get this in early so we start picking up `macro` targets without having to re-analyze too many versions.


⚠️ schema change ⚠️