### PR TITLE
Add version.productDependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .package(url: "https://github.com/JohnSundell/Ink.git", from: "0.5.1"),
         .package(url: "https://github.com/daveverwer/Plot.git", branch: "sitemapindex"),
         .package(url: "https://github.com/MrLotU/SwiftPrometheus.git", from: "1.0.0-alpha"),
-        .package(url: "https://github.com/SwiftPackageIndex/DependencyResolution", from: "1.0.0"),
+        .package(url: "https://github.com/SwiftPackageIndex/DependencyResolution", from: "1.1.2"),
         .package(url: "https://github.com/SwiftPackageIndex/SPIManifest.git", from: "1.0.0"),
         .package(url: "https://github.com/SwiftPackageIndex/SemanticVersion", from: "0.3.0"),
         .package(url: "https://github.com/SwiftPackageIndex/ShellOut.git", from: "3.1.0"),

--- a/Sources/App/Migrations/068/UpdateVersionAddProductDependencies.swift
+++ b/Sources/App/Migrations/068/UpdateVersionAddProductDependencies.swift
@@ -14,19 +14,19 @@
 
 import Fluent
 
-struct UpdateVersionAddResolvedDependencies: Migration {
-    func prepare(on database: Database) -> EventLoopFuture<Void> {
-        database.schema("versions")
-            .field("resolved_dependencies",
+struct UpdateVersionAddProductDependencies: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("versions")
+            .field("product_dependencies",
                    .array(of: .json),
                    .sql(.default("{}"))
             )
             .update()
     }
 
-    func revert(on database: Database) -> EventLoopFuture<Void> {
-        database.schema("versions")
-            .deleteField("resolved_dependencies")
+    func revert(on database: Database) async throws {
+        try await database.schema("versions")
+            .deleteField("product_dependencies")
             .update()
     }
 }

--- a/Sources/App/Models/Version.swift
+++ b/Sources/App/Models/Version.swift
@@ -62,6 +62,9 @@ final class Version: Model, Content {
     @Field(key: "package_name")
     var packageName: String?
 
+    @Field(key: "product_dependencies")
+    var productDependencies: [ProductDependency]?
+
     @Field(key: "published_at")
     var publishedAt: Date?
 
@@ -115,6 +118,7 @@ final class Version: Model, Content {
          hasBinaryTargets: Bool = false,
          latest: Kind? = nil,
          packageName: String? = nil,
+         productDependencies: [ProductDependency]? = nil,
          publishedAt: Date? = nil,
          reference: Reference,
          releaseNotes: String? = nil,
@@ -133,6 +137,7 @@ final class Version: Model, Content {
         self.hasBinaryTargets = hasBinaryTargets
         self.latest = latest
         self.packageName = packageName
+        self.productDependencies = productDependencies
         self.publishedAt = publishedAt
         self.reference = reference
         self.releaseNotes = releaseNotes

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -300,6 +300,9 @@ public func configure(_ app: Application) throws -> String {
     do { // Migration 067 - remove readmeUrl, readmeHtmlUrl from repositories, add readmeEtag
         app.migrations.add(UpdateRepositoryReadmeChanges())
     }
+    do { // Migration 068 - add product_dependencies to versions
+        app.migrations.add(UpdateVersionAddProductDependencies())
+    }
 
     app.commands.use(Analyze.Command(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/VersionTests.swift
+++ b/Tests/AppTests/VersionTests.swift
@@ -34,6 +34,7 @@ class VersionTests: AppTestCase {
         v.commit = "commit"
         v.latest = .defaultBranch
         v.packageName = "pname"
+        v.productDependencies = [.init(identity: "foo", name: "Foo", url: "https://github.com/foo/Foo.git", dependencies: [])]
         v.publishedAt = Date(timeIntervalSince1970: 1)
         v.reference = .branch("branch")
         v.releaseNotes = "release notes"
@@ -51,6 +52,8 @@ class VersionTests: AppTestCase {
             XCTAssertEqual(v.commit, "commit")
             XCTAssertEqual(v.latest, .defaultBranch)
             XCTAssertEqual(v.packageName, "pname")
+            XCTAssertEqual(v.productDependencies,
+                           [.init(identity: "foo", name: "Foo", url: "https://github.com/foo/Foo.git", dependencies: [])])
             XCTAssertEqual(v.publishedAt, Date(timeIntervalSince1970: 1))
             XCTAssertEqual(v.reference, .branch("branch"))
             XCTAssertEqual(v.releaseNotes, "release notes")


### PR DESCRIPTION
We're already reporting "product dependencies" (top level dependencies without test dependencies) from our builders. This change accepts this new property in the build report and stores is in `versions.product_dependencies`.