### PR TITLE
Revert "Remove Runestone"

### DIFF
--- a/restfiles/doc-test.restfile
+++ b/restfiles/doc-test.restfile
@@ -320,6 +320,10 @@ requests:
     url: ${base_url}/simonbs/KeyboardToolbar/documentation
     validation:
       status: .regex((2|3)\d\d)
+  /simonbs/Runestone/documentation:
+    url: ${base_url}/simonbs/Runestone/documentation
+    validation:
+      status: .regex((2|3)\d\d)
   /sindresorhus/Defaults/documentation:
     url: ${base_url}/sindresorhus/Defaults/documentation
     validation:


### PR DESCRIPTION
This reverts commit 2b6984b5331c1e95705dd39efbcd0931283f0dde.

Runestone docs are back now