### PR TITLE
Re-enable the package score section on the maintainer page in production

### DIFF
--- a/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
+++ b/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
@@ -178,32 +178,30 @@ enum MaintainerInfoIndex {
                     ),
                     " to validate your ", .code(".spi.yml"), "file."
                 ),
-                .if(Current.environment() != .production,
+                .div(
+                    .id("package-score"),
+                    .h3("Package Score"),
+                    .p(
+                        "This package has a total score of \(model.score) points. The Swift Package Index uses package score in combination with the relevancy of a search query to influence the ordering of search results."
+                    ),
+                    .p(
+                        "The score is currently evaluated based on \(model.scoreCategories.count) traits, and the breakdown of each trait is shown below."
+                    ),
                     .div(
-                        .id("package-score"),
-                        .h3("Package Score"),
-                        .p(
-                            "This package has a total score of \(model.score) points. The Swift Package Index uses package score in combination with the relevancy of a search query to influence the ordering of search results."
-                        ),
-                        .p(
-                            "The score is currently evaluated based on \(model.scoreCategories.count) traits, and the breakdown of each trait is shown below."
-                        ),
-                        .div(
-                            .class("package-score"),
-                            .text("Total – \(model.score) points")
-                        ),
-                        .div(
-                            .class("package-score-breakdown"),
-                            model.packageScoreCategories()
-                        ),
-                        .p(
-                            "The package score is a work in progress. We have an ",
-                            .a(
-                                .href(model.packageScoreDiscussionURL),
-                                "always-open discussion thread"
-                            ),
-                            .text(" if you are interested in providing feedback on existing traits or would like to propose new ones.")
-                        )
+                        .class("package-score"),
+                        .text("Total – \(model.score) points")
+                    ),
+                    .div(
+                        .class("package-score-breakdown"),
+                        model.packageScoreCategories()
+                    ),
+                    .p(
+                        "The package score is a work in progress. We have an ",
+                       .a(
+                        .href(model.packageScoreDiscussionURL),
+                        "always-open discussion thread"
+                       ),
+                       .text(" if you are interested in providing feedback on existing traits or would like to propose new ones.")
                     )
                 )
             )

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MaintainerInfoIndex.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MaintainerInfoIndex.1.html
@@ -145,6 +145,67 @@
             <a href="/validate-spi-manifest">online manifest validation helper</a> to validate your 
             <code>.spi.yml</code>file.
           </p>
+          <div id="package-score">
+            <h3>Package Score</h3>
+            <p>This package has a total score of 117 points. The Swift Package Index uses package score in combination with the relevancy of a search query to influence the ordering of search results.</p>
+            <p>The score is currently evaluated based on 10 traits, and the breakdown of each trait is shown below.</p>
+            <div class="package-score">Total – 117 points</div>
+            <div class="package-score-breakdown">
+              <div class="score-trait">
+                <p>Archived</p>
+                <p>20 points</p>
+                <p>Repository is not archived.</p>
+              </div>
+              <div class="score-trait">
+                <p>Contributors</p>
+                <p>10 points</p>
+                <p>Has 20 contributors.</p>
+              </div>
+              <div class="score-trait">
+                <p>Dependencies</p>
+                <p>2 points</p>
+                <p>Depends on 3 packages.</p>
+              </div>
+              <div class="score-trait">
+                <p>Documentation</p>
+                <p>15 points</p>
+                <p>Includes  documentation.</p>
+              </div>
+              <div class="score-trait">
+                <p>Last Activity</p>
+                <p>15 points</p>
+                <p>Last maintenance activity 10 days ago.</p>
+              </div>
+              <div class="score-trait">
+                <p>License</p>
+                <p>10 points</p>
+                <p>OSI-compatible license which is compatible with the App Store.</p>
+              </div>
+              <div class="score-trait">
+                <p>README</p>
+                <p>15 points</p>
+                <p>Has a README file.</p>
+              </div>
+              <div class="score-trait">
+                <p>Releases</p>
+                <p>10 points</p>
+                <p>Has 10 releases.</p>
+              </div>
+              <div class="score-trait">
+                <p>Stars</p>
+                <p>20 points</p>
+                <p>Has 300 stars.</p>
+              </div>
+              <div class="score-trait">
+                <p>Tests</p>
+                <p>0 points</p>
+                <p>Has no test targets.</p>
+              </div>
+            </div>
+            <p>The package score is a work in progress. We have an 
+              <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/discussions/2591">always-open discussion thread</a> if you are interested in providing feedback on existing traits or would like to propose new ones.
+            </p>
+          </div>
         </div>
       </div>
     </main>


### PR DESCRIPTION
Reverts SwiftPackageIndex/SwiftPackageIndex-Server#2688