### PR TITLE
Pin Percy to 1.27.4

### DIFF
--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Run Percy
         if: steps.front-end-changes.outputs.matching-files != '0'
         run: |
-          npm install -g @percy/cli
+          npm install -g @percy/cli@1.27.4
           echo "=== Installed Percy Version ==="
           npx percy --version
           echo "=== Running Snapshots ==="


### PR DESCRIPTION
Separating this out from #2768 because the baseline snapshots got set without styling as a result of the Percy issue. This will pin the version of the Percy tool, and also reset our base snapshots back to being correct, so that #2768 can correctly show the *actual* differences between the old and new logos.

This one is ready to merge.