### PR TITLE
Show the Swift version "(beta)" note on the build index and detail pages

### DIFF
--- a/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
@@ -74,14 +74,23 @@ enum BuildIndex {
                     "."
                 ),
                 .forEach(SwiftVersion.allActive.reversed()) { swiftVersion in
-                    .group(
-                        .hr(),
-                        .h3(.text(swiftVersion.longDisplayName)),
-                        .ul(
-                            .class("matrix builds"),
-                            .group(model.buildMatrix[swiftVersion].map(\.node))
+                        .group(
+                            .hr(),
+                            .h3(
+                                .text(swiftVersion.longDisplayName),
+                                .unwrap(swiftVersion.note, { note in
+                                        .group(
+                                            .text(" ("),
+                                            .text(note),
+                                            .text(")")
+                                        )
+                                })
+                            ),
+                            .ul(
+                                .class("matrix builds"),
+                                .group(model.buildMatrix[swiftVersion].map(\.node))
+                            )
                         )
-                    )
                 }
             )
         }

--- a/Sources/App/Views/PackageController/Builds/BuildShow+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+View.swift
@@ -67,7 +67,16 @@ enum BuildShow {
                         .text(model.packageName)
                     ),
                     .text(" with "),
-                    .strong(.text(model.buildInfo.swiftVersion.longDisplayName)),
+                    .strong(
+                        .text(model.buildInfo.swiftVersion.longDisplayName),
+                        .unwrap(model.buildInfo.swiftVersion.note, { note in
+                                .group(
+                                    .text(" ("),
+                                    .text(note),
+                                    .text(")")
+                                )
+                        })
+                    ),
                     .text(" for "),
                     .strong(.text(model.buildInfo.platform.displayName)),
                     .unwrap(model.buildInfo.xcodeVersion) {

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_BuildIndex.1.html
@@ -98,7 +98,7 @@
             <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new/choose">raise an issue</a>.
           </p>
           <hr/>
-          <h3>Swift 5.9</h3>
+          <h3>Swift 5.9 (beta)</h3>
           <ul class="matrix builds">
             <li class="row">
               <div class="row-labels">


### PR DESCRIPTION
This is about to go away, but we were not including the (beta) note on either the build results index or show pages.

![Screenshot 2023-09-26 at 12 28 39@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/1042f19b-9be6-49e6-8a94-5c839fd12467)

![Screenshot 2023-09-26 at 12 29 59@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/2fc3a01e-4b80-4ed3-aa99-448bfe67efe0)

In preparation for Swift 6.0 (beta) 😂