### PR TITLE
Store readmes as public

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -171,15 +171,6 @@
       }
     },
     {
-      "identity" : "soto-s3-file-transfer",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/soto-project/soto-s3-file-transfer.git",
-      "state" : {
-        "revision" : "78d655d4f811026dce90f065d5aa88946d7a1b1e",
-        "version" : "1.2.0"
-      }
-    },
-    {
       "identity" : "spimanifest",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftPackageIndex/SPIManifest.git",

--- a/Package.swift
+++ b/Package.swift
@@ -36,7 +36,7 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.12.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.11.1"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
-        .package(url: "https://github.com/soto-project/soto-s3-file-transfer.git", from: "1.2.0"),
+        .package(url: "https://github.com/soto-project/soto.git", from: "6.0.0"),
         .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0"),
         .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
@@ -62,7 +62,7 @@ let package = Package(
             .product(name: "Vapor", package: "vapor"),
         ]),
         .target(name: "S3Store", dependencies: [
-            .product(name: "SotoS3FileTransfer", package: "soto-s3-file-transfer"),
+            .product(name: "SotoS3", package: "soto"),
         ]),
         .testTarget(name: "AppTests",
                     dependencies: [

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -243,10 +243,8 @@ struct FileManager {
     var contents: (_ atPath: String) -> Data?
     var checkoutsDirectory: () -> String
     var createDirectory: (String, Bool, [FileAttributeKey : Any]?) throws -> Void
-    var createFile: (_ atPath: String, _ contents: Data?, _ attributes: [FileAttributeKey : Any]?) -> Bool
     var fileExists: (String) -> Bool
     var removeItem: (_ path: String) throws -> Void
-    var withTempDir: ((String) async throws -> Void) async throws -> Void
     var workingDirectory: () -> String
 
     // pass-through methods to preserve argument labels
@@ -262,9 +260,6 @@ struct FileManager {
                          attributes: [FileAttributeKey : Any]?) throws {
         try createDirectory(path, createIntermediates, attributes)
     }
-    func createFile(atPath path: String, contents: Data?, attributes: [FileAttributeKey : Any]? = nil) -> Bool {
-        createFile(path, contents, attributes)
-    }
     func fileExists(atPath path: String) -> Bool { fileExists(path) }
     func removeItem(atPath path: String) throws { try removeItem(path) }
 
@@ -274,10 +269,8 @@ struct FileManager {
         contents: Foundation.FileManager.default.contents(atPath:),
         checkoutsDirectory: { Environment.get("CHECKOUTS_DIR") ?? DirectoryConfiguration.detect().workingDirectory + "SPI-checkouts" },
         createDirectory: Foundation.FileManager.default.createDirectory(atPath:withIntermediateDirectories: attributes:),
-        createFile: Foundation.FileManager.default.createFile(atPath:contents:attributes:),
         fileExists: Foundation.FileManager.default.fileExists(atPath:),
         removeItem: Foundation.FileManager.default.removeItem(atPath:),
-        withTempDir: { try await TempDir(body: $0) },
         workingDirectory: { DirectoryConfiguration.detect().workingDirectory }
     )
 }

--- a/Tests/AppTests/Helpers/TempDir.swift
+++ b/Tests/AppTests/Helpers/TempDir.swift
@@ -17,9 +17,9 @@ import Foundation
 
 class TempDir {
     let path: String
-    let fileManager: Foundation.FileManager
+    let fileManager: FileManager
 
-    init(fileManager: Foundation.FileManager = .default) throws {
+    init(fileManager: FileManager = .default) throws {
         self.fileManager = fileManager
         let tempDir = fileManager.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)
@@ -34,12 +34,6 @@ class TempDir {
         } catch {
             print("⚠️ failed to delete temp directory: \(error.localizedDescription)")
         }
-    }
-
-    @discardableResult
-    convenience init(body: (String) async throws -> Void) async throws {
-        try self.init()
-        try await body(path)
     }
 }
 

--- a/Tests/AppTests/Mocks/AppFileManager+mock.swift
+++ b/Tests/AppTests/Mocks/AppFileManager+mock.swift
@@ -26,10 +26,8 @@ extension App.FileManager {
             contents: { _ in .init() },
             checkoutsDirectory: { DirectoryConfiguration.detect().workingDirectory + "SPI-checkouts" },
             createDirectory: { _, _, _ in },
-            createFile: { _, _, _ in true },
             fileExists: { path in fileExists },
             removeItem: { _ in },
-            withTempDir: { try await TempDir(body: $0) },
             workingDirectory: { DirectoryConfiguration.detect().workingDirectory }
         )
     }

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -145,7 +145,7 @@ class PackageController_routesTests: AppTestCase {
     }
 
     func test_readme_basic() async throws {
-        // Test that readme happy path
+        // Test readme fragment happy path
         // setup
         let pkg = try savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner", readmeHtmlUrl: "html url")
@@ -167,7 +167,7 @@ class PackageController_routesTests: AppTestCase {
     }
 
     func test_readme_no_readmeHtmlUrl() async throws {
-        // Test page when there's no readme html url
+        // Test readme fragment when there's no readme html url
         // setup
         let pkg = try savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner", readmeHtmlUrl: nil)
@@ -194,6 +194,7 @@ class PackageController_routesTests: AppTestCase {
     }
 
     func test_readme_error() async throws {
+        // Test readme fragment when fetchS3Readme throws
         // setup
         struct Error: Swift.Error { }
         Current.fetchS3Readme = { _, _, _ in throw Error() }


### PR DESCRIPTION
Use Soto to store payload directly without a temp file and configured as a public object.