### PR TITLE
Issue 2525

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -190,6 +190,9 @@ func updateRepository(on database: Database,
                       readmeInfo: Github.Readme?,
                       s3Readme: S3Readme?) async throws {
     guard let repoMetadata = metadata.repository else {
+        if repository.$package.value == nil {
+            try await repository.$package.load(on: database)
+        }
         throw AppError.genericError(repository.package.id,
                                     "repository metadata is nil for package \(repository.name ?? "unknown")")
     }

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -133,12 +133,12 @@ extension Github {
         let response = try await client.get(uri, headers: defaultHeaders(with: token))
 
         guard !isRateLimited(response) else {
-            Current.logger().critical("rate limited while fetching resource \(T.self)")
+            Current.logger().critical("rate limited while fetching resource \(uri)")
             throw Error.requestFailed(.tooManyRequests)
         }
 
         guard response.status == .ok else {
-            Current.logger().warning("fetchResource request failed with status \(response.status)")
+            Current.logger().warning("fetchResource \(uri) request failed with status \(response.status)")
             throw Error.requestFailed(response.status)
         }
 


### PR DESCRIPTION
This should fix the crashing part of #2525 and get us to a better place when dealing with the GH errors.

I wish Fluent didn't `fatalError` in these cases.