### PR TITLE
Stop updating resolved_dependencies from analysis

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -519,7 +519,6 @@ extension Analyze {
 
     struct PackageInfo: Equatable {
         var packageManifest: Manifest
-        var dependencies: [ResolvedDependency]?
         var spiManifest: SPIManifest.Manifest?
     }
 
@@ -540,12 +539,9 @@ extension Analyze {
 
         do {
             let packageManifest = try await dumpPackage(at: cacheDir)
-            let resolvedDependencies = getResolvedDependencies(Current.fileManager,
-                                                               at: cacheDir)
             let spiManifest = Current.loadSPIManifest(cacheDir)
 
             return PackageInfo(packageManifest: packageManifest,
-                               dependencies: resolvedDependencies,
                                spiManifest: spiManifest)
         } catch let AppError.invalidRevision(_, msg) {
             // re-package error to attach version.id
@@ -565,10 +561,6 @@ extension Analyze {
                               packageInfo: PackageInfo) -> EventLoopFuture<Void> {
         let manifest = packageInfo.packageManifest
         version.packageName = manifest.name
-        if let resolvedDependencies = packageInfo.dependencies {
-            // Don't overwrite information provided by the build system unless it's a non-nil (i.e. valid) value
-            version.resolvedDependencies = resolvedDependencies
-        }
         version.swiftVersions = manifest.swiftLanguageVersions?.compactMap(SwiftVersion.init) ?? []
         version.supportedPlatforms = manifest.platforms?.compactMap(Platform.init(from:)) ?? []
         version.toolsVersion = manifest.toolsVersion?.version

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -16,7 +16,6 @@ import XCTest
 
 @testable import App
 
-import DependencyResolution
 import Fluent
 import SPIManifest
 import ShellOut
@@ -60,13 +59,6 @@ class AnalyzerTests: AppTestCase {
             if path.hasSuffix("Package.swift") { return true }
             if path.hasSuffix("Package.resolved") { return true }
             return false
-        }
-        Current.fileManager.contents = { path in
-            if path.hasSuffix("github.com-foo-1/Package.resolved") {
-                return .mockPackageResolved(for: "foo-1")
-            } else {
-                return nil
-            }
         }
         Current.fileManager.createDirectory = { path, _, _ in checkoutDir.setValue(path) }
         Current.git = .live
@@ -178,10 +170,6 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(sortedVersions1.map(\.reference.description), ["main", "1.0.0", "1.1.1"])
         XCTAssertEqual(sortedVersions1.map(\.latest), [.defaultBranch, nil, .release])
         XCTAssertEqual(sortedVersions1.map(\.releaseNotes), [nil, "rel 1.0.0", nil])
-        XCTAssertEqual(sortedVersions1
-                        .flatMap { $0.resolvedDependencies ?? [] }
-                        .map(\.packageName),
-                       ["foo-1", "foo-1", "foo-1"])
 
         let pkg2 = try await Package.query(on: app.db).filter(by: urls[1].url).with(\.$versions).first()!
         XCTAssertEqual(pkg2.status, .ok)
@@ -190,10 +178,6 @@ class AnalyzerTests: AppTestCase {
         let sortedVersions2 = pkg2.versions.sorted(by: { $0.createdAt! < $1.createdAt! })
         XCTAssertEqual(sortedVersions2.map(\.reference.description), ["main", "2.0.0", "2.1.0"])
         XCTAssertEqual(sortedVersions2.map(\.latest), [.defaultBranch, nil, .release])
-        XCTAssertEqual(sortedVersions2
-                        .flatMap { $0.resolvedDependencies ?? [] }
-                        .map(\.packageName),
-                       [])
 
         // validate products
         // (2 packages with 3 versions with 1 product each = 6 products)
@@ -210,7 +194,7 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(targets.map(\.name), ["t1", "t1", "t1", "t2", "t2", "t2"])
 
         // validate score
-        XCTAssertEqual(pkg1.score, 35)
+        XCTAssertEqual(pkg1.score, 30)
         XCTAssertEqual(pkg2.score, 40)
 
         // ensure stats, recent packages, and releases are refreshed
@@ -735,9 +719,6 @@ class AnalyzerTests: AppTestCase {
             }
             return ""
         }
-        Current.fileManager.contents = { _ in
-            Data.mockPackageResolved(for: "1")
-        }
         let pkg = try savePackage(on: app.db, "https://github.com/foo/1")
         try await Repository(package: pkg, name: "1", owner: "foo").save(on: app.db)
         let version = try Version(id: UUID(), package: pkg, reference: .tag(.init(0, 4, 2)))
@@ -753,20 +734,6 @@ class AnalyzerTests: AppTestCase {
             "swift package dump-package"
         ])
         XCTAssertEqual(info.packageManifest.name, "SPI-Server")
-        XCTAssertEqual(info.dependencies?.map(\.packageName), ["1"])
-    }
-
-    func test_getResolvedDependencies() throws {
-        // setup
-        Current.fileManager.contents = { _ in
-            Data.mockPackageResolved(for: "Foo")
-        }
-
-        // MUT
-        let deps = getResolvedDependencies(Current.fileManager, at: "path")
-
-        // validate
-        XCTAssertEqual(deps?.map(\.packageName), ["Foo"])
     }
 
     func test_updateVersion() throws {
@@ -781,8 +748,6 @@ class AnalyzerTests: AppTestCase {
                                 swiftLanguageVersions: ["1", "2", "3.0.0"],
                                 targets: [],
                                 toolsVersion: .init(version: "5.0.0"))
-        let dep = ResolvedDependency(packageName: "foo",
-                                     repositoryURL: "http://foo.com")
         let spiManifest = try SPIManifest.Manifest(yml: """
             version: 1
             builder:
@@ -795,48 +760,16 @@ class AnalyzerTests: AppTestCase {
         _ = try Analyze.updateVersion(on: app.db,
                                       version: version,
                                       packageInfo: .init(packageManifest: manifest,
-                                                         dependencies: [dep],
                                                          spiManifest: spiManifest)).wait()
 
         // read back and validate
         let v = try Version.query(on: app.db).first().wait()!
         XCTAssertEqual(v.packageName, "foo")
-        XCTAssertEqual(v.resolvedDependencies?.map(\.packageName),
-                       ["foo"])
+        XCTAssertEqual(v.resolvedDependencies?.map(\.packageName), nil)
         XCTAssertEqual(v.swiftVersions, ["1", "2", "3.0.0"].asSwiftVersions)
         XCTAssertEqual(v.supportedPlatforms, [.ios("11.0"), .macos("10.10")])
         XCTAssertEqual(v.toolsVersion, "5.0.0")
         XCTAssertEqual(v.spiManifest, spiManifest)
-    }
-
-    func test_updateVersion_preserveDependencies() throws {
-        // Ensure we don't overwrite existing dependencies when update value is nil
-        // setup
-        let pkg = Package(id: UUID(), url: "1")
-        try pkg.save(on: app.db).wait()
-        let version = try Version(
-            package: pkg,
-            resolvedDependencies: [ResolvedDependency(packageName: "foo",
-                                                      repositoryURL: "")]
-        )
-        let manifest = Manifest(name: "foo",
-                                platforms: [.init(platformName: .ios, version: "11.0"),
-                                            .init(platformName: .macos, version: "10.10")],
-                                products: [],
-                                swiftLanguageVersions: [],
-                                targets: [],
-                                toolsVersion: .init(version: "5.0.0"))
-
-        // MUT
-        _ = try Analyze.updateVersion(on: app.db,
-                                      version: version,
-                                      packageInfo: .init(packageManifest: manifest,
-                                                         dependencies: nil)).wait()
-
-        // read back and validate
-        let v = try Version.query(on: app.db).first().wait()!
-        XCTAssertEqual(v.resolvedDependencies?.map(\.packageName),
-                       ["foo"])
     }
 
     func test_createProducts() throws {
@@ -1616,30 +1549,4 @@ private enum TestError: Error {
     case simulatedCheckoutError
     case simulatedFetchError
     case unknownCommand
-}
-
-
-private extension Data {
-    static func mockPackageResolved(for packageName: String) -> Self {
-        .init(
-            #"""
-            {
-              "object": {
-                "pins": [
-                  {
-                    "package": "\#(packageName)",
-                    "repositoryURL": "https://github.com/foo/\#(packageName)",
-                    "state": {
-                      "branch": null,
-                      "revision": "fca5fe8e7b8218d563f99daadffd86dbf11dd98b",
-                      "version": "1.2.3"
-                    }
-                  }
-                ],
-                "version": 1
-              }
-            }
-            """#.utf8
-        )
-    }
 }


### PR DESCRIPTION
This removes `resolved_dependency` updating in analysis, as [previously outlined](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1979#issuecomment-1221256063).

It becomes harder to reason about which process "owns" updating a field if we do it from two places. Performing this update in analysis has the advantage of being faster, because it can happen immediately instead of relying on a build to run.

However, it is also potentially incorrect if we simply take for granted (as we did) what's in a checked-in `Package.resolved` file. It need not be up to date.

Our builder will have run `swift package resolve` and report the up-to-date value.

Merge after merging #2738 