### PR TITLE
Don't log warning on fetchResource != 200

### DIFF
--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -138,7 +138,6 @@ extension Github {
         }
 
         guard response.status == .ok else {
-            Current.logger().warning("fetchResource \(uri) request failed with status \(response.status)")
             throw Error.requestFailed(response.status)
         }
 


### PR DESCRIPTION
We're logging a warning when `fetchResource` isn't getting a 200. However, this method is called only in cases where we ignore the thrown error:

```swift
        return try? await Github.fetchResource(Github.License.self, client: client, uri: uri)
```

```swift
            struct Response: Decodable {
                var htmlUrl: String
            }
            return try? await Github.fetchResource(Response.self, client: client, uri: uri).htmlUrl
```

If we ever want to make that warning visible we should do so at the call site, not inside the `fetchResource` call. A few repos don't have a readme and more no license, so this is not something we'll want to log.