### PR TITLE
Applying version 4.4.4 and updated example

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -437,8 +437,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dankinsoid/SwiftOpenAPI.git",
       "state" : {
-        "revision" : "2ee6c2ad3da09601a1979bd51e6f76c0517369f5",
-        "version" : "2.18.4"
+        "revision" : "aec41de7bbea8176e68ec5d4d270da453e9c0d11",
+        "version" : "2.19.3"
       }
     },
     {
@@ -473,8 +473,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dankinsoid/VaporToOpenAPI.git",
       "state" : {
-        "revision" : "7c5d60a5a7574564d44dfbc39006d21b0a6386ff",
-        "version" : "4.3.12"
+        "revision" : "5c6fab1c1a896e8ec4e346eeae47582084d6eb75",
+        "version" : "4.4.3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -437,8 +437,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dankinsoid/SwiftOpenAPI.git",
       "state" : {
-        "revision" : "aec41de7bbea8176e68ec5d4d270da453e9c0d11",
-        "version" : "2.19.3"
+        "revision" : "2746032ae58a058e2961bc7030b94ee358e2fd97",
+        "version" : "2.19.4"
       }
     },
     {
@@ -473,8 +473,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/dankinsoid/VaporToOpenAPI.git",
       "state" : {
-        "revision" : "5c6fab1c1a896e8ec4e346eeae47582084d6eb75",
-        "version" : "4.4.3"
+        "revision" : "68893454e81773f4a89850ae151c2609b8b2964f",
+        "version" : "4.4.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftPackageIndex/SemanticVersion", from: "0.3.0"),
         .package(url: "https://github.com/SwiftPackageIndex/ShellOut.git", from: "3.1.4"),
         .package(url: "https://github.com/apple/swift-package-manager.git", revision: "swift-5.9-RELEASE"),
-        .package(url: "https://github.com/dankinsoid/VaporToOpenAPI.git", from: "4.0.4"),
+        .package(url: "https://github.com/dankinsoid/VaporToOpenAPI.git", from: "4.4.3"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "0.10.0"),
         .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.12.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.11.1"),

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftPackageIndex/SemanticVersion", from: "0.3.0"),
         .package(url: "https://github.com/SwiftPackageIndex/ShellOut.git", from: "3.1.4"),
         .package(url: "https://github.com/apple/swift-package-manager.git", revision: "swift-5.9-RELEASE"),
-        .package(url: "https://github.com/dankinsoid/VaporToOpenAPI.git", from: "4.4.3"),
+        .package(url: "https://github.com/dankinsoid/VaporToOpenAPI.git", from: "4.4.4"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "0.10.0"),
         .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.12.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.11.1"),

--- a/Sources/App/Controllers/API/Types+WithExample.swift
+++ b/Sources/App/Controllers/API/Types+WithExample.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 import VaporToOpenAPI
-
+import DependencyResolution
 
 // MARK: - External types
 
@@ -242,6 +242,12 @@ extension API.PostBuildReportDTO: WithExample {
         .init(builderVersion: "1.2.3",
               buildId: .example,
               platform: .iOS,
+              productDependencies: [
+                  ProductDependency(identity: "1",
+                                    name: "name",
+                                    url: "http://vapor.com",
+                                    dependencies: [])
+              ],
               status: .ok,
               swiftVersion: .v5_8)
     }


### PR DESCRIPTION
With the combination of https://github.com/dankinsoid/VaporToOpenAPI/issues/17, and some follow on work, he released a version 4.4.4 of VaporToOpenAPI that correctly renders the openapi.json (or at least it fully validates). I grabbed the openapi.json that was generated with this PR in my local dev instance, and stashed it at https://github.com/dankinsoid/VaporToOpenAPI.git - and then in turn used that to generate source (clients and types) using the Swift OpenAPI Generator project.