### PR TITLE
Use xcbeautify's new `github-actions` renderer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ run:
 test: xcbeautify
 	set -o pipefail \
 	&& swift test --disable-automatic-resolution \
-	2>&1 | ./xcbeautify
+	2>&1 | ./xcbeautify --renderer github-actions
 
 test-query-performance: xcbeautify
 	set -o pipefail \
@@ -45,7 +45,7 @@ test-query-performance: xcbeautify
 	   --filter QueryPerformanceTests \
 	2>&1 | tee test.log
 	grep "ℹ️" test.log
-	grep -v "\] Compiling" test.log | ./xcbeautify
+	grep -v "\] Compiling" test.log | ./xcbeautify --renderer github-actions
 
 test-fast:
 	@echo Skipping image snapshot tests


### PR DESCRIPTION
I had actually reverted the change in the previous branch to compare the outputs and the whole PR was empty.