### PR TITLE
Add s3readme type

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -127,7 +127,7 @@ func ingest(client: Client,
                     let s3Readme: S3Readme?
                     do {
                         if let upstreamEtag = readme?.etag,
-                           repo.s3ReadmeNeedsUpdate(upstreamEtag: upstreamEtag),
+                           repo.s3Readme?.needsUpdate(upstreamEtag: upstreamEtag) ?? true,
                            let owner = metadata.repositoryOwner,
                            let repository = metadata.repositoryName,
                            let html = readme?.html {

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -68,7 +68,7 @@ struct AppEnvironment {
     var setLogger: (Logger) -> Void
     var shell: Shell
     var siteURL: () -> String
-    var storeS3Readme: (_ owner: String, _ repository: String, _ readme: String) async throws -> Void
+    var storeS3Readme: (_ owner: String, _ repository: String, _ readme: String) async throws -> String
     var triggerBuild: (_ client: Client,
                        _ logger: Logger,
                        _ buildId: Build.Id,

--- a/Sources/App/Core/Extensions/S3Store+ext.swift
+++ b/Sources/App/Core/Extensions/S3Store+ext.swift
@@ -26,7 +26,7 @@ extension S3Store {
         return body.asString()
     }
 
-    static func storeReadme(owner: String, repository: String, readme: String) async throws {
+    static func storeReadme(owner: String, repository: String, readme: String) async throws -> String {
         guard let accessKeyId = Current.awsAccessKeyId(),
               let secretAccessKey = Current.awsSecretAccessKey()
         else {
@@ -44,6 +44,8 @@ extension S3Store {
             Current.logger().debug("Copying \(tempfile) to \(key.s3Uri) ...")
             try await store.copy(from: tempfile, to: key, logger: Current.logger())
         }
+
+        return key.objectUrl
     }
 
 }

--- a/Sources/App/Migrations/067/UpdateRepositoryReadmeChanges.swift
+++ b/Sources/App/Migrations/067/UpdateRepositoryReadmeChanges.swift
@@ -20,13 +20,13 @@ struct UpdateRepositoryReadmeChanges: AsyncMigration {
             .deleteField("readme_url")
             .update()
         try await database.schema("repositories")
-            .field("readme_etag", .string)
+            .field("s3_readme", .json)
             .update()
     }
 
     func revert(on database: Database) async throws {
         try await database.schema("repositories")
-            .deleteField("readme_etag")
+            .deleteField("s3_readme")
             .update()
         try await database.schema("repositories")
             .field("readme_url", .string)

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -257,15 +257,10 @@ enum S3Readme: Codable, Equatable {
                 return true
         }
     }
-}
 
-
-extension Repository {
-    func s3ReadmeNeedsUpdate(upstreamEtag: String) -> Bool {
-        switch s3Readme {
-            case .none:
-                return true
-            case let .cached(s3ObjectUrl: _, githubEtag: existingEtag):
+    func needsUpdate(upstreamEtag: String) -> Bool {
+        switch self {
+            case let .cached(_, githubEtag: existingEtag):
                 return existingEtag != upstreamEtag
             case .error:
                 return true

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -105,14 +105,14 @@ final class Repository: Model, Content {
     @Field(key: "owner_avatar_url")
     var ownerAvatarUrl: String?
 
-    @Field(key: "s3_readme")
-    var s3Readme: S3Readme?
-
     @Field(key: "readme_html_url")
     var readmeHtmlUrl: String?
 
     @Field(key: "releases")
     var releases: [Release]
+    
+    @Field(key: "s3_readme")
+    var s3Readme: S3Readme?
 
     @Field(key: "stars")
     var stars: Int
@@ -147,9 +147,9 @@ final class Repository: Model, Content {
          owner: String? = nil,
          ownerName: String? = nil,
          ownerAvatarUrl: String? = nil,
-         s3Readme: S3Readme? = nil,
          readmeHtmlUrl: String? = nil,
          releases: [Release] = [],
+         s3Readme: S3Readme? = nil,
          stars: Int = 0,
          summary: String? = nil
     ) throws {
@@ -179,9 +179,9 @@ final class Repository: Model, Content {
         self.owner = owner
         self.ownerName = ownerName
         self.ownerAvatarUrl = ownerAvatarUrl
-        self.s3Readme = s3Readme
         self.readmeHtmlUrl = readmeHtmlUrl
         self.releases = releases
+        self.s3Readme = s3Readme
         self.stars = stars
     }
 
@@ -207,9 +207,9 @@ final class Repository: Model, Content {
         self.owner = nil
         self.ownerName = nil
         self.ownerAvatarUrl = nil
-        self.s3Readme = nil
         self.readmeHtmlUrl = nil
         self.releases = []
+        self.s3Readme = nil
         self.stars = 0
         self.summary = nil
     }

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -69,7 +69,7 @@ extension AppEnvironment {
             setLogger: { logger in Self.logger = logger },
             shell: .mock,
             siteURL: { Environment.get("SITE_URL") ?? "http://localhost:8080" },
-            storeS3Readme: { _, _, _ in },
+            storeS3Readme: { _, _, _ in "s3ObjectUrl" },
             triggerBuild: { _, _, _, _, _, _, _, _ in
                 eventLoop.future(.init(status: .ok, webUrl: "http://web_url"))
             },

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -216,7 +216,7 @@ class PackageController_routesTests: AppTestCase {
         XCTAssertEqual(node.render(indentedBy: .spaces(2)),
             """
             <turbo-frame id="readme_content">
-              <p>This package's README file couldn't be loaded. Try
+              <p>This package's README file couldn't be loaded. Try 
                 <a href="html url">viewing it on GitHub</a>.
               </p>
             </turbo-frame>

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -42,7 +42,6 @@ final class RepositoryTests: AppTestCase {
                                   licenseUrl: "https://github.com/foo/bar/blob/main/LICENSE",
                                   openIssues: 3,
                                   openPullRequests: 4,
-                                  s3Readme: .cached(s3ObjectUrl: "objectUrl", githubEtag: "etag"),
                                   readmeHtmlUrl: "https://github.com/foo/bar/blob/main/README.md",
                                   releases: [
                                     .init(description: "a release",
@@ -51,6 +50,7 @@ final class RepositoryTests: AppTestCase {
                                           tagName: "1.2.3",
                                           url: "https://example.com/release/1.2.3")
                                   ],
+                                  s3Readme: .cached(s3ObjectUrl: "objectUrl", githubEtag: "etag"),
                                   stars: 42,
                                   summary: "desc")
 

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -42,7 +42,7 @@ final class RepositoryTests: AppTestCase {
                                   licenseUrl: "https://github.com/foo/bar/blob/main/LICENSE",
                                   openIssues: 3,
                                   openPullRequests: 4,
-                                  readmeEtag: "3c1ba46c96a24a64dfd6bc3a79ef6e2bfbc6ab6d12211178818f1b4d13bc3058",
+                                  s3Readme: .cached(s3ObjectUrl: "objectUrl", githubEtag: "etag"),
                                   readmeHtmlUrl: "https://github.com/foo/bar/blob/main/README.md",
                                   releases: [
                                     .init(description: "a release",
@@ -76,7 +76,7 @@ final class RepositoryTests: AppTestCase {
             XCTAssertEqual(r.licenseUrl, "https://github.com/foo/bar/blob/main/LICENSE")
             XCTAssertEqual(r.openIssues, 3)
             XCTAssertEqual(r.openPullRequests, 4)
-            XCTAssertEqual(r.readmeEtag, "3c1ba46c96a24a64dfd6bc3a79ef6e2bfbc6ab6d12211178818f1b4d13bc3058")
+            XCTAssertEqual(r.s3Readme, .cached(s3ObjectUrl: "objectUrl", githubEtag: "etag"))
             XCTAssertEqual(r.readmeHtmlUrl, "https://github.com/foo/bar/blob/main/README.md")
             XCTAssertEqual(r.releases, [
                 .init(description: "a release",

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -257,5 +257,11 @@ final class RepositoryTests: AppTestCase {
             "CREATE INDEX idx_repositories_name ON repositories USING gin (name gin_trgm_ops)"
         ).run().wait()
     }
+    
+    func test_S3Readme_needsUpdate() {
+        XCTAssertTrue(S3Readme.error("").needsUpdate(upstreamEtag: "etag"))
+        XCTAssertFalse(S3Readme.cached(s3ObjectUrl: "", githubEtag: "old etag").needsUpdate(upstreamEtag: "old etag"))
+        XCTAssertTrue(S3Readme.cached(s3ObjectUrl: "", githubEtag: "old etag").needsUpdate(upstreamEtag: "new etag"))
+    }
 
 }


### PR DESCRIPTION
This changes `repositories.readme_etag` into a proper `repositories.s3_readme` object to better allow us to track caching status. We'll want to be able to see why it failed, not just have `NULL` in the field.

This also ensure we reset the field to an error state if we can't fetch it in the `PackageController`. Without that, a failing read would potentially never resolve if the readme doesn't change to a new etag.