### PR TITLE
Align with latest template changes brining back backtrace support

### DIFF
--- a/Sources/Run/entrypoint.swift
+++ b/Sources/Run/entrypoint.swift
@@ -17,6 +17,12 @@ import Vapor
 import Dispatch
 import Logging
 
+#if swift(>=5.9.1)
+// For lack of a better place to put this reminder about Dockerfile changes
+// https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/2636
+#warning("Review backtrace changes in Dockerfile")
+#endif
+
 /// This extension is temporary and can be removed once Vapor gets this support.
 private extension Vapor.Application {
     static let baseExecutionQueue = DispatchQueue(label: "vapor.codes.entrypoint")


### PR DESCRIPTION
Upstream changes: https://github.com/vapor/template/pull/108/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557

There's an open bug preventing backtraces from working: https://github.com/apple/swift/pull/68669

Expected to be fixed in 5.9.1
