### PR TITLE
Fix relative URLs in README files

### DIFF
--- a/Tests/AppTests/Mocks/PackageReadmeModel+mock.swift
+++ b/Tests/AppTests/Mocks/PackageReadmeModel+mock.swift
@@ -21,6 +21,9 @@ extension PackageReadme.Model {
     static var mock: PackageReadme.Model {
         .init(
             url: "https://example.com/owner/repo/README",
+            repositoryOwner: "owner",
+            repositoryName: "repo",
+            defaultBranch: "main",
             readme: """
             <div id="readme">
                 <article>

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -23,6 +23,9 @@ class PackageReadmeModelTests: SnapshotTestCase {
     func test_processReadme_extractReadmeElement() throws {
         let model = PackageReadme.Model(
             url: "https://example.com/owner/repo/README",
+            repositoryOwner: "owner",
+            repositoryName: "repo",
+            defaultBranch: "main",
             readme: """
             <div id="readme">
                 <article>
@@ -38,6 +41,9 @@ class PackageReadmeModelTests: SnapshotTestCase {
     func test_processReadme_processRelativeImages() throws {
         let model = PackageReadme.Model(
             url: "https://example.com/owner/repo/README",
+            repositoryOwner: "owner",
+            repositoryName: "repo",
+            defaultBranch: "main",
             readme: """
             <div id="readme">
                 <article>
@@ -59,6 +65,9 @@ class PackageReadmeModelTests: SnapshotTestCase {
     func test_processReadme_processRelativeLinks() throws {
         let model = PackageReadme.Model(
             url: "https://example.com/owner/repo/README",
+            repositoryOwner: "owner",
+            repositoryName: "repo",
+            defaultBranch: "main",
             readme: """
             <div id="readme">
                 <article>

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -257,7 +257,11 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     // Note: This snapshot test deliberately omits an image snapshot as the HTML being tested has no explicit styling.
     func test_PackageReadmeView_unparseableReadme_noImageSnapshots() throws {
-        let model = PackageReadme.Model(url: "https://example.com/owner/repo/README", readme: nil)
+        let model = PackageReadme.Model(url: "https://example.com/owner/repo/README",
+                                        repositoryOwner: "owner",
+                                        repositoryName: "repo",
+                                        defaultBranch: "main",
+                                        readme: nil)
         let page = { PackageReadme.View(model: model).document() }
 
         assertSnapshot(matching: page, as: .html)
@@ -265,7 +269,11 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     // Note: This snapshot test deliberately omits an image snapshot as the HTML being tested has no explicit styling.
     func test_PackageReadmeView_noReadme_noImageSnapshots() throws {
-        let model = PackageReadme.Model(url: nil, readme: nil)
+        let model = PackageReadme.Model(url: nil,
+                                        repositoryOwner: "owner",
+                                        repositoryName: "repo",
+                                        defaultBranch: "main",
+                                        readme: nil)
         let page = { PackageReadme.View(model: model).document() }
 
         assertSnapshot(matching: page, as: .html)

--- a/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeImages.1.txt
+++ b/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeImages.1.txt
@@ -1,7 +1,7 @@
 <p>README content.</p> 
 <img src="https://example.com/absolute/image/url.png"> 
-<img src="https://github.com/root/relative/image/url.png"> 
-<img src="relative/image/url.png"> 
-<img src="https://github.com/url/with/encoded%20spaces.png"> 
-<img src="https://github.com/url/with/unencoded%20spaces.png"> 
+<img src="https://github.com/owner/repo/raw/main/root/relative/image/url.png"> 
+<img src="https://github.com/owner/repo/raw/main/relative/image/url.png"> 
+<img src="https://github.com/owner/repo/raw/main/url/with/encoded%20spaces.png"> 
+<img src="https://github.com/owner/repo/raw/main/url/with/unencoded%20spaces.png"> 
 <img>

--- a/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeLinks.1.txt
+++ b/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_processReadme_processRelativeLinks.1.txt
@@ -1,8 +1,8 @@
 <p>README content.</p> 
 <a href="https://example.com/absolute/url">Absolute link.</a> 
-<a href="https://github.com/root/relative/url">Root relative link.</a> 
-<a href="relative/url">Relative link.</a> 
-<a href="https://github.com/url/with/encoded%20spaces">Encoded spaces.</a> 
-<a href="https://github.com/url/with/unencoded%20spaces">Unencoded spaces.</a> 
+<a href="https://github.com/owner/repo/blob/main/root/relative/url">Root relative link.</a> 
+<a href="https://github.com/owner/repo/blob/main/relative/url">Relative link.</a> 
+<a href="https://github.com/owner/repo/blob/main/url/with/encoded%20spaces">Encoded spaces.</a> 
+<a href="https://github.com/owner/repo/blob/main/url/with/unencoded%20spaces">Unencoded spaces.</a> 
 <a href="#anchor">Anchor link.</a> 
 <a>Invalid link.</a>


### PR DESCRIPTION
Fixes #2502

This turned out to be a real bug rather than a phantom. The original rendered README files we got from scraping GitHub included all parts of the URL from a `github.com` base URL. The README file API gives back URLs without owner/repo/branch parts.

We also get one additional bit of functionality here, which would have been difficult to do previously. We now get to fix up truly relative URLs as well as root relative ones.