### PR TITLE
Additional trim builds testing

### DIFF
--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -906,7 +906,7 @@ class BuildTriggerTests: AppTestCase {
     }
 
     func test_trimBuilds_allVariants() async throws {
-        // trimBuilds is acting on three properties with two status each:
+        // trimBuilds is acting on three properties with two states each:
         // created_at: within 4h / older
         // status: triggered or infrastructureError / otherwise
         // latest: not null / null

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -573,7 +573,6 @@ class BuildTriggerTests: AppTestCase {
         try await Build(id: .id2, version: v, platform: .iOS, status: .triggered, swiftVersion: .v2)
             .save(on: app.db)
         // shift createdAt back to make build eligible from trimming
-        try await updateBuildCreatedAt(id: .id2, addTimeInterval: -.hours(5), on: app.db)
         XCTAssertEqual(try Build.query(on: app.db).count().wait(), 1)
 
         // MUT
@@ -884,7 +883,7 @@ class BuildTriggerTests: AppTestCase {
             // old triggered build (delete)
             try await Build(id: .id0, version: v, platform: .iOS, status: .triggered, swiftVersion: .v2)
                 .save(on: app.db)
-            // new triggered build (keep)
+            // new triggered build (delete)
             try await Build(id: .id1, version: v, platform: .iOS, status: .triggered, swiftVersion: .v3)
                 .save(on: app.db)
             // old non-triggered build (delete)
@@ -902,8 +901,8 @@ class BuildTriggerTests: AppTestCase {
         let deleteCount = try await trimBuilds(on: app.db)
 
         // validate
-        XCTAssertEqual(deleteCount, 2)
-        try await XCTAssertEqualAsync(try await Build.query(on: app.db).all().map(\.id), [.id1])
+        XCTAssertEqual(deleteCount, 3)
+        try await XCTAssertEqualAsync(try await Build.query(on: app.db).all().map(\.id), [])
     }
 
     func test_trimBuilds_bindParam() async throws {

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -922,24 +922,24 @@ class BuildTriggerTests: AppTestCase {
 
         do {  // set up builds
             try await [
-                // recent, release, ok (keep)
+                // ✅ recent, release, ok
                 Build(id: .id0, version: release, platform: .iOS, status: .ok, swiftVersion: .latest),
-                // recent, release, triggered (keep)
+                // ✅ recent, release, triggered
                 Build(id: .id1, version: release, platform: .linux, status: .triggered, swiftVersion: .latest),
-                // recent, nonSignificant, ok (delete)
+                // ❌ recent, nonSignificant, ok
                 Build(id: .id2, version: nonSignificant, platform: .iOS, status: .ok, swiftVersion: .latest),
-                // recent, nonSignificant, triggered (delete)
+                // ❌ recent, nonSignificant, triggered
                 Build(id: .id3, version: nonSignificant, platform: .linux, status: .triggered, swiftVersion: .latest),
             ].save(on: app.db)
 
             let oldBuilds = try [
-                // old, release, ok (keep)
+                // ✅ old, release, ok
                 Build(id: .id4, version: release, platform: .watchOS, status: .ok, swiftVersion: .latest),
-                // old, release, triggered (delete)
+                // ❌ old, release, triggered
                 Build(id: .id5, version: release, platform: .tvOS, status: .triggered, swiftVersion: .latest),
-                // old, nonSignificant, ok (delete)
+                // ❌ old, nonSignificant, ok
                 Build(id: .id6, version: nonSignificant, platform: .watchOS, status: .ok, swiftVersion: .latest),
-                // old, nonSignificant, triggered (delete)
+                // ❌ old, nonSignificant, triggered
                 Build(id: .id7, version: nonSignificant, platform: .tvOS, status: .triggered, swiftVersion: .latest),
             ]
             try await oldBuilds.save(on: app.db)


### PR DESCRIPTION
No functional changes, just bringing back some of the test updates from 80019223fe41436aa7fd8f5096b5de043dc774e3 but without the change to `trimBuilds`, plus an additional new test `test_trimBuilds_allVariants` that covers all the variants of properties being selected on in the trim builds where clause.