### PR TITLE
Align function names with actual property name

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -296,11 +296,11 @@ enum PackageController {
         let packageResult = try await PackageResult.query(on: req.db, owner: owner, repository: repository)
         let urls = await linkablePathUrls(client: req.client, packageResult: packageResult)
 
-        return try await siteMap(packageResult: packageResult, linkableEntityUrls: urls)
+        return try await siteMap(packageResult: packageResult, linkablePathUrls: urls)
             .encodeResponse(for: req)
     }
 
-    static func siteMap(packageResult: PackageResult, linkableEntityUrls: [String]) async throws -> SiteMap {
+    static func siteMap(packageResult: PackageResult, linkablePathUrls: [String]) async throws -> SiteMap {
         guard let canonicalOwner = packageResult.repository.owner,
               let canonicalRepository = packageResult.repository.name
         else {
@@ -319,7 +319,7 @@ enum PackageController {
                                      .none).absoluteURL()),
                 lastmod
             ),
-            .forEach(linkableEntityUrls, { url in
+            .forEach(linkablePathUrls, { url in
                     .url(.loc(url), lastmod)
             })
         )

--- a/Tests/AppTests/SitemapTests.swift
+++ b/Tests/AppTests/SitemapTests.swift
@@ -162,7 +162,7 @@ class SitemapTests: SnapshotTestCase {
             .query(on: app.db, owner: "owner", repository: "repo0")
 
         // MUT
-        let sitemap = try await PackageController.siteMap(packageResult: packageResult, linkableEntityUrls: [])
+        let sitemap = try await PackageController.siteMap(packageResult: packageResult, linkablePathUrls: [])
         let xml = sitemap.render(indentedBy: .spaces(2))
 
         // Validation
@@ -181,7 +181,7 @@ class SitemapTests: SnapshotTestCase {
                           reference: .branch("default")).save(on: app.db)
         let packageResult = try await PackageController.PackageResult
             .query(on: app.db, owner: "owner", repository: "repo0")
-        let linkableEntitiesUlrs = [
+        let linkablePathUrls = [
             "/documentation/semanticversion/semanticversion/minor",
             "/documentation/semanticversion/semanticversion/_(_:_:)-4ftn7",
             "/documentation/semanticversion/semanticversion/'...(_:)-40b95"
@@ -189,7 +189,7 @@ class SitemapTests: SnapshotTestCase {
 
         // MUT
         let sitemap = try await PackageController.siteMap(packageResult: packageResult,
-                                                          linkableEntityUrls: linkableEntitiesUlrs)
+                                                          linkablePathUrls: linkablePathUrls)
         let xml = sitemap.render(indentedBy: .spaces(2))
 
         // Validation


### PR DESCRIPTION
We've switched out the source file but didn't align all the function names.