### PR TITLE
Fix Compatibility section title on iPad

### DIFF
--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -172,6 +172,12 @@
             }
         }
 
+        section.main-compatibility .title {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+        }
+
         section.sidebar-versions {
             width: 100%;
 

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -180,7 +180,7 @@ extension PackageShow {
             .section(
                 .class("main-compatibility"),
                 .div(
-                    .class("two-column v-end"),
+                    .class("title"),
                     .h3("Compatibility"),
                     .a(
                         .href(SiteURL.package(.value(model.repositoryOwner), .value(model.repositoryName), .builds).relativeURL()),

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -167,7 +167,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -170,7 +170,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -171,7 +171,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
@@ -167,7 +167,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/owner/repo/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -167,7 +167,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -198,7 +198,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -373,7 +373,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -162,7 +162,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -167,7 +167,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -170,7 +170,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -169,7 +169,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -170,7 +170,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -167,7 +167,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -167,7 +167,7 @@
             </section>
             <hr class="minor"/>
             <section class="main-compatibility">
-              <div class="two-column v-end">
+              <div class="title">
                 <h3>Compatibility</h3>
                 <a href="/Alamo/Alamofire/builds">Full Build Results</a>
               </div>


### PR DESCRIPTION
Merge after #2535

Noticed a slight bug when viewing the package page in portrait on iPad:

![Screenshot 2023-08-02 at 19 48 30@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/4769ca7b-786f-4346-a65d-48b02aae816d)

Fixed and now looks like:

![Screenshot 2023-08-02 at 19 49 27@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/0bde0399-3308-4a23-babb-95f249c771e2)
