### PR TITLE
Make sure dependabot is done by Monday morning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "02:00"
     groups:
       dependencies:
         patterns:
@@ -13,6 +14,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "02:00"
     groups:
       dependencies:
         patterns:
@@ -21,6 +23,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      time: "02:00"
     groups:
       dependencies:
         patterns:


### PR DESCRIPTION
> By default, Dependabot checks for new versions at a random set time for the repository