### PR TITLE
Replace the default DocC `title` tag on the server to encourage crawlers to index the content

### DIFF
--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -71,6 +71,7 @@ struct DocumentationPageProcessor {
 
         do {
             document = try SwiftSoup.parse(rawHtml)
+            try document.title("\(packageName) Documentation – Swift Package Index")
             if let metaNoIndex = self.metaNoIndex {
                 try document.head()?.prepend(metaNoIndex)
             }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate.1.html
@@ -3,7 +3,7 @@
  <head> 
   <meta charset="UTF-8"> 
   <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
-  <title>DocC Template Page</title> 
+  <title>Package Name Documentation – Swift Package Index</title> 
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_multipleVersions.1.html
@@ -3,7 +3,7 @@
  <head> 
   <meta charset="UTF-8"> 
   <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
-  <title>DocC Template Page</title> 
+  <title>Package Name Documentation – Swift Package Index</title> 
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_DocCTemplate_outdatedStableVersion.1.html
@@ -3,7 +3,7 @@
  <head> 
   <meta charset="UTF-8"> 
   <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
-  <title>DocC Template Page</title> 
+  <title>Package Name Documentation – Swift Package Index</title> 
   <link rel="stylesheet" href="/path/to/some/styles.css?12345"> 
   <script src="/path/to/some/script.js?12345" defer></script> 
   <link rel="stylesheet" href="/docc.css?test">


### PR DESCRIPTION
Someone in [this thread](https://support.google.com/webmasters/thread/231644414/struggling-to-get-google-to-crawl-our-%E2%80%9Cdiscovered-%E2%80%93-currently-not-indexed%E2%80%9D-pages?hl=en&sjid=8621727410133138402-EU) suggested that even though DocC replaces the title tag with the symbol name as soon as JavaScript starts executing, Google might also like to see more information in the server-rendered version before it starts executing JavaScript.

This won't help with the issue being discussed in the thread as Google isn't hitting these pages *at all*, so the title tag is irrelevant with or without JavaScript, but it can't hurt to change this given how trivial it is.