### PR TITLE
Macro search

### DIFF
--- a/Sources/App/Core/SearchFilter/Filters/ProductTypeSearchFilter.swift
+++ b/Sources/App/Core/SearchFilter/Filters/ProductTypeSearchFilter.swift
@@ -65,6 +65,7 @@ extension ProductTypeSearchFilter {
     enum ProductType: String, Codable, CaseIterable {
         case executable
         case library
+        case macro
         case plugin
 
         var displayDescription: String {
@@ -73,6 +74,8 @@ extension ProductTypeSearchFilter {
                     return "Executable"
                 case .library:
                     return "Library"
+                case .macro:
+                    return "Macro"
                 case .plugin:
                     return "Plugin"
             }

--- a/Sources/App/Migrations/066/UpdateSearchAddMacroProductType.swift
+++ b/Sources/App/Migrations/066/UpdateSearchAddMacroProductType.swift
@@ -1,0 +1,104 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+
+struct UpdateSearchAddMacroProductType: AsyncMigration {
+    let dropSQL: SQLQueryString = "DROP MATERIALIZED VIEW search"
+
+    func prepare(on database: Database) async throws {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        // Create an index on targets.version_id - this speeds up search view creation
+        // dramatically.
+        try await db.raw("CREATE INDEX idx_targets_version_id ON targets (version_id)")
+            .run()
+
+        // ** IMPORTANT **
+        // When updating the query underlying the materialized view, make sure to also
+        // update the matching performance test in QueryPerformanceTests.test_Search_refresh!
+        try await db.raw(dropSQL).run()
+        try await db.raw("""
+            -- v11
+            CREATE MATERIALIZED VIEW search AS
+            SELECT
+              p.id AS package_id,
+              p.platform_compatibility,
+              p.score,
+              r.keywords,
+              r.last_commit_date,
+              r.license,
+              r.name AS repo_name,
+              r.owner AS repo_owner,
+              r.stars,
+              r.last_activity_at,
+              r.summary,
+              v.package_name,
+              ARRAY_LENGTH(doc_archives, 1) >= 1 AS has_docs,
+              ARRAY(
+                SELECT DISTINCT JSONB_OBJECT_KEYS(type) FROM products WHERE products.version_id = v.id
+                UNION
+                SELECT * FROM (
+                  SELECT DISTINCT JSONB_OBJECT_KEYS(type) AS "type" FROM targets
+                  WHERE targets.version_id = v.id) AS macro_targets
+                WHERE type = 'macro'
+              ) AS product_types,
+              ARRAY(SELECT DISTINCT name FROM products WHERE products.version_id = v.id) AS product_names,
+              TO_TSVECTOR(CONCAT_WS(' ', COALESCE(v.package_name, ''), r.name, COALESCE(r.summary, ''), ARRAY_TO_STRING(r.keywords, ' '))) AS tsvector
+            FROM packages p
+              JOIN repositories r ON r.package_id = p.id
+              JOIN versions v ON v.package_id = p.id
+            WHERE v.reference ->> 'branch' = r.default_branch
+            """).run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        try await db.raw(dropSQL).run()
+        try await db.raw("""
+            -- v10
+            CREATE MATERIALIZED VIEW search AS
+            SELECT
+              p.id AS package_id,
+              p.platform_compatibility,
+              p.score,
+              r.keywords,
+              r.last_commit_date,
+              r.license,
+              r.name AS repo_name,
+              r.owner AS repo_owner,
+              r.stars,
+              r.last_activity_at,
+              r.summary,
+              v.package_name,
+              ARRAY_LENGTH(doc_archives, 1) >= 1 AS has_docs,
+              ARRAY(SELECT DISTINCT JSONB_OBJECT_KEYS(type) FROM products WHERE products.version_id = v.id) AS product_types,
+              ARRAY(SELECT DISTINCT name FROM products WHERE products.version_id = v.id) AS product_names,
+              TO_TSVECTOR(CONCAT_WS(' ', COALESCE(v.package_name, ''), r.name, COALESCE(r.summary, ''), ARRAY_TO_STRING(r.keywords, ' '))) AS tsvector
+            FROM packages p
+              JOIN repositories r ON r.package_id = p.id
+              JOIN versions v ON v.package_id = p.id
+            WHERE v.reference ->> 'branch' = r.default_branch
+            """).run()
+
+        try await db.raw("DROP INDEX idx_targets_version_id").run()
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -287,6 +287,9 @@ public func configure(_ app: Application) throws -> String {
     do { // Migration 065 - add linkable_paths_count to doc_uploads
         app.migrations.add(UpdateDocUploadAddLinkablePathsCount())
     }
+    do { // Migration 066 - add virtual macro product type to search view
+        app.migrations.add(UpdateSearchAddMacroProductType())
+    }
 
     app.commands.use(Analyze.Command(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -115,7 +115,6 @@ class QueryPerformanceTests: XCTestCase {
     }
 
     func test_12_Search_refresh() async throws {
-        throw XCTSkip("run only after schema change with new index has been deployed")
         // We can't "explain analyze" the refresh itself so we need to measure the underlying
         // query.
         // Unfortunately, this means it'll need to be kept in sync when updating the search
@@ -155,7 +154,7 @@ class QueryPerformanceTests: XCTestCase {
               JOIN versions v ON v.package_id = p.id
             WHERE v.reference ->> 'branch' = r.default_branch
             """)
-        try await assertQueryPerformance(query, expectedCost: 31_300, variation: 500)
+        try await assertQueryPerformance(query, expectedCost: 55_000, variation: 500)
     }
 
 }

--- a/Tests/AppTests/SearchFilterTests.swift
+++ b/Tests/AppTests/SearchFilterTests.swift
@@ -431,11 +431,29 @@ class SearchFilterTests: AppTestCase {
         XCTAssertEqual(binds(filter.rightHandSide), ["{executable}"])
     }
 
+    func test_productTypeFilter_macro() throws {
+        // Test "virtual" macro product filter
+        let filter = try ProductTypeSearchFilter(expression: .init(operator: .is, value: "macro"))
+        XCTAssertEqual(filter.key, .productType)
+        XCTAssertEqual(filter.predicate, .init(operator: .contains,
+                                               bindableValue: .value("macro"),
+                                               displayValue: "Macro"))
+
+        // test view representation
+        XCTAssertEqual(filter.viewModel.description, "Package products contain a Macro")
+
+        // test sql representation
+        XCTAssertEqual(renderSQL(filter.leftHandSide), #""product_types""#)
+        XCTAssertEqual(renderSQL(filter.sqlOperator), "@>")
+        XCTAssertEqual(binds(filter.rightHandSide), ["{macro}"])
+    }
+
     func test_productTypeFilter_spelling() throws {
         let expectedDisplayValues = [
             ProductTypeSearchFilter.ProductType.executable: "Package products contain an Executable",
             ProductTypeSearchFilter.ProductType.plugin: "Package products contain a Plugin",
-            ProductTypeSearchFilter.ProductType.library: "Package products contain a Library"
+            ProductTypeSearchFilter.ProductType.library: "Package products contain a Library",
+            ProductTypeSearchFilter.ProductType.macro: "Package products contain a Macro"
         ]
 
         for type in ProductTypeSearchFilter.ProductType.allCases {


### PR DESCRIPTION
Merge after #2480 

This add support for `product:macro` searches via "virtual" macro product types: we insert macro targets as "virtual" macro products into our search view (and there only, we don't change any of the underlying source data).

Fixes #2425 