### PR TITLE
Package update

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -401,8 +401,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-syntax.git",
       "state" : {
-        "revision" : "74203046135342e4a4a627476dd6caf8b28fe11b",
-        "version" : "509.0.0"
+        "revision" : "ffa3cd6fc2aa62adbedd31d3efaf7c0d86a9f029",
+        "version" : "509.0.1"
       }
     },
     {


### PR DESCRIPTION
The change to the new setup yesterday probably reset the scheduled run. Let's use the old one for this week's update.