### PR TITLE
Added a tooltip to the release and branch dates

### DIFF
--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -361,7 +361,10 @@ extension API.PackageController.GetRoute.Model {
                 )
             ),
             .strong(.text(title)),
-            .small(.text([datePrefix, dateLink.date.relative].joined(separator: " ")))
+            .small(
+                .title(Self.releaseMetadataTooltipDateFormatter.string(from: dateLink.date)),
+                .text([datePrefix, dateLink.date.relative].joined(separator: " "))
+            )
         )
     }
 
@@ -623,4 +626,13 @@ private extension API.PackageController.GetRoute.Model.Target.TargetType {
             case .macro: return "macros"
         }
     }
+}
+
+extension API.PackageController.GetRoute.Model {
+    static let releaseMetadataTooltipDateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM d yyyy 'at' HH:mm"
+        formatter.locale = .init(identifier: "en_US_POSIX")
+        return formatter
+    }()
 }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -323,21 +323,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -323,21 +323,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -327,21 +327,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
@@ -320,21 +320,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -320,21 +320,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -351,21 +351,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -526,21 +526,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -315,21 +315,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -203,21 +203,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -323,21 +323,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -322,21 +322,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -323,21 +323,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -256,21 +256,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -323,21 +323,21 @@
                     <span class="stable">5.2.0</span>
                   </a>
                   <strong>Latest Stable Release</strong>
-                  <small>Released 12 days ago</small>
+                  <small title="Dec 20 1969 at 01:00">Released 12 days ago</small>
                 </li>
                 <li class="beta">
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
                     <span class="beta">5.3.0-beta.1</span>
                   </a>
                   <strong>Latest Beta Release</strong>
-                  <small>Released 4 days ago</small>
+                  <small title="Dec 28 1969 at 01:00">Released 4 days ago</small>
                 </li>
                 <li class="branch">
                   <a href="https://github.com/Alamofire/Alamofire">
                     <span class="branch">main</span>
                   </a>
                   <strong>Default Branch</strong>
-                  <small>Modified 12 minutes ago</small>
+                  <small title="Jan 1 1970 at 00:48">Modified 12 minutes ago</small>
                 </li>
               </ul>
             </section>


### PR DESCRIPTION
I keep wanting to know when 24h has passed for a package's default branch update date, this means you can hover over it for a precise time. 

The biggest downside of this is that it exposes the server's time to the world and that could confuse people. We could do it as an HTML comment instead to avoid that.