### PR TITLE
Fix versions latest update

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -220,6 +220,10 @@ extension Analyze {
                 }
 
                 try await applyVersionDelta(on: tx, delta: versionDelta)
+                do {
+                    let versions = try await updateLatestVersions(on: tx, package: package)
+                    updateScore(package: package, versions: versions)
+                }
 
                 let newVersions = versionDelta.toAdd
 
@@ -238,10 +242,6 @@ extension Analyze {
                     try await recreateProducts(on: tx, version: version, manifest: pkgInfo.packageManifest)
                     try await recreateTargets(on: tx, version: version, manifest: pkgInfo.packageManifest)
                 }
-
-                let versions = try await updateLatestVersions(on: tx, package: package)
-
-                updateScore(package: package, versions: versions)
 
                 await onNewVersions(client: client, logger: logger, package: package, versions: newVersions)
             }

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -1189,8 +1189,9 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(removedPaths, ["/checkouts/foo"])
     }
 
-    func test_issue_2571() async throws {
+    func test_issue_2571_tags() async throws {
         // Ensure bad git commands do not delete existing tag revisions
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2571
         let pkgId = UUID()
         let pkg = Package(id: pkgId, url: "1".asGithubUrl.url, processingStage: .ingestion)
         try await pkg.save(on: app.db)
@@ -1273,6 +1274,120 @@ class AnalyzerTests: AppTestCase {
             try await p.$versions.load(on: app.db)
             let versions = p.versions.map(\.reference.description).sorted()
             XCTAssertEqual(versions, ["1.0.0", "main"])
+        }
+    }
+
+    func test_issue_2571_latest_version() async throws {
+        // Ensure `latest` remains set in case of AppError.noValidVersions
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2571
+        let pkgId = UUID()
+        let pkg = Package(id: pkgId, url: "1".asGithubUrl.url, processingStage: .ingestion)
+        try await pkg.save(on: app.db)
+        try await Repository(package: pkg,
+                             defaultBranch: "main",
+                             name: "1",
+                             owner: "foo").save(on: app.db)
+        try await Version(package: pkg,
+                          commit: "commit0",
+                          commitDate: .t0,
+                          latest: .defaultBranch,
+                          packageName: "foo-1",
+                          reference: .branch("main")).save(on: app.db)
+        try await Version(package: pkg,
+                          commit: "commit0",
+                          commitDate: .t0,
+                          latest: .release,
+                          packageName: "foo-1",
+                          reference: .tag(1, 0, 0)).save(on: app.db)
+        Current.fileManager.fileExists = { _ in true }
+        Current.git.commitCount = { _ in 2 }
+        Current.git.firstCommitDate = { _ in .t0 }
+        Current.git.lastCommitDate = { _ in .t1 }
+        struct Error: Swift.Error { }
+        Current.git.shortlog = { _ in
+            """
+            1\tPerson 1
+            1\tPerson 2
+            """
+        }
+        Current.git.getTags = { _ in [.tag(1, 0, 0)] }
+        Current.shell.run = { cmd, path in return "" }
+
+        do {  // ensure happy path passes test (no revision changes)
+            Current.git.revisionInfo = { ref, _ in
+                switch ref {
+                    case .tag(.init(1, 0, 0), "1.0.0"):
+                        return .init(commit: "commit0", date: .t0)
+                    case .branch("main"):
+                        return .init(commit: "commit0", date: .t0)
+                    default:
+                        throw Error()
+                }
+            }
+
+            // MUT
+            try await Analyze.analyze(client: app.client,
+                                      database: app.db,
+                                      logger: app.logger,
+                                      mode: .limit(1))
+
+            // validate versions
+            let p = try await Package.find(pkgId, on: app.db).unwrap()
+            try await p.$versions.load(on: app.db)
+            let versions = p.versions.sorted(by: { $0.reference.description < $1.reference.description })
+            XCTAssertEqual(versions.map(\.reference.description), ["1.0.0", "main"])
+            XCTAssertEqual(versions.map(\.latest), [.release, .defaultBranch])
+        }
+
+        // make package available for analysis again
+        pkg.processingStage = .ingestion
+        try await pkg.save(on: app.db)
+
+        do {  // simulate "main" branch moving forward to ("commit0", .t1)
+            Current.git.revisionInfo = { ref, _ in
+                switch ref {
+                    case .tag(.init(1, 0, 0), "1.0.0"):
+                        return .init(commit: "commit0", date: .t0)
+                    case .branch("main"):
+                        // main branch has new commit
+                        return .init(commit: "commit1", date: .t1)
+                    default:
+                        throw Error()
+                }
+            }
+            Current.shell.run = { cmd, path in
+                // simulate error in getPackageInfo by failing checkout
+                if cmd == .gitCheckout(branch: "main") {
+                    throw Error()
+                }
+                return ""
+            }
+
+            // MUT
+            try await Analyze.analyze(client: app.client,
+                                      database: app.db,
+                                      logger: app.logger,
+                                      mode: .limit(1))
+
+            // validate error logs
+            try logger.logs.withValue { logs in
+                XCTAssertEqual(logs.count, 1)
+                let error = try logs.first.unwrap()
+                XCTAssertTrue(
+                    error.message.contains(
+                    #"""
+                    No valid version found for package 'https://github.com/foo/1'
+                    """#
+                    ),
+                    "was: \(error.message)"
+                )
+            }
+            // validate versions
+            let p = try await Package.find(pkgId, on: app.db).unwrap()
+            try await p.$versions.load(on: app.db)
+            let versions = p.versions.sorted(by: { $0.reference.description < $1.reference.description })
+            XCTAssertEqual(versions.map(\.reference.description), ["1.0.0", "main"])
+            XCTAssertEqual(versions.map(\.latest), [.release, .defaultBranch])
         }
     }
 


### PR DESCRIPTION
Just leaving a note here that this whole fix should not be required, because the entire analysis section is wrapped in a transaction. So it shouldn't be possible for the `applyVersionDelta` to be committed without the `updateLatestVersions` also running. Reordering these calls should not make any difference whatsoever and if it does, it means the transaction isn't working as intended.

⛔ do not merge until this is understood ⛔