### PR TITLE
Make perf regressions more easily visible in Github

### DIFF
--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -217,7 +217,7 @@ private extension QueryPerformanceTests {
                 break
             default:
                 if isRunningInCI {
-                "::error file=\(filePath),line=\(lineNumber)::Total cost of \(parsedPlan.cost.total) above threshold of \(expectedCost + variation) (incl variation)"
+                    print("::error file=\(filePath),line=\(lineNumber)::Total cost of \(parsedPlan.cost.total) above threshold of \(expectedCost + variation) (incl variation)")
                 }
                 XCTFail("""
                         Total cost of \(parsedPlan.cost.total) above threshold of \(expectedCost + variation) (incl variation)

--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -216,6 +216,9 @@ private extension QueryPerformanceTests {
             case ..<(expectedCost + variation):
                 break
             default:
+                if isRunningInCI {
+                "::error file=\(filePath),line=\(lineNumber)::Total cost of \(parsedPlan.cost.total) above threshold of \(expectedCost + variation) (incl variation)"
+                }
                 XCTFail("""
                         Total cost of \(parsedPlan.cost.total) above threshold of \(expectedCost + variation) (incl variation)
 

--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -206,6 +206,9 @@ private extension QueryPerformanceTests {
 
         switch parsedPlan.cost.total {
             case ..<10.0:
+                if isRunningInCI {
+                    print("::error file=\(filePath),line=\(lineNumber),title=\(testName)::Cost very low \(parsedPlan.cost.total) - did you run the query against an empty database?")
+                }
                 XCTFail("""
                         Cost very low \(parsedPlan.cost.total) - did you run the query against an empty database?
 
@@ -213,11 +216,15 @@ private extension QueryPerformanceTests {
                         """,
                         file: filePath,
                         line: lineNumber)
-            case ..<(expectedCost + variation):
+            case ..<expectedCost:
                 break
+            case ..<(expectedCost + variation):
+                if isRunningInCI {
+                    print("::warning file=\(filePath),line=\(lineNumber),title=\(testName)::Total cost of \(parsedPlan.cost.total) above threshold of \(expectedCost + variation) (within variation)")
+                }
             default:
                 if isRunningInCI {
-                    print("::error file=\(filePath),line=\(lineNumber)::Total cost of \(parsedPlan.cost.total) above threshold of \(expectedCost + variation) (incl variation)")
+                    print("::error file=\(filePath),line=\(lineNumber),title=\(testName)::Total cost of \(parsedPlan.cost.total) above threshold of \(expectedCost + variation) (incl variation)")
                 }
                 XCTFail("""
                         Total cost of \(parsedPlan.cost.total) above threshold of \(expectedCost + variation) (incl variation)

--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -41,72 +41,72 @@ class QueryPerformanceTests: XCTestCase {
 
     func test_01_Search_packageMatchQuery() async throws {
         let query = Search.packageMatchQueryBuilder(on: app.db, terms: ["a"], filters: [])
-        try await assertQueryPerformance(query, expectedCost: 1250, variation: 150)
+        try await assertQueryPerformance(query, expectedCost: 1300, variation: 150)
     }
 
     func test_02_Search_keywordMatchQuery() async throws {
         let query = Search.keywordMatchQueryBuilder(on: app.db, terms: ["a"])
-        try await assertQueryPerformance(query, expectedCost: 4960, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 5200, variation: 200)
     }
 
     func test_03_Search_authorMatchQuery() async throws {
         let query = Search.authorMatchQueryBuilder(on: app.db, terms: ["a"])
-        try await assertQueryPerformance(query, expectedCost: 860, variation: 50)
+        try await assertQueryPerformance(query, expectedCost: 910, variation: 50)
     }
 
     func test_04_Search_query_noFilter() async throws {
         let query = try Search.query(app.db, ["a"], page: 1)
             .unwrap()
-        try await assertQueryPerformance(query, expectedCost: 6800, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 7100, variation: 200)
     }
 
     func test_05_Search_query_authorFilter() async throws {
         let filter = try AuthorSearchFilter(expression: .init(operator: .is, value: "apple"))
         let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
-        try await assertQueryPerformance(query, expectedCost: 6500, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 6800, variation: 200)
     }
 
     func test_06_Search_query_keywordFilter() async throws {
         let filter = try KeywordSearchFilter(expression: .init(operator: .is, value: "apple"))
         let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
-        try await assertQueryPerformance(query, expectedCost: 6600, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 6800, variation: 200)
     }
 
     func test_07_Search_query_lastActicityFilter() async throws {
         let filter = try LastActivitySearchFilter(expression: .init(operator: .greaterThan, value: "2000-01-01"))
         let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
-        try await assertQueryPerformance(query, expectedCost: 6850, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 7100, variation: 200)
     }
 
     func test_08_Search_query_licenseFilter() async throws {
         let filter = try LicenseSearchFilter(expression: .init(operator: .is, value: "mit"))
         let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
-        try await assertQueryPerformance(query, expectedCost: 6750, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 7000, variation: 200)
     }
 
     func test_09_Search_query_platformFilter() async throws {
         let filter = try PlatformSearchFilter(expression: .init(operator: .is, value: "macos,ios"))
         let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
-        try await assertQueryPerformance(query, expectedCost: 6600, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 6800, variation: 200)
     }
 
     func test_10_Search_query_productTypeFilter() async throws {
         let filter = try ProductTypeSearchFilter(expression: .init(operator: .is, value: "plugin"))
         let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
-        try await assertQueryPerformance(query, expectedCost: 6500, variation: 200)
+        try await assertQueryPerformance(query, expectedCost: 6800, variation: 200)
     }
 
     func test_11_Search_query_starsFilter() async throws {
         let filter = try StarsSearchFilter(expression: .init(operator: .greaterThan, value: "5"))
         let query = try Search.query(app.db, ["a"], filters: [filter], page: 1)
             .unwrap()
-        try await assertQueryPerformance(query, expectedCost: 6700, variation: 300)
+        try await assertQueryPerformance(query, expectedCost: 7000, variation: 300)
     }
 
     func test_12_Search_refresh() async throws {
@@ -152,7 +152,7 @@ class QueryPerformanceTests: XCTestCase {
               JOIN versions v ON v.package_id = p.id
             WHERE v.reference ->> 'branch' = r.default_branch
             """)
-        try await assertQueryPerformance(query, expectedCost: 64_000, variation: 3000)
+        try await assertQueryPerformance(query, expectedCost: 69_000, variation: 3000)
     }
 
 }


### PR DESCRIPTION
This logs query performance failures as GH annotations, making updating them much easier:

https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/actions/runs/7527904656

![CleanShot 2024-01-15 at 12 10 09@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/65520/1b3e23dd-ee3a-44f9-915a-cf6c25bfb51a)
