### PR TITLE
Cope with visionOS platforms being specified in the Package manifest

### DIFF
--- a/Sources/App/Models/Manifest.swift
+++ b/Sources/App/Models/Manifest.swift
@@ -45,6 +45,7 @@ struct Manifest: Decodable, Equatable {
             case macos
             case openbsd      // from 5.8
             case tvos
+            case visionos     // from 5.9
             case wasi         // from 5.3
             case watchos
             case windows      // from 5.2

--- a/Sources/App/Models/Platform.swift
+++ b/Sources/App/Models/Platform.swift
@@ -27,6 +27,7 @@ struct Platform: Codable, Equatable {
         case macos
         case openbsd
         case tvos
+        case visionos
         case wasi
         case watchos
         case windows
@@ -71,6 +72,8 @@ extension Platform: CustomStringConvertible {
                 return "OpenBSD \(version)"
             case .tvos:
                 return "tvOS \(version)"
+            case .visionos:
+                return "visionOS \(version)"
             case .wasi:
                 return "WASI \(version)"
             case .watchos:


### PR DESCRIPTION
Fixes #2605

The issue was [this line](https://github.com/fatbobman/SwiftDataKit/blob/4a476fc8ad2ce1ded20082e697226a2f2cebbf81/Package.swift#L13) in the `SwiftDataKit` package manifest. It’s the first time we’ve seen a `visionOS` platform explicitly declared.

I checked [SupportedPlatforms.swift](https://github.com/apple/swift-package-manager/blob/main/Sources/PackageDescription/SupportedPlatforms.swift) and we’re now up to date again with nothing missing.

When it comes to testing this, we could add a test to `ManifestTests` to verify that we never remove `visionos` or any of the other cases, but I don’t think we can add anything sensible that will catch this error for future platforms. I don’t think a test makes sense here, unless you have an idea for one @finestructure?