### PR TITLE
default 15d → 30d

### DIFF
--- a/mon.yml
+++ b/mon.yml
@@ -74,7 +74,7 @@ services:
     image: prom/prometheus:v2.47.0
     volumes:
       - prometheus_data:/prometheus
-    command: --config.file=/prometheus.yml
+    command: --config.file=/prometheus.yml --storage.tsdb.retention.time=30d
     configs:
       - source: prometheus_cfg
         target: /prometheus.yml


### PR DESCRIPTION
I want to make sure we don't lose the start of this graph while we're still investigating the capacity issues:

![CleanShot 2023-10-02 at 16 15 25@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/65520/6ada4daa-99b4-4854-afa8-2451a3b3f819)
