### PR TITLE
Metanoindex

### DIFF
--- a/Public/robots.txt
+++ b/Public/robots.txt
@@ -1,6 +1,1 @@
-# All robots allowed
-User-agent: *
-Disallow: /builds/*
-
-# Sitemap files
 Sitemap: https://swiftpackageindex.com/sitemap.xml

--- a/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
@@ -26,6 +26,11 @@ enum BuildIndex {
             super.init(path: path)
         }
 
+        override func allowIndexing() -> Bool {
+            // Block this page from being indexed by search engines.
+            return false
+        }
+
         override func pageTitle() -> String? {
             "\(model.packageName) &ndash; Build Results"
         }

--- a/Sources/App/Views/PackageController/Builds/BuildShow+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+View.swift
@@ -26,6 +26,11 @@ enum BuildShow {
             super.init(path: path)
         }
 
+        override func allowIndexing() -> Bool {
+            // Block this page from being indexed by search engines.
+            return false
+        }
+
         override func pageTitle() -> String? {
             "\(model.packageName) &ndash; Build Information"
         }

--- a/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
+++ b/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
@@ -25,6 +25,11 @@ enum MaintainerInfoIndex {
             super.init(path: path)
         }
 
+        override func allowIndexing() -> Bool {
+            // Block this page from being indexed by search engines.
+            return false
+        }
+
         override func pageTitle() -> String? {
             "\(model.packageName) &ndash; Maintainer Information"
         }

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -94,14 +94,25 @@ class PublicPage {
         )
     }
 
-    /// For non-production environments, if a search engine requests the page, tell it not to index it.
+    /// if a search engine requests the page, we can tell it not to index it by including this meta tag.
+    /// For non-production environments, this will *always* return true.
     /// - Returns: Either nothing, or a <meta> element telling search engines not to index this content.
     final func metaNoIndex() -> Node<HTML.HeadContext> {
-        return .if(Environment.current != .production,
-                   .meta(
-                    .name("robots"),
-                    .content("noindex")
-                   ))
+        if Environment.current == .production && allowIndexing() {
+            return .empty
+        } else {
+            return .meta(
+                .name("robots"),
+                .content("noindex")
+            )
+
+        }
+    }
+
+    /// Whether this page should be indexed by search engines, as determined by the page.
+    /// - Returns: A booleam indicating whether the page should be indexed.
+    func allowIndexing() -> Bool {
+        return true
     }
 
     /// The Plausible analytics code to be inserted into the <head> element.


### PR DESCRIPTION
Fixes #2448

- [x] Allow `PublicPage` subclasses to opt-out of being indexed in production environments (staging will always `noindex`)
- [x] Opt out the Information for package maintainers and the two build pages (index and show)
- [x] Replace the `noindex`ing of the build detail pages from the `robots.txt`