### PR TITLE
Completely disable site maps on staging

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -320,10 +320,10 @@ enum PackageController {
             [String]()
         }
 
-        return try await SiteMapView.packageSiteMap(owner: packageResult.repository.owner,
-                                                    repository: packageResult.repository.name,
-                                                    lastActivityAt: packageResult.repository.lastActivityAt,
-                                                    linkablePathUrls: urls).encodeResponse(for: req)
+        return try await SiteMapView.package(owner: packageResult.repository.owner,
+                                             repository: packageResult.repository.name,
+                                             lastActivityAt: packageResult.repository.lastActivityAt,
+                                             linkablePathUrls: urls).encodeResponse(for: req)
     }
 
     static func linkablePathUrls(client: Client, packageResult: PackageResult) async -> [String] {

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -287,7 +287,7 @@ enum PackageController {
         return response
     }
 
-    static func siteMap(req: Request) async throws -> Response {
+    static func siteMap(req: Request) async throws -> SiteMap {
         guard
             let owner = req.parameters.get("owner"),
             let repository = req.parameters.get("repository")
@@ -319,7 +319,7 @@ enum PackageController {
         return try await SiteMapView.package(owner: packageResult.repository.owner,
                                              repository: packageResult.repository.name,
                                              lastActivityAt: packageResult.repository.lastActivityAt,
-                                             linkablePathUrls: urls).encodeResponse(for: req)
+                                             linkablePathUrls: urls)
     }
 
     static func linkablePathUrls(client: Client, packageResult: PackageResult) async -> [String] {

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -293,6 +293,10 @@ enum PackageController {
             let repository = req.parameters.get("repository")
         else { throw Abort(.notFound) }
 
+        // Only serve sitemaps in production.
+        guard Current.environment() == .production
+        else { throw Abort(.notFound) }
+
         // Temporarily limit documentation in package sitemaps with an allow list to convince
         // Google we have not been hacked! This should take us from ~460,000 URLs to < 20,000.
         let allowList = [

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -293,10 +293,6 @@ enum PackageController {
             let repository = req.parameters.get("repository")
         else { throw Abort(.notFound) }
 
-        // Only serve sitemaps in production.
-        guard Current.environment() == .production
-        else { throw Abort(.notFound) }
-
         // Temporarily limit documentation in package sitemaps with an allow list to convince
         // Google we have not been hacked! This should take us from ~460,000 URLs to < 20,000.
         let allowList = [

--- a/Sources/App/Controllers/SiteMapController.swift
+++ b/Sources/App/Controllers/SiteMapController.swift
@@ -36,10 +36,6 @@ enum SiteMapController {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
 
-        // Only serve sitemaps in production.
-        guard Current.environment() == .production
-        else { throw Abort(.notFound) }
-
         // Drive sitemap from the search view as it only includes presentable packages.
         let query = db.select()
             .column(Search.repoOwner, as: "owner")
@@ -54,10 +50,6 @@ enum SiteMapController {
     }
 
     static func staticPages(req: Request) async throws -> Response {
-        // Only serve sitemaps in production.
-        guard Current.environment() == .production
-        else { throw Abort(.notFound) }
-
         return try await SiteMapView.staticPages().encodeResponse(for: req)
     }
 }

--- a/Sources/App/Controllers/SiteMapController.swift
+++ b/Sources/App/Controllers/SiteMapController.swift
@@ -50,7 +50,7 @@ enum SiteMapController {
             .orderBy(Search.repoName)
 
         let packages = try await query.all(decoding: Package.self)
-        return try await SiteMapView.siteMapIndex(packages: packages).encodeResponse(for: req)
+        return try await SiteMapView.index(packages: packages).encodeResponse(for: req)
     }
 
     static func staticPages(req: Request) async throws -> Response {
@@ -58,6 +58,6 @@ enum SiteMapController {
         guard Current.environment() == .production
         else { throw Abort(.notFound) }
 
-        return try await SiteMapView.staticPagesSiteMap().encodeResponse(for: req)
+        return try await SiteMapView.staticPages().encodeResponse(for: req)
     }
 }

--- a/Sources/App/Controllers/SiteMapController.swift
+++ b/Sources/App/Controllers/SiteMapController.swift
@@ -45,6 +45,10 @@ enum SiteMapController {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
 
+        // Only serve sitemaps in production.
+        guard Current.environment() == .production
+        else { throw Abort(.notFound) }
+
         // Drive sitemap from the search view as it only includes presentable packages.
         let query = db.select()
             .column(Search.repoOwner, as: "owner")
@@ -74,7 +78,11 @@ enum SiteMapController {
     }
 
     static func staticPages(req: Request) async throws -> Response {
-        try await SiteMap(.group(
+        // Only serve sitemaps in production.
+        guard Current.environment() == .production
+        else { throw Abort(.notFound) }
+
+        return try await SiteMap(.group(
             staticRoutes.map { page -> Node<SiteMap.URLSetContext> in
                     .url(
                         .loc(page.absoluteURL())

--- a/Sources/App/Controllers/SiteMapController.swift
+++ b/Sources/App/Controllers/SiteMapController.swift
@@ -31,7 +31,7 @@ enum SiteMapController {
         }
     }
 
-    static func index(req: Request) async throws -> Response {
+    static func index(req: Request) async throws -> SiteMapIndex {
         guard let db = req.db as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
         }
@@ -46,10 +46,10 @@ enum SiteMapController {
             .orderBy(Search.repoName)
 
         let packages = try await query.all(decoding: Package.self)
-        return try await SiteMapView.index(packages: packages).encodeResponse(for: req)
+        return SiteMapView.index(packages: packages)
     }
 
-    static func staticPages(req: Request) async throws -> Response {
-        return try await SiteMapView.staticPages().encodeResponse(for: req)
+    static func staticPages(req: Request) async throws -> SiteMap {
+        return SiteMapView.staticPages()
     }
 }

--- a/Sources/App/Views/SiteMap/SiteMapView.swift
+++ b/Sources/App/Views/SiteMap/SiteMapView.swift
@@ -1,0 +1,47 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+import Plot
+
+enum SiteMapView {
+
+    static func packageSiteMap(owner: String?,
+                               repository: String?,
+                               lastActivityAt: Date?,
+                               linkablePathUrls: [String]) async throws -> SiteMap {
+        guard let owner,
+              let repository
+        else {
+            // This should never happen, but we should return an empty
+            // sitemap instead of an incorrect one.
+            return SiteMap()
+        }
+
+        // See SwiftPackageIndex-Server#2485 for context on the performance implications of this
+        let lastmod: Node<SiteMap.URLContext> = lastActivityAt.map { .lastmod($0, timeZone: .utc) } ?? .empty
+
+        return SiteMap(
+            .url(
+                .loc(SiteURL.package(.value(owner),
+                                     .value(repository),
+                                     .none).absoluteURL()),
+                lastmod
+            ),
+            .forEach(linkablePathUrls, { url in
+                    .url(.loc(url), lastmod)
+            })
+        )
+    }
+}

--- a/Sources/App/Views/SiteMap/SiteMapView.swift
+++ b/Sources/App/Views/SiteMap/SiteMapView.swift
@@ -26,7 +26,7 @@ enum SiteMapView {
         .privacy
     ]
 
-    static func siteMapIndex(packages: [SiteMapController.Package]) -> SiteMapIndex {
+    static func index(packages: [SiteMapController.Package]) -> SiteMapIndex {
         SiteMapIndex(
             .sitemap(
                 .loc(SiteURL.siteMapStaticPages.absoluteURL()),
@@ -45,7 +45,7 @@ enum SiteMapView {
         )
     }
 
-    static func staticPagesSiteMap() -> SiteMap {
+    static func staticPages() -> SiteMap {
         SiteMap(
             .group(
                 staticRoutes.map { page -> Node<SiteMap.URLSetContext> in
@@ -57,10 +57,10 @@ enum SiteMapView {
         )
     }
 
-    static func packageSiteMap(owner: String?,
-                               repository: String?,
-                               lastActivityAt: Date?,
-                               linkablePathUrls: [String]) async throws -> SiteMap {
+    static func package(owner: String?,
+                        repository: String?,
+                        lastActivityAt: Date?,
+                        linkablePathUrls: [String]) async throws -> SiteMap {
         guard let owner,
               let repository
         else {

--- a/Sources/App/Views/SiteMap/SiteMapView.swift
+++ b/Sources/App/Views/SiteMap/SiteMapView.swift
@@ -17,6 +17,46 @@ import Plot
 
 enum SiteMapView {
 
+    static var staticRoutes: [SiteURL] = [
+        .home,
+        .addAPackage,
+        .faq,
+        .supporters,
+        .buildMonitor,
+        .privacy
+    ]
+
+    static func siteMapIndex(packages: [SiteMapController.Package]) -> SiteMapIndex {
+        SiteMapIndex(
+            .sitemap(
+                .loc(SiteURL.siteMapStaticPages.absoluteURL()),
+                .lastmod(Current.date(), timeZone: .utc) // The home page updates every day.
+            ),
+            .group(
+                packages.map { package -> Node<SiteMapIndex.SiteMapIndexContext> in
+                        .sitemap(
+                            .loc(SiteURL.package(.value(package.owner),
+                                                 .value(package.repository),
+                                                 .siteMap).absoluteURL()),
+                            .unwrap(package.lastActivityAt, { .lastmod($0, timeZone: .utc) })
+                        )
+                }
+            )
+        )
+    }
+
+    static func staticPagesSiteMap() -> SiteMap {
+        SiteMap(
+            .group(
+                staticRoutes.map { page -> Node<SiteMap.URLSetContext> in
+                        .url(
+                            .loc(page.absoluteURL())
+                        )
+                }
+            )
+        )
+    }
+
     static func packageSiteMap(owner: String?,
                                repository: String?,
                                lastActivityAt: Date?,

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -296,7 +296,7 @@ func routes(_ app: Application) throws {
         }
     }
 
-    do { // Site map index and site maps
+    do { // Site map index and static page site map
         app.group(BackendReportingMiddleware(path: .sitemapIndex)) {
             $0.get(SiteURL.siteMapIndex.pathComponents, use: SiteMapController.index)
                 .excludeFromOpenAPI()

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -123,11 +123,14 @@ func routes(_ app: Application) throws {
         app.get(SiteURL.package(.key, .key, .maintainerInfo).pathComponents,
                 use: PackageController.maintainerInfo).excludeFromOpenAPI()
 
-        // Package specific site map, including all documentation URLs if available.
-        // Backend reporting currently disabled to avoid reporting costs for metrics we don't need.
-        app.group(BackendReportingMiddleware(path: .sitemapPackage, isActive: false)) {
-            $0.get(SiteURL.package(.key, .key, .siteMap).pathComponents,
-                    use: PackageController.siteMap).excludeFromOpenAPI()
+        // Only serve sitemaps in production.
+        if Current.environment() == .production {
+            // Package specific site map, including all documentation URLs if available.
+            // Backend reporting currently disabled to avoid reporting costs for metrics we don't need.
+            app.group(BackendReportingMiddleware(path: .sitemapPackage, isActive: false)) {
+                $0.get(SiteURL.package(.key, .key, .siteMap).pathComponents,
+                       use: PackageController.siteMap).excludeFromOpenAPI()
+            }
         }
     }
 
@@ -296,15 +299,18 @@ func routes(_ app: Application) throws {
         }
     }
 
-    do { // Site map index and static page site map
-        app.group(BackendReportingMiddleware(path: .sitemapIndex)) {
-            $0.get(SiteURL.siteMapIndex.pathComponents, use: SiteMapController.index)
-                .excludeFromOpenAPI()
-        }
+    // Only serve sitemaps in production.
+    if Current.environment() == .production {
+        do { // Site map index and static page site map
+            app.group(BackendReportingMiddleware(path: .sitemapIndex)) {
+                $0.get(SiteURL.siteMapIndex.pathComponents, use: SiteMapController.index)
+                    .excludeFromOpenAPI()
+            }
 
-        app.group(BackendReportingMiddleware(path: .sitemapStaticPages)) {
-            $0.get(SiteURL.siteMapStaticPages.pathComponents, use: SiteMapController.staticPages)
-                .excludeFromOpenAPI()
+            app.group(BackendReportingMiddleware(path: .sitemapStaticPages)) {
+                $0.get(SiteURL.siteMapStaticPages.pathComponents, use: SiteMapController.staticPages)
+                    .excludeFromOpenAPI()
+            }
         }
     }
 

--- a/Tests/AppTests/SitemapTests.swift
+++ b/Tests/AppTests/SitemapTests.swift
@@ -55,6 +55,7 @@ class SitemapTests: SnapshotTestCase {
                        as: .init(pathExtension: "xml", diffing: .lines))
     }
 
+    @MainActor
     func test_siteMap_basic_request() async throws {
         // Test basic sitemap request
         // setup
@@ -75,7 +76,7 @@ class SitemapTests: SnapshotTestCase {
 
         // Validation
         assertSnapshot(matching: siteMap.render(indentedBy: .spaces(2)),
-                       as: .init(pathExtension: "xml", diffing: .lines), record: true)
+                       as: .init(pathExtension: "xml", diffing: .lines))
     }
 
     func test_linkablePathUrls() async throws {

--- a/Tests/AppTests/SitemapTests.swift
+++ b/Tests/AppTests/SitemapTests.swift
@@ -55,30 +55,6 @@ class SitemapTests: SnapshotTestCase {
                        as: .init(pathExtension: "xml", diffing: .lines))
     }
 
-    @MainActor
-    func test_siteMap_basic_request() async throws {
-        // Test basic sitemap request
-        // setup
-        let package = Package(url: URL(stringLiteral: "https://example.com/owner/repo0"))
-        try await package.save(on: app.db)
-        try await Repository(package: package, defaultBranch: "default",
-                             lastCommitDate: Current.date(),
-                             name: "Repo0", owner: "Owner").save(on: app.db)
-        try await Version(package: package, latest: .defaultBranch, packageName: "SomePackage",
-                          reference: .branch("default")).save(on: app.db)
-
-        let req = Request(application: app, on: app.eventLoopGroup.next())
-        req.parameters.set("owner", to: "Owner")
-        req.parameters.set("repository", to: "Repo0")
-
-        // MUT
-        let siteMap = try await PackageController.siteMap(req: req)
-
-        // Validation
-        assertSnapshot(matching: siteMap.render(indentedBy: .spaces(2)),
-                       as: .init(pathExtension: "xml", diffing: .lines))
-    }
-
     func test_linkablePathUrls() async throws {
         // setup
         let package = Package(url: URL(stringLiteral: "https://example.com/owner/repo0"))

--- a/Tests/AppTests/SitemapTests.swift
+++ b/Tests/AppTests/SitemapTests.swift
@@ -162,10 +162,10 @@ class SitemapTests: SnapshotTestCase {
             .query(on: app.db, owner: "owner", repository: "repo0")
 
         // MUT
-        let sitemap = try await SiteMapView.packageSiteMap(owner: packageResult.repository.owner,
-                                                           repository: packageResult.repository.name,
-                                                           lastActivityAt: packageResult.repository.lastActivityAt,
-                                                           linkablePathUrls: [])
+        let sitemap = try await SiteMapView.package(owner: packageResult.repository.owner,
+                                                    repository: packageResult.repository.name,
+                                                    lastActivityAt: packageResult.repository.lastActivityAt,
+                                                    linkablePathUrls: [])
         let xml = sitemap.render(indentedBy: .spaces(2))
 
         // Validation
@@ -191,10 +191,10 @@ class SitemapTests: SnapshotTestCase {
         ]
 
         // MUT
-        let sitemap = try await SiteMapView.packageSiteMap(owner: packageResult.repository.owner,
-                                                           repository: packageResult.repository.name,
-                                                           lastActivityAt: packageResult.repository.lastActivityAt,
-                                                           linkablePathUrls: linkablePathUrls)
+        let sitemap = try await SiteMapView.package(owner: packageResult.repository.owner,
+                                                    repository: packageResult.repository.name,
+                                                    lastActivityAt: packageResult.repository.lastActivityAt,
+                                                    linkablePathUrls: linkablePathUrls)
         let xml = sitemap.render(indentedBy: .spaces(2))
 
         // Validation

--- a/Tests/AppTests/SitemapTests.swift
+++ b/Tests/AppTests/SitemapTests.swift
@@ -162,7 +162,10 @@ class SitemapTests: SnapshotTestCase {
             .query(on: app.db, owner: "owner", repository: "repo0")
 
         // MUT
-        let sitemap = try await PackageController.siteMap(packageResult: packageResult, linkablePathUrls: [])
+        let sitemap = try await SiteMapView.packageSiteMap(owner: packageResult.repository.owner,
+                                                           repository: packageResult.repository.name,
+                                                           lastActivityAt: packageResult.repository.lastActivityAt,
+                                                           linkablePathUrls: [])
         let xml = sitemap.render(indentedBy: .spaces(2))
 
         // Validation
@@ -188,8 +191,10 @@ class SitemapTests: SnapshotTestCase {
         ]
 
         // MUT
-        let sitemap = try await PackageController.siteMap(packageResult: packageResult,
-                                                          linkablePathUrls: linkablePathUrls)
+        let sitemap = try await SiteMapView.packageSiteMap(owner: packageResult.repository.owner,
+                                                           repository: packageResult.repository.name,
+                                                           lastActivityAt: packageResult.repository.lastActivityAt,
+                                                           linkablePathUrls: linkablePathUrls)
         let xml = sitemap.render(indentedBy: .spaces(2))
 
         // Validation

--- a/Tests/AppTests/__Snapshots__/SitemapTests/test_siteMapIndex.1.xml
+++ b/Tests/AppTests/__Snapshots__/SitemapTests/test_siteMapIndex.1.xml
@@ -1,1 +1,19 @@
-<?xml version="1.0" encoding="UTF-8"?><sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><sitemap><loc>http://localhost:8080/sitemap-static-pages.xml</loc><lastmod>1970-01-01</lastmod></sitemap><sitemap><loc>http://localhost:8080/foo/0/sitemap.xml</loc><lastmod>1970-01-01</lastmod></sitemap><sitemap><loc>http://localhost:8080/foo/1/sitemap.xml</loc><lastmod>1970-01-01</lastmod></sitemap><sitemap><loc>http://localhost:8080/foo/2/sitemap.xml</loc><lastmod>1970-01-01</lastmod></sitemap></sitemapindex>
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>http://localhost:8080/sitemap-static-pages.xml</loc>
+    <lastmod>1970-01-01</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>http://localhost:8080/foo/0/sitemap.xml</loc>
+    <lastmod>1970-01-01</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>http://localhost:8080/foo/1/sitemap.xml</loc>
+    <lastmod>1970-01-01</lastmod>
+  </sitemap>
+  <sitemap>
+    <loc>http://localhost:8080/foo/2/sitemap.xml</loc>
+    <lastmod>1970-01-01</lastmod>
+  </sitemap>
+</sitemapindex>

--- a/Tests/AppTests/__Snapshots__/SitemapTests/test_siteMapStaticPages.1.xml
+++ b/Tests/AppTests/__Snapshots__/SitemapTests/test_siteMapStaticPages.1.xml
@@ -1,1 +1,21 @@
-<?xml version="1.0" encoding="UTF-8"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"><url><loc>http://localhost:8080/</loc></url><url><loc>http://localhost:8080/add-a-package</loc></url><url><loc>http://localhost:8080/faq</loc></url><url><loc>http://localhost:8080/supporters</loc></url><url><loc>http://localhost:8080/build-monitor</loc></url><url><loc>http://localhost:8080/privacy</loc></url></urlset>
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>http://localhost:8080/</loc>
+  </url>
+  <url>
+    <loc>http://localhost:8080/add-a-package</loc>
+  </url>
+  <url>
+    <loc>http://localhost:8080/faq</loc>
+  </url>
+  <url>
+    <loc>http://localhost:8080/supporters</loc>
+  </url>
+  <url>
+    <loc>http://localhost:8080/build-monitor</loc>
+  </url>
+  <url>
+    <loc>http://localhost:8080/privacy</loc>
+  </url>
+</urlset>

--- a/Tests/AppTests/__Snapshots__/SitemapTests/test_siteMap_basic_request.1.xml
+++ b/Tests/AppTests/__Snapshots__/SitemapTests/test_siteMap_basic_request.1.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
-  <url>
-    <loc>http://localhost:8080/Owner/Repo0</loc>
-    <lastmod>1970-01-01</lastmod>
-  </url>
-</urlset>

--- a/Tests/AppTests/__Snapshots__/SitemapTests/test_siteMap_basic_request.1.xml
+++ b/Tests/AppTests/__Snapshots__/SitemapTests/test_siteMap_basic_request.1.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1">
+  <url>
+    <loc>http://localhost:8080/Owner/Repo0</loc>
+    <lastmod>1970-01-01</lastmod>
+  </url>
+</urlset>


### PR DESCRIPTION
We previously had site maps available in all environments, but just to be double sure we don't ever serve them in a staging environment, this PR completely disables them outside production.

It was a bit risky having them before, we didn't point directly at them, but if any search engine happened to request `/sitemap.xml`, they would have seen thousands of incorrect URLs.

This also adds a new SiteMapView type to slightly separate out the queries and controller processing from the site map rendering.