### PR TITLE
Fix --user argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,10 +131,10 @@ db-down-test:
 db-reset: db-down db-up migrate
 
 build-front-end:
-	docker run --rm -v $$PWD:/host -w /host --user $(id -u):$(id -g) --entrypoint sh node:20-alpine -c "/usr/local/bin/yarn && /usr/local/bin/yarn build"
+	docker run --rm -v $$PWD:/host -w /host --user $$(id -u):$$(id -g) --entrypoint sh node:20-alpine -c "/usr/local/bin/yarn && /usr/local/bin/yarn build"
 
 serve-front-end:
-	docker run --rm -it -v $$PWD:/host -w /host --user $(id -u):$(id -g) --entrypoint sh node:20-alpine -c "/usr/local/bin/yarn && /usr/local/bin/yarn serve"
+	docker run --rm -it -v $$PWD:/host -w /host --user $$(id -u):$$(id -g) --entrypoint sh node:20-alpine -c "/usr/local/bin/yarn && /usr/local/bin/yarn serve"
 
 copy-front-end-resources:
 	@# copy front-end resources from existing image (rather than build them)


### PR DESCRIPTION
The flag wasn't actually taking effect:

```
docker run --rm -v $PWD:/host -w /host --user : --entrypoint sh node:20-alpine -c "/usr/local/bin/yarn && /usr/local/bin/yarn build"
```

https://gitlab.com/finestructure/swiftpackageindex/-/jobs/5761071117

It just happened to succeed because no new files were generated.

I've reset the permissions in all directories on the builders so hopefully this won't fail again.