### PR TITLE
Add pageSize parameter to search API

### DIFF
--- a/Sources/App/Controllers/SearchController.swift
+++ b/Sources/App/Controllers/SearchController.swift
@@ -23,8 +23,7 @@ enum SearchController {
         let query = try req.query.decode(API.SearchController.Query.self)
 
         let response = try await API.search(database: req.db,
-                                            query: query,
-                                            pageSize: Constants.resultsPageSize)
+                                            query: query)
 
         let matchedKeywords = response.results.compactMap { $0.keywordResult?.keyword }
 

--- a/Sources/App/Core/Constants.swift
+++ b/Sources/App/Core/Constants.swift
@@ -36,8 +36,6 @@ enum Constants {
     static let rssFeedMaxItemCount = 500
     static let rssTTL: TimeInterval = .minutes(60)
 
-    static let resultsPageSize = 20
-
     // analyzer settings
     static let gitCheckoutMaxAge: TimeInterval = .days(30)
 

--- a/Sources/App/Core/Search.swift
+++ b/Sources/App/Core/Search.swift
@@ -305,7 +305,7 @@ enum Search {
                       _ sanitizedTerms: [String],
                       filters: [SearchFilterProtocol] = [],
                       page: Int,
-                      pageSize: Int) -> SQLSelectBuilder? {
+                      pageSize: Int = API.SearchController.Query.defaultPageSize) -> SQLSelectBuilder? {
         //  This function assembles results from the different search types (packages,
         //  keywords, ...) into a single query.
         //

--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -52,64 +52,56 @@ class QueryPerformanceTests: XCTestCase {
     }
 
     func test_04_Search_query_noFilter() async throws {
-        let query = try Search.query(app.db, ["a"],
-                                     page: 1, pageSize: Constants.resultsPageSize)
+        let query = try Search.query(app.db, ["a"], page: 1)
             .unwrap()
         try await assertQueryPerformance(query, expectedCost: 6080, variation: 200)
     }
 
     func test_05_Search_query_authorFilter() async throws {
         let filter = try AuthorSearchFilter(expression: .init(operator: .is, value: "apple"))
-        let query = try Search.query(app.db, ["a"], filters: [filter],
-                                     page: 1, pageSize: Constants.resultsPageSize)
+        let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
         try await assertQueryPerformance(query, expectedCost: 5810, variation: 200)
     }
 
     func test_06_Search_query_keywordFilter() async throws {
         let filter = try KeywordSearchFilter(expression: .init(operator: .is, value: "apple"))
-        let query = try Search.query(app.db, ["a"], filters: [filter],
-                                     page: 1, pageSize: Constants.resultsPageSize)
+        let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
         try await assertQueryPerformance(query, expectedCost: 5880, variation: 200)
     }
 
     func test_07_Search_query_lastActicityFilter() async throws {
         let filter = try LastActivitySearchFilter(expression: .init(operator: .greaterThan, value: "2000-01-01"))
-        let query = try Search.query(app.db, ["a"], filters: [filter],
-                                     page: 1, pageSize: Constants.resultsPageSize)
+        let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
         try await assertQueryPerformance(query, expectedCost: 6100, variation: 200)
     }
 
     func test_08_Search_query_licenseFilter() async throws {
         let filter = try LicenseSearchFilter(expression: .init(operator: .is, value: "mit"))
-        let query = try Search.query(app.db, ["a"], filters: [filter],
-                                     page: 1, pageSize: Constants.resultsPageSize)
+        let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
         try await assertQueryPerformance(query, expectedCost: 6000, variation: 200)
     }
 
     func test_09_Search_query_platformFilter() async throws {
         let filter = try PlatformSearchFilter(expression: .init(operator: .is, value: "macos,ios"))
-        let query = try Search.query(app.db, ["a"], filters: [filter],
-                                     page: 1, pageSize: Constants.resultsPageSize)
+        let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
         try await assertQueryPerformance(query, expectedCost: 5910, variation: 200)
     }
 
     func test_10_Search_query_productTypeFilter() async throws {
         let filter = try ProductTypeSearchFilter(expression: .init(operator: .is, value: "plugin"))
-        let query = try Search.query(app.db, ["a"], filters: [filter],
-                                     page: 1, pageSize: Constants.resultsPageSize)
+        let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
         try await assertQueryPerformance(query, expectedCost: 5810, variation: 200)
     }
 
     func test_11_Search_query_starsFilter() async throws {
         let filter = try StarsSearchFilter(expression: .init(operator: .greaterThan, value: "5"))
-        let query = try Search.query(app.db, ["a"], filters: [filter],
-                                     page: 1, pageSize: Constants.resultsPageSize)
+        let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
         try await assertQueryPerformance(query, expectedCost: 6000, variation: 300)
     }

--- a/Tests/AppTests/SearchTests.swift
+++ b/Tests/AppTests/SearchTests.swift
@@ -361,8 +361,7 @@ class SearchTests: AppTestCase {
         do {  // first page
             // MUT
             let res = try await API.search(database: app.db,
-                                           query: .init(query: "foo", page: 1),
-                                           pageSize: 3)
+                                           query: .init(query: "foo", page: 1, pageSize: 3))
 
             // validate
             XCTAssertTrue(res.hasMoreResults)
@@ -373,8 +372,7 @@ class SearchTests: AppTestCase {
         do {  // second page
             // MUT
             let res = try await API.search(database: app.db,
-                                           query: .init(query: "foo", page: 2),
-                                           pageSize: 3)
+                                           query: .init(query: "foo", page: 2, pageSize: 3))
 
             // validate
             XCTAssertTrue(res.hasMoreResults)
@@ -385,8 +383,7 @@ class SearchTests: AppTestCase {
         do {  // third page
             // MUT
             let res = try await API.search(database: app.db,
-                                           query: .init(query: "foo", page: 3),
-                                           pageSize: 3)
+                                           query: .init(query: "foo", page: 3, pageSize: 3))
 
             // validate
             XCTAssertFalse(res.hasMoreResults)
@@ -415,8 +412,7 @@ class SearchTests: AppTestCase {
         do {  // first page
             // MUT
             let res = try await API.search(database: app.db,
-                                           query: .init(query: "foo", page: 1),
-                                           pageSize: 3)
+                                           query: .init(query: "foo", page: 1, pageSize: 3))
 
             // validate
             XCTAssertTrue(res.hasMoreResults)
@@ -427,8 +423,7 @@ class SearchTests: AppTestCase {
         do {  // second page
             // MUT
             let res = try await API.search(database: app.db,
-                                           query: .init(query: "foo", page: 2),
-                                           pageSize: 3)
+                                           query: .init(query: "foo", page: 2, pageSize: 3))
 
             // validate
             XCTAssertTrue(res.hasMoreResults)
@@ -456,8 +451,7 @@ class SearchTests: AppTestCase {
         do {  // page out of bounds (too large)
               // MUT
             let res = try await API.search(database: app.db,
-                                           query: .init(query: "foo", page: 4),
-                                           pageSize: 3)
+                                           query: .init(query: "foo", page: 4, pageSize: 3))
 
             // validate
             XCTAssertFalse(res.hasMoreResults)
@@ -468,8 +462,7 @@ class SearchTests: AppTestCase {
         do {  // page out of bounds (too small - will be clamped to page 1)
               // MUT
             let res = try await API.search(database: app.db,
-                                           query: .init(query: "foo", page: 0),
-                                           pageSize: 3)
+                                           query: .init(query: "foo", page: 0, pageSize: 3))
             XCTAssertTrue(res.hasMoreResults)
             XCTAssertEqual(res.results.map(\.testDescription),
                            ["a:foobar", "p:0", "p:1", "p:2"])


### PR DESCRIPTION
When I added the [`source:` option to the PackageListTool](https://github.com/SwiftPackageIndex/PackageListTool/pull/28) I noticed that we don't have a way to limit search API requests to a certain number of records.

This adds `pageSize` parameter, such that along with `page=1` a `limit` can be expressed when fetching search results.