### PR TITLE
Fix very long package names layout

### DIFF
--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -18,8 +18,12 @@
 
 .package {
     h2 {
+        overflow: hidden;
+        max-width: 600px;
         margin: 0;
         padding: 0;
+        white-space: nowrap;
+        text-overflow: ellipsis;
     }
 
     .package-title {

--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -17,18 +17,20 @@
 // -------------------------------------------------------------------------
 
 .package {
-    h2 {
-        overflow: hidden;
-        max-width: 600px;
-        margin: 0;
-        padding: 0;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-    }
-
     .package-title {
         display: flex;
+        overflow: hidden;
         flex-direction: column;
+
+        h2 {
+            display: -webkit-box;
+            overflow: hidden;
+            margin: 0;
+            padding: 0;
+            white-space: pre-wrap;
+            -webkit-box-orient: vertical;
+            -webkit-line-clamp: 1;
+        }
 
         span {
             margin: 0 2px;
@@ -286,6 +288,10 @@
     }
 
     @media screen and (max-width: $mobile-breakpoint) {
+        .package-title h2 {
+            -webkit-line-clamp: 2;
+        }
+
         article.details {
             section.main-metadata {
                 order: 2;


### PR DESCRIPTION
Limited to a single line in desktop mode and two lines in mobile.

On desktop:

![Screenshot 2023-08-24 at 15 33 54@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/f2f2cdd3-466e-4d07-953e-edd63c4813c5)

and on mobile:

![Screenshot 2023-08-24 at 15 33 05@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/2e9c1402-762e-4909-9e98-a6452c6dc8f8)
