### PR TITLE
Process the package deny list from the PackageList repository during reconciliation

### DIFF
--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -43,6 +43,7 @@ struct AppEnvironment {
     var fetchDocumentation: (_ client: Client, _ url: URI) async throws -> ClientResponse
     var fetchHTTPStatusCode: (_ url: String) async throws -> HTTPStatus
     var fetchPackageList: (_ client: Client) async throws -> [URL]
+    var fetchPackageDenyList: (_ client: Client) async throws -> [URL]
     var fetchLicense: (_ client: Client, _ packageUrl: String) async -> Github.License?
     var fetchMetadata: (_ client: Client, _ packageUrl: String) async throws -> Github.Metadata
     var fetchReadme: (_ client: Client, _ packageUrl: String) async -> Github.Readme?
@@ -167,6 +168,7 @@ extension AppEnvironment {
         fetchDocumentation: { client, url in try await client.get(url) },
         fetchHTTPStatusCode: Networking.fetchHTTPStatusCode,
         fetchPackageList: liveFetchPackageList,
+        fetchPackageDenyList: liveFetchPackageDenyList,
         fetchLicense: Github.fetchLicense(client:packageUrl:),
         fetchMetadata: Github.fetchMetadata(client:packageUrl:),
         fetchReadme: Github.fetchReadme(client:packageUrl:),

--- a/Sources/App/Core/Constants.swift
+++ b/Sources/App/Core/Constants.swift
@@ -25,6 +25,7 @@ enum Constants {
     static let gitSuffix = ".git"
 
     static let packageListUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json")
+    static let packageDenyListUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/denylist.json")
 
     // NB: the underlying materialised views also have a limit, this is just an additional
     // limit to ensure we don't spill too many rows onto the home page

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -45,6 +45,9 @@ extension AppEnvironment {
                 ["https://github.com/finestructure/Gala",
                  "https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server"].asURLs
             },
+            fetchPackageDenyList: { _ in
+                ["https://github.com/daveverwer/LeftPad"].asURLs
+            },
             fetchLicense: { _, _ in .init(htmlUrl: "https://github.com/foo/bar/blob/main/LICENSE") },
             fetchMetadata: { _, _ in .mock },
             fetchReadme: { _, _ in .init(html: "readme html", htmlUrl: "readme html url") },

--- a/Tests/AppTests/ReconcilerTests.swift
+++ b/Tests/AppTests/ReconcilerTests.swift
@@ -77,12 +77,12 @@ class ReconcilerTests: AppTestCase {
             try await Package(url: url).save(on: app.db)
         }
 
-        // New list drops 2 and adds 4, 5
-        let packageList = ["1", "3", "4", "5"]
+        // New list adds two new packages 4, 5
+        let packageList = ["1", "2", "3", "4", "5"]
         Current.fetchPackageList = { _ in packageList.asURLs }
 
-        // Deny list denies 4
-        let packageDenyList = ["4"]
+        // Deny list denies 2 and 4 (one existing and one new)
+        let packageDenyList = ["2", "4"]
         Current.fetchPackageDenyList = { _ in packageDenyList.asURLs }
 
         // MUT

--- a/Tests/AppTests/ReconcilerTests.swift
+++ b/Tests/AppTests/ReconcilerTests.swift
@@ -70,4 +70,26 @@ class ReconcilerTests: AppTestCase {
         let packages = try await Package.query(on: app.db).all()
         XCTAssertEqual(packages.map(\.url).sorted(), urls.sorted())
     }
+
+    func test_packageDenyList() async throws {
+        // Save the intial set of packages
+        for url in ["1", "2", "3"].asURLs {
+            try await Package(url: url).save(on: app.db)
+        }
+
+        // New list drops 2 and adds 4, 5
+        let packageList = ["1", "3", "4", "5"]
+        Current.fetchPackageList = { _ in packageList.asURLs }
+
+        // Deny list denies 4
+        let packageDenyList = ["4"]
+        Current.fetchPackageDenyList = { _ in packageDenyList.asURLs }
+
+        // MUT
+        try await reconcile(client: app.client, database: app.db)
+
+        // validate
+        let packages = try await Package.query(on: app.db).all()
+        XCTAssertEqual(packages.map(\.url).sorted(), ["1", "3", "5"])
+    }
 }


### PR DESCRIPTION
Progress towards #665

We still need to stop the "Add Package" workflow adding these back, and have the PackageList nightly remove them after discovery, but at least this now keeps denied packages out of the actual index!