### PR TITLE
Remove dependencies defaults

### DIFF
--- a/Sources/App/Migrations/071/UpdateVersionResetProductDependenciesWithDefault.swift
+++ b/Sources/App/Migrations/071/UpdateVersionResetProductDependenciesWithDefault.swift
@@ -16,7 +16,7 @@ import Fluent
 import SQLKit
 
 
-struct UpdateVersionUpdateProductDependencies: AsyncMigration {
+struct UpdateVersionResetProductDependenciesWithDefault: AsyncMigration {
     func prepare(on database: Database) async throws {
         // re-create field without default
         try await database.schema("versions")

--- a/Sources/App/Migrations/071/UpdateVersionResetResolvedDependencies.swift
+++ b/Sources/App/Migrations/071/UpdateVersionResetResolvedDependencies.swift
@@ -16,25 +16,19 @@ import Fluent
 import SQLKit
 
 
-struct UpdateVersionUpdateProductDependencies: AsyncMigration {
+struct UpdateVersionResetResolvedDependencies: AsyncMigration {
     func prepare(on database: Database) async throws {
-        // re-create field without default
+        // reset field values by dropping and re-creating the field
         try await database.schema("versions")
-            .deleteField("product_dependencies")
+            .deleteField("resolved_dependencies")
             .update()
         try await database.schema("versions")
-            .field("product_dependencies",
+            .field("resolved_dependencies",
                    .array(of: .json))
             .update()
     }
 
     func revert(on database: Database) async throws {
-        guard let db = database as? SQLDatabase else {
-            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
-        }
-
-        // set default on product_dependencies
-        // we can't revert the field reset so we just leave the values as they are
-        try await db.raw(#"ALTER TABLE versions ALTER COLUMN product_dependencies SET DEFAULT '{}'"#).run()
+        // we cannot revert the column reset, so this revert is blank
     }
 }

--- a/Sources/App/Migrations/071/UpdateVersionUpdateProductDependencies.swift
+++ b/Sources/App/Migrations/071/UpdateVersionUpdateProductDependencies.swift
@@ -1,0 +1,37 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+
+struct UpdateVersionUpdateProductDependencies: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        // remove default from product_dependencies
+        try await db.raw(#"ALTER TABLE versions ALTER COLUMN product_dependencies DROP DEFAULT"#).run()
+    }
+
+    func revert(on database: Database) async throws {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        // set defaults on product_dependencies
+        try await db.raw(#"ALTER TABLE versions ALTER COLUMN product_dependencies SET DEFAULT '{}'"#).run()
+    }
+}

--- a/Sources/App/Models/Version.swift
+++ b/Sources/App/Models/Version.swift
@@ -123,7 +123,7 @@ final class Version: Model, Content {
          reference: Reference,
          releaseNotes: String? = nil,
          releaseNotesHTML: String? = nil,
-         resolvedDependencies: [ResolvedDependency] = [],
+         resolvedDependencies: [ResolvedDependency]? = nil,
          spiManifest: SPIManifest.Manifest? = nil,
          supportedPlatforms: [Platform] = [],
          swiftVersions: [SwiftVersion] = [],

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -310,7 +310,7 @@ public func configure(_ app: Application) throws -> String {
         app.migrations.add(UpdatePackageAddScoreDetails())
     }
     do { // Migraation 071 - Remove defaults from product_dependencies, reset resolved_dependencies
-        app.migrations.add(UpdateVersionUpdateProductDependencies())
+        app.migrations.add(UpdateVersionResetProductDependenciesWithDefault())
         app.migrations.add(UpdateVersionResetResolvedDependencies())
     }
 

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -309,8 +309,9 @@ public func configure(_ app: Application) throws -> String {
     do { // Migration 070 - Add score_details to packages
         app.migrations.add(UpdatePackageAddScoreDetails())
     }
-    do { // Migraation 071 - Remove defaults from product_dependencies
+    do { // Migraation 071 - Remove defaults from product_dependencies, reset resolved_dependencies
         app.migrations.add(UpdateVersionUpdateProductDependencies())
+        app.migrations.add(UpdateVersionResetResolvedDependencies())
     }
 
     app.commands.use(Analyze.Command(), as: "analyze")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -309,6 +309,9 @@ public func configure(_ app: Application) throws -> String {
     do { // Migration 070 - Add score_details to packages
         app.migrations.add(UpdatePackageAddScoreDetails())
     }
+    do { // Migraation 071 - Remove defaults from product_dependencies
+        app.migrations.add(UpdateVersionUpdateProductDependencies())
+    }
 
     app.commands.use(Analyze.Command(), as: "analyze")
     app.commands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -309,7 +309,7 @@ public func configure(_ app: Application) throws -> String {
     do { // Migration 070 - Add score_details to packages
         app.migrations.add(UpdatePackageAddScoreDetails())
     }
-    do { // Migraation 071 - Remove defaults from product_dependencies, reset resolved_dependencies
+    do { // Migraation 071 - Remove default from product_dependencies, reset product_dependencies and resolved_dependencies
         app.migrations.add(UpdateVersionResetProductDependenciesWithDefault())
         app.migrations.add(UpdateVersionResetResolvedDependencies())
     }

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -211,7 +211,7 @@ class AnalyzerTests: AppTestCase {
 
         // validate score
         XCTAssertEqual(pkg1.score, 35)
-        XCTAssertEqual(pkg2.score, 45)
+        XCTAssertEqual(pkg2.score, 40)
 
         // ensure stats, recent packages, and releases are refreshed
         try await XCTAssertEqualAsync(try await Stats.fetch(on: app.db).get(), .init(packageCount: 2))

--- a/Tests/AppTests/Helpers/Version+init.swift
+++ b/Tests/AppTests/Helpers/Version+init.swift
@@ -18,7 +18,7 @@ extension Version {
                      reference: Reference = .branch("main"),
                      releaseNotes: String? = nil,
                      releaseNotesHTML: String? = nil,
-                     resolvedDependencies: [ResolvedDependency] = [],
+                     resolvedDependencies: [ResolvedDependency]? = nil,
                      supportedPlatforms: [Platform] = [],
                      swiftVersions: [SwiftVersion] = [],
                      toolsVersion: String? = nil,

--- a/Tests/AppTests/ScoreTests.swift
+++ b/Tests/AppTests/ScoreTests.swift
@@ -238,6 +238,7 @@ class ScoreTests: AppTestCase {
         try await Version(package: pkg,
                           docArchives: [.init(name: "archive1", title: "Archive One")],
                           reference: .branch("default"),
+                          resolvedDependencies: [],
                           swiftVersions: ["5"].asSwiftVersions).save(on: app.db)
         try (0..<20).forEach {
             try Version(package: pkg, reference: .tag(.init($0, 0, 0)))
@@ -262,4 +263,38 @@ class ScoreTests: AppTestCase {
             XCTAssertEqual(details.score, 97)
         }
     }
+
+    func test_computeDetails_unknown_resolvedDependencies() async throws {
+        // setup
+        let pkg = try await savePackageAsync(on: app.db, "1")
+        try await Repository(package: pkg, defaultBranch: "default", stars: 10_000).save(on: app.db)
+        try await Version(package: pkg,
+                          docArchives: [.init(name: "archive1", title: "Archive One")],
+                          reference: .branch("default"),
+                          resolvedDependencies: nil,
+                          swiftVersions: ["5"].asSwiftVersions).save(on: app.db)
+        try (0..<20).forEach {
+            try Version(package: pkg, reference: .tag(.init($0, 0, 0)))
+                .save(on: app.db).wait()
+        }
+        let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
+        // update versions
+        let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
+
+        // MUT
+        let details = Score.computeDetails(repo: jpr.repository, versions: versions)
+
+        do { // validate
+            let details = try XCTUnwrap(details)
+            XCTAssertEqual(details.scoreBreakdown, [
+                .archive: 20,
+                // no .dependencies category
+                .documentation: 15,
+                .releases: 20,
+                .stars: 37,
+            ])
+            XCTAssertEqual(details.score, 92)
+        }
+    }
+
 }

--- a/Tests/AppTests/ScoreTests.swift
+++ b/Tests/AppTests/ScoreTests.swift
@@ -248,6 +248,18 @@ class ScoreTests: AppTestCase {
         let versions = try await Analyze.updateLatestVersions(on: app.db, package: jpr)
 
         // MUT
-        XCTAssertEqual(Score.computeDetails(repo: jpr.repository, versions: versions)?.score, 97)
+        let details = Score.computeDetails(repo: jpr.repository, versions: versions)
+
+        do { // validate
+            let details = try XCTUnwrap(details)
+            XCTAssertEqual(details.scoreBreakdown, [
+                .archive: 20,
+                .dependencies: 5,
+                .documentation: 15,
+                .releases: 20,
+                .stars: 37,
+            ])
+            XCTAssertEqual(details.score, 97)
+        }
     }
 }

--- a/Tests/AppTests/VersionTests.swift
+++ b/Tests/AppTests/VersionTests.swift
@@ -176,6 +176,21 @@ class VersionTests: AppTestCase {
         XCTAssertEqual(latest?.id, vid)
     }
 
+    func test_defaults() async throws {
+        // setup
+        let pkg = try await savePackageAsync(on: app.db, "1".asGithubUrl.url)
+        let v = try Version(package: pkg)
+
+        // MUT
+        try await v.save(on: app.db)
+
+        do { // validate
+            let v = try await XCTUnwrapAsync(try await Version.find(v.id, on: app.db))
+            XCTAssertEqual(v.resolvedDependencies, nil)
+            XCTAssertEqual(v.productDependencies, nil)
+        }
+    }
+
 }
 
 


### PR DESCRIPTION
⚠️ Do not deploy before the [corresponding builder change](https://gitlab.com/finestructure/swiftpackageindex-builder/-/merge_requests/237) is live ⚠️

It is currently impossible to tell if a package has no `product_dependencies` or if product dependency discovery hasn't run yet or failed, because we initialise it to `{}` by default. This removes the default and adjusts it to the same we have for `resolved_dependencies`, which is `NULL`.

However, `resolved_dependencies` also had problem: we set a default `[]` when instantiating a `Version` object, thereby giving every version zero dependencies by default instead of leaving it undecided despite there being no actual SQL level default.

In order for this second fix to be complete, we also need to update the builder, which currently sends a default `[]` if no `Package.swift` file can be found.

That is problematic, because while the lack of a `Package.swift` file can indicate no dependencies, it can also mean that package resolution failed. We can detect this though and send the correct value in that case, with some adjustments.

⚠️ Schema change ⚠️