### PR TITLE
Unpin vapor

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0"),
         .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit", from: "4.13.0"),
-        .package(url: "https://github.com/vapor/vapor.git", exact: "4.86.2"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
     ],
     targets: [
         .executableTarget(name: "Run", dependencies: ["App"]),


### PR DESCRIPTION
The new vapor version will be tagged with https://github.com/vapor/vapor/pull/3100

To do: Remove the temporary explicit console-kit dependency and re-run the tests after that version has been released.