### PR TITLE
Improve local development setup

### DIFF
--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -40,7 +40,11 @@ Close the scheme editor and run the application by selecting "Run" from the Xcod
 
 When working locally, it's helpful to have a database with pre-populated data from the live system. [Talk to us on Discord](https://discord.gg/vQRb6KkYRw), and we'll supply you with a recent database dump that you can load with `./scripts/load-db.sh`.
 
-**Note:** Running the `load-db.sh` script requires that the Postgres command line tools are available on your system. The easiest way to get these is with [brew](https://brew.sh/) by running `brew install postgresql`.
+**Note:** Running the `load-db.sh` script requires that the PostgreSQL command line tools are available on your system and in your `PATH`. The easiest way to get these is with [brew](https://brew.sh/) by running:
+
+```bash
+brew install postgresql@13 && brew install pgcli && brew link libpq --force
+```
 
 ### Setup the Front End
 

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -70,7 +70,7 @@ Or, if you want to run either the CSS or JavaScript linting steps separately, ru
 
 ### Check Everything Works!
 
-Navigate to `http://127.0.0.1:8080` with a web browser, and the site should be up and running locally with CSS and JavaScript working!
+Navigate to <http://127.0.0.1:8080> with a web browser, and the site should be up and running locally with CSS and JavaScript working!
 
 ## Logging database queries
 

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -40,11 +40,7 @@ Close the scheme editor and run the application by selecting "Run" from the Xcod
 
 When working locally, it's helpful to have a database with pre-populated data from the live system. [Talk to us on Discord](https://discord.gg/vQRb6KkYRw), and we'll supply you with a recent database dump that you can load with `./scripts/load-db.sh`.
 
-**Note:** Running the `load-db.sh` script requires that the PostgreSQL command line tools are available on your system and in your `PATH`. The easiest way to get these is with [brew](https://brew.sh/) by running:
-
-```bash
-brew install postgresql@13 && brew install pgcli && brew link libpq --force
-```
+**Note:** Running the `load-db.sh` script requires that the Postgres command line tools are available on your system. The easiest way to get these is with [brew](https://brew.sh/) by running `brew install postgresql`.
 
 ### Setup the Front End
 


### PR DESCRIPTION
While setting up the project for local development, I made two improvements to the documentation:

- Make `http://127.0.0.1:8080` link clickable for quicker access
- Improve installation steps for the `psql` command
  - @daveverwer already added a note about installing the PostgreSQL CLI in <https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/2543> but it wasn't enough on my machine