### PR TITLE
Remove deprecated `set-output` commands

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -36,15 +36,15 @@ jobs:
         run: |
           branch=$(git branch --show-current)
           if [ $branch == "main" ]; then
-            echo "::set-output name=comparison-ref::HEAD^"
+            echo "comparison-ref=HEAD^" >> $GITHUB_OUTPUT
           else
-            echo "::set-output name=comparison-ref::origin/main"
+            echo "comparison-ref=origin/main" >> $GITHUB_OUTPUT
           fi
       - name: Diff for Front-End Changes
         id: front-end-changes
         run: |
           filecount=$(git diff ${{steps.determine-comparison-ref.outputs.comparison-ref}} --shortstat "**.html" "**.scss" "**.js" ".percy.yml" ".github/workflows/snapshots.yml" | awk '{print $1}')
-          echo "::set-output name=matching-files::${filecount:-0}"
+          echo "matching-files=${filecount:-0}" >> $GITHUB_OUTPUT
       - name: Run Percy
         if: steps.front-end-changes.outputs.matching-files != '0'
         run: |


### PR DESCRIPTION
Merge after #2486

Fixes:

![Screenshot 2023-07-05 at 20 19 02@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/2ec67a41-1b6a-4fbe-be02-c82005f6e478)
