### PR TITLE
Updated Vapor to 4.84.3 to patch CVE-2023-44386

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/jwt-kit",
       "state" : {
-        "revision" : "9e929d925434b91857661bcd455d1bd53f00bf22",
-        "version" : "4.13.0"
+        "revision" : "cd0fe3af36764e876182137c3132a6d8459e1867",
+        "version" : "4.13.1"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftPackageIndex/ShellOut.git",
       "state" : {
-        "revision" : "20f08a9d94757838ed282048af4bb8fcf5528f18",
-        "version" : "3.1.1"
+        "revision" : "79bc247323691d6689a358b4bbb24e5ef952e73f",
+        "version" : "3.1.3"
       }
     },
     {
@@ -230,8 +230,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "6c89474e62719ddcc1e9614989fff2f68208fe10",
-        "version" : "1.1.0"
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
       }
     },
     {
@@ -257,8 +257,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "937e904258d22af6e447a0b72c0bc67583ef64a2",
-        "version" : "1.0.4"
+        "revision" : "a902f1823a7ff3c9ab2fba0f992396b948eda307",
+        "version" : "1.0.5"
       }
     },
     {
@@ -392,8 +392,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
       "state" : {
-        "revision" : "696b86a6d151578bca7c1a2a3ed419a5f834d40f",
-        "version" : "1.13.0"
+        "revision" : "506b6052384d8e97a4bb16fe8680325351c23c64",
+        "version" : "1.14.0"
       }
     },
     {
@@ -455,8 +455,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",
       "state" : {
-        "revision" : "036d67e4da46126810f56c6a6ce813bcf259a745",
-        "version" : "4.84.1"
+        "revision" : "c17d9b90d1e94cffa2a10cba63ec5b97147f7472",
+        "version" : "4.84.3"
       }
     },
     {


### PR DESCRIPTION
https://blog.vapor.codes/posts/security-advisory-GHSA-3mwq-h3g6-ffhm/