### PR TITLE
Drop version safeguard

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -224,9 +224,7 @@ extension Analyze {
                                                       package: package)
             let netDeleteCount = versionDelta.toDelete.count - versionDelta.toAdd.count
             if netDeleteCount > 1 {
-                // Sudden loss of versions is suspicious, warn and throw error
-                let error = "Suspicious loss of \(netDeleteCount) versions for package \(package.model.id) - aborting analysis"
-                throw AppError.genericError(package.model.id, error)
+                logger.warning("Suspicious loss of \(netDeleteCount) versions for package \(package.model.id)")
             }
 
             try await applyVersionDelta(on: tx, delta: versionDelta)

--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -36,10 +36,13 @@ func updatePackages(client: Client,
         let total = results.count
         let errors = results.filter(\.isError).count
         let errorRate = total > 0 ? 100.0 * Double(errors) / Double(total) : 0.0
-        if errorRate < 20 {
-            logger.info("Updating \(total) packages for stage '\(stage)' (errors: \(errors))")
-        } else {
-            logger.critical("updatePackages: unusually high error rate: \(errors)/\(total) = \(errorRate)%")
+        switch errorRate {
+            case 0:
+                logger.info("Updating \(total) packages for stage '\(stage)'")
+            case 0..<20:
+                logger.info("Updating \(total) packages for stage '\(stage)' (errors: \(errors))")
+            default:
+                logger.critical("updatePackages: unusually high error rate: \(errors)/\(total) = \(errorRate)%")
         }
     }
     for result in results {

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -87,7 +87,7 @@ func ingest(client: Client,
     switch mode {
         case .id(let id):
             logger.info("Ingesting (id: \(id)) ...")
-            let pkg = try await Package.fetchCandidate(database, id: id).get()
+            let pkg = try await Package.fetchCandidate(database, id: id)
             await ingest(client: client,
                          database: database,
                          logger: logger,

--- a/Sources/App/Commands/ReAnalyzeVersions.swift
+++ b/Sources/App/Commands/ReAnalyzeVersions.swift
@@ -118,7 +118,7 @@ enum ReAnalyzeVersions {
                                   versionsLastUpdatedBefore cutOffDate: Date,
                                   refreshCheckouts: Bool,
                                   packageId: Package.Id) async throws {
-        let pkg = try await Package.fetchCandidate(database, id: packageId).get()
+        let pkg = try await Package.fetchCandidate(database, id: packageId)
         try await reAnalyzeVersions(client: client,
                                     database: database,
                                     logger: logger,

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -270,10 +270,16 @@ extension QueryBuilder where Model == Package {
 
 
 extension Package {
-    static func fetchCandidate(_ database: Database,
-                               id: Id) -> EventLoopFuture<Joined<Package, Repository>> {
-        Joined.query(on: database)
+    static func fetchCandidate(_ database: Database, id: Id) async throws -> Joined<Package, Repository> {
+        try await Joined.query(on: database)
             .filter(\.$id == id)
+            .first()
+            .unwrap(or: Abort(.notFound))
+    }
+
+    static func fetchCandidate(_ database: Database, url: String) async throws -> Joined<Package, Repository> {
+        try await Joined.query(on: database)
+            .filter(Package.self, \.$url, .custom("ilike"), "%\(url)%")
             .first()
             .unwrap(or: Abort(.notFound))
     }

--- a/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
+++ b/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
@@ -172,7 +172,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         try await Repository(package: pkg, defaultBranch: "main").save(on: app.db)
         let old = try makeVersion(pkg, "sha_old", .hours(-23), .branch("main"), .defaultBranch)
         try await old.save(on: app.db)
-        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
 
         do {  // keep old version if too soon
             Current.git.revisionInfo = { _, _ in
@@ -235,7 +235,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         let pkg = Package(url: "1".asGithubUrl.url)
         try await pkg.save(on: app.db)
         try await Repository(package: pkg, defaultBranch: "main").save(on: app.db)
-        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
 
         // start at t0
         var t = Date.t0

--- a/Tests/AppTests/PackageReleasesModelTests.swift
+++ b/Tests/AppTests/PackageReleasesModelTests.swift
@@ -19,7 +19,7 @@ import XCTVapor
 
 class PackageReleasesModelTests: AppTestCase {
 
-    func test_initialise() throws {
+    func test_initialise() async throws {
         // Setup
 
         // Work-around to set the local time zone for time sensitive
@@ -34,16 +34,16 @@ class PackageReleasesModelTests: AppTestCase {
 
         Current.date = { .spiBirthday }
         let pkg = Package(id: UUID(), url: "1".asGithubUrl.url)
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
 
-        try Repository(package: pkg, releases: [
+        try await Repository(package: pkg, releases: [
             .mock(description: "Release Notes", descriptionHTML: "Release Notes",
                   publishedAt: 2, tagName: "1.0.0", url: "some url"),
 
             .mock(description: nil, descriptionHTML: nil,
                   publishedAt: 1, tagName: "0.0.1", url: "some url"),
-        ]).save(on: app.db).wait()
-        let jpr = try Package.fetchCandidate(app.db, id: pkg.id!).wait()
+        ]).save(on: app.db)
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
 
 
         // MUT

--- a/Tests/AppTests/ScoreTests.swift
+++ b/Tests/AppTests/ScoreTests.swift
@@ -205,7 +205,7 @@ class ScoreTests: AppTestCase {
             try Version(package: pkg, reference: .tag(.init($0, 0, 0)))
                 .save(on: app.db).wait()
         }
-        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
         // update versions
         let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 

--- a/Tests/AppTests/SocialTests.swift
+++ b/Tests/AppTests/SocialTests.swift
@@ -129,7 +129,7 @@ class SocialTests: AppTestCase {
                              summary: "This is a test package").save(on: app.db)
         let version = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
         try await version.save(on: app.db)
-        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
 
         // MUT
         let res = Social.firehoseMessage(package: jpr,
@@ -154,7 +154,7 @@ class SocialTests: AppTestCase {
                              summary: "This is a test package").save(on: app.db)
         let version = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
         try await version.save(on: app.db)
-        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
 
         // MUT
         let res = Social.firehoseMessage(package: jpr,
@@ -186,7 +186,7 @@ class SocialTests: AppTestCase {
                           reference: .tag(2, 0, 0, "b1")).save(on: app.db)
         try await Version(package: pkg, packageName: "MyPackage", reference: .branch("main"))
             .save(on: app.db)
-        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
         let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         Current.twitterCredentials = {
@@ -218,7 +218,7 @@ class SocialTests: AppTestCase {
             .save(on: app.db)
         try await Version(package: pkg, packageName: "MyPackage", reference: .tag(2, 0, 0))
             .save(on: app.db)
-        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
         let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         Current.twitterCredentials = {

--- a/Tests/AppTests/TwitterTests.swift
+++ b/Tests/AppTests/TwitterTests.swift
@@ -115,7 +115,7 @@ class TwitterTests: AppTestCase {
                              summary: "This is a test package").save(on: app.db)
         let v = try Version(package: pkg, packageName: "MyPackage", reference: .tag(1, 2, 3))
         try await v.save(on: app.db)
-        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!).get()
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
         Current.twitterCredentials = {
             .init(apiKey: ("key", "secret"), accessToken: ("key", "secret"))
         }


### PR DESCRIPTION
The "version deletion safeguard" I added recently assumes that authors don't reset their version - but of course they do.

The package `super agent-swift` aborts analysis:

```
[ INFO ] Analyzing (url: superagent) ... [component: analyze]
[ INFO ] Checkout directory: /Users/sas/Projects/SPI/spi-server/SPI-checkouts [component: analyze]
[ INFO ] cloning https://github.com/simonweniger/superagent-swift.git to /Users/sas/Projects/SPI/spi-server/SPI-checkouts/github.com-simonweniger-superagent-swift [component: analyze]
[ CRITICAL ] updatePackages: unusually high error rate: 1/1 = 100.0% [component: analyze]
[ WARNING ] Error: Suspicious loss of 7 versions for package 8FC94FA1-D307-49F8-AA5F-C1BEF55A9509 - aborting analysis (id: 8FC94FA1-D307-49F8-AA5F-C1BEF55A9509) [component: analyze]
```

It used to have a number of tags:

```sql
select coalesce(reference->'tag'->>'tagName', reference->>'branch') "ref"
from versions where package_id = '8FC94FA1-D307-49F8-AA5F-C1BEF55A9509';
0.0.5
0.0.6
0.0.7
0.0.8
0.1.0
0.1.1
0.1.2
0.1.4
main
```

but now doesn't anymore:

```
~/P/S/s/S/github.com-simonweniger-superagent-swift on main 
✦ ❯ git tag
v1.0.0-beta
```

This PR keeps the warning but doesn't abort analysis anymore.