### PR TITLE
Fix version transaction

### DIFF
--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -405,8 +405,12 @@ class AnalyzerTests: AppTestCase {
                 firstDirCloned = true
             }
 
-            // returning a blank string will cause an exception when trying to
-            // decode it as the manifest result - we use this to simulate errors
+            if cmd == .swiftDumpPackage {
+                // Simulate error when reading the manifest
+                struct Error: Swift.Error { }
+                throw Error()
+            }
+
             return ""
         }
 


### PR DESCRIPTION
This fixes the default branch `latest` flag flickering we observed as part of #2571 by properly re-instating the db transaction we had in place to avoid exactly this problem.

I broke this in 5d13688873b460da1fbd984d73b4209c57b46835 during the async/await rework.

We now have a regression test in place that will prevent this from breaking again.