### PR TITLE
Persist linkable paths count

### DIFF
--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -136,6 +136,7 @@ private extension DocUpload {
             id: .init(),
             error: dto.error,
             fileCount: dto.fileCount,
+            linkablePathsCount: dto.linkablePathsCount,
             logUrl: dto.logUrl,
             mbSize: dto.mbSize,
             status: dto.status

--- a/Sources/App/Controllers/API/API+DTOs.swift
+++ b/Sources/App/Controllers/API/API+DTOs.swift
@@ -39,6 +39,7 @@ extension API {
         var docArchives: [DocArchive]?
         var error: String?
         var fileCount: Int?
+        var linkablePathsCount: Int?
         var logUrl: String?
         var mbSize: Int?
         var status: DocUpload.Status

--- a/Sources/App/Controllers/API/Types+WithExample.swift
+++ b/Sources/App/Controllers/API/Types+WithExample.swift
@@ -250,6 +250,7 @@ extension API.PostDocReportDTO: WithExample {
         .init(docArchives: [.init(name: "linkedlist", title: "LinkedList")],
               error: nil,
               fileCount: 2639,
+              linkablePathsCount: 137,
               logUrl: "https://us-east-2.console.aws.amazon.com/logs/123456678",
               mbSize: 23,
               status: .ok)

--- a/Sources/App/Migrations/065/UpdateDocUploadAddLinkablePathsCount.swift
+++ b/Sources/App/Migrations/065/UpdateDocUploadAddLinkablePathsCount.swift
@@ -1,0 +1,29 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+
+struct UpdateDocUploadAddLinkablePathsCount: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("doc_uploads")
+            .field("linkable_paths_count", .int)
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("doc_uploads")
+            .deleteField("linkable_paths_count")
+            .update()
+    }
+}

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -64,6 +64,7 @@ final class DocUpload: Model, Content {
         id: Id? = nil,
         error: String? = nil,
         fileCount: Int? = nil,
+        linkablePathsCount: Int? = nil,
         logUrl: String? = nil,
         mbSize: Int? = nil,
         status: Status
@@ -71,6 +72,7 @@ final class DocUpload: Model, Content {
         self.id = id
         self.error = error
         self.fileCount = fileCount
+        self.linkablePathsCount = linkablePathsCount
         self.logUrl = logUrl
         self.mbSize = mbSize
         self.status = status

--- a/Sources/App/Models/DocUpload.swift
+++ b/Sources/App/Models/DocUpload.swift
@@ -46,6 +46,9 @@ final class DocUpload: Model, Content {
     @Field(key: "file_count")
     var fileCount: Int?
 
+    @Field(key: "linkable_paths_count")
+    var linkablePathsCount: Int?
+
     @Field(key: "log_url")
     var logUrl: String?
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -284,6 +284,9 @@ public func configure(_ app: Application) throws -> String {
     do { // Migration 064 - add type to targets
         app.migrations.add(UpdateTargetAddType())
     }
+    do { // Migration 065 - add linkable_paths_count to doc_uploads
+        app.migrations.add(UpdateDocUploadAddLinkablePathsCount())
+    }
 
     app.commands.use(Analyze.Command(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -345,6 +345,7 @@ class ApiTests: AppTestCase {
         do {  // MUT - initial insert
             let dto: API.PostDocReportDTO = .init(error: "too large",
                                                   fileCount: 70_000,
+                                                  linkablePathsCount: 137,
                                                   logUrl: "log url",
                                                   mbSize: 900,
                                                   status: .skipped)
@@ -362,6 +363,7 @@ class ApiTests: AppTestCase {
                     let d = try docUploads.first.unwrap()
                     XCTAssertEqual(d.error, "too large")
                     XCTAssertEqual(d.fileCount, 70_000)
+                    XCTAssertEqual(d.linkablePathsCount, 137)
                     XCTAssertEqual(d.logUrl, "log url")
                     XCTAssertEqual(d.mbSize, 900)
                     XCTAssertEqual(d.status, .skipped)


### PR DESCRIPTION
This saves the new doc report property `linkablePathsCount` to the database. The change is backwards compatible (but the new builder is already live, too).

⚠️ schema change ⚠️