### PR TITLE
Add ingest by url

### DIFF
--- a/Sources/App/Commands/CommandMode.swift
+++ b/Sources/App/Commands/CommandMode.swift
@@ -1,0 +1,49 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Vapor
+
+
+enum SPICommand {
+    static let defaultLimit = 1
+
+    struct Signature: CommandSignature {
+        @Option(name: "limit", short: "l")
+        var limit: Int?
+
+        @Option(name: "id", help: "package id")
+        var id: Package.Id?
+
+        @Option(name: "url")
+        var url: String?
+    }
+
+    enum Mode {
+        case id(Package.Id)
+        case limit(Int)
+        case url(String)
+
+        init(signature: Signature) {
+            if let id = signature.id {
+                self = .id(id)
+            } else if let url = signature.url {
+                self = .url(url)
+            } else if let limit = signature.limit {
+                self = .limit(limit)
+            } else {
+                self = .limit(SPICommand.defaultLimit)
+            }
+        }
+    }
+}

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -18,7 +18,7 @@ import Fluent
 
 struct IngestCommand: AsyncCommand {
     typealias Signature = SPICommand.Signature
-    
+
     var help: String { "Run package ingestion (fetching repository metadata)" }
 
     func run(using context: CommandContext, signature: SPICommand.Signature) async throws {
@@ -28,10 +28,8 @@ struct IngestCommand: AsyncCommand {
 
         Self.resetMetrics()
 
-        let mode = SPICommand.Mode(signature: signature)
-
         do {
-            try await ingest(client: client, database: db, logger: logger, mode: mode)
+            try await ingest(client: client, database: db, logger: logger, mode: .init(signature: signature))
         } catch {
             logger.error("\(error.localizedDescription)")
         }

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -17,33 +17,18 @@ import Fluent
 
 
 struct IngestCommand: AsyncCommand {
-    let defaultLimit = 1
-
-    struct Signature: CommandSignature {
-        @Option(name: "limit", short: "l")
-        var limit: Int?
-
-        @Option(name: "id", help: "package id")
-        var id: Package.Id?
-    }
-
+    typealias Signature = SPICommand.Signature
+    
     var help: String { "Run package ingestion (fetching repository metadata)" }
 
-    enum Mode {
-        case id(Package.Id)
-        case limit(Int)
-    }
-
-    func run(using context: CommandContext, signature: Signature) async throws {
-        let limit = signature.limit ?? defaultLimit
-
+    func run(using context: CommandContext, signature: SPICommand.Signature) async throws {
         let client = context.application.client
         let db = context.application.db
         let logger = Logger(component: "ingest")
 
         Self.resetMetrics()
 
-        let mode = signature.id.map(Mode.id) ?? .limit(limit)
+        let mode = SPICommand.Mode(signature: signature)
 
         do {
             try await ingest(client: client, database: db, logger: logger, mode: mode)
@@ -80,7 +65,7 @@ extension IngestCommand {
 func ingest(client: Client,
             database: Database,
             logger: Logger,
-            mode: IngestCommand.Mode) async throws {
+            mode: SPICommand.Mode) async throws {
     let start = DispatchTime.now().uptimeNanoseconds
     defer { AppMetrics.ingestDurationSeconds?.time(since: start) }
 
@@ -88,18 +73,18 @@ func ingest(client: Client,
         case .id(let id):
             logger.info("Ingesting (id: \(id)) ...")
             let pkg = try await Package.fetchCandidate(database, id: id)
-            await ingest(client: client,
-                         database: database,
-                         logger: logger,
-                         packages: [pkg])
+            await ingest(client: client, database: database, logger: logger, packages: [pkg])
+
         case .limit(let limit):
             logger.info("Ingesting (limit: \(limit)) ...")
             let packages = try await Package.fetchCandidates(database, for: .ingestion, limit: limit)
             logger.info("Candidate count: \(packages.count)")
-            await ingest(client: client,
-                         database: database,
-                         logger: logger,
-                         packages: packages)
+            await ingest(client: client, database: database, logger: logger, packages: packages)
+
+        case .url(let url):
+            logger.info("Ingesting (url: \(url)) ...")
+            let pkg = try await Package.fetchCandidate(database, url: url)
+            await ingest(client: client, database: database, logger: logger, packages: [pkg])
     }
 }
 


### PR DESCRIPTION
Make it easier to ingest specific packages via url fragments, just like for analysis:

```
swift run Run ingest --url Nextbike
[ INFO ] Ingesting (url: Nextbike) ... [component: ingest]
[ WARNING ] fetchResource https://api.github.com/repos/kiliankoe/Nextbike/license request failed with status 404 Not Found [component: server]
[ WARNING ] storeS3Readme failed [component: ingest]
[ WARNING ] Environment variable not set: METRICS_PUSHGATEWAY_URL [component: ingest]
Program ended with exit code: 0
```