### PR TITLE
Show package funding links under package metadata

### DIFF
--- a/FrontEnd/styles/colors.scss
+++ b/FrontEnd/styles/colors.scss
@@ -163,6 +163,8 @@
     --panel-button-text: var(--white);
     --panel-accent: var(--dark-grey);
 
+    --package-funding-background: var(--very-light-grey);
+
     --scta-avatar-gradient: linear-gradient(
         rgba(241, 241, 241, 0%) 0,
         rgba(241, 241, 241, 0%) 50%,

--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -287,6 +287,41 @@
         }
     }
 
+    .funding-links {
+        .community-bridge {
+        }
+
+        .custom-url {
+        }
+
+        .github {
+        }
+
+        .issue-hunt {
+        }
+
+        .ko-fi {
+        }
+
+        .lfx-crowdfunding {
+        }
+
+        .liberapay {
+        }
+
+        .open-collective {
+        }
+
+        .otechie {
+        }
+
+        .patreon {
+        }
+
+        .tide-lift {
+        }
+    }
+
     @media screen and (max-width: $mobile-breakpoint) {
         .package-title h2 {
             -webkit-line-clamp: 2;

--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -299,7 +299,7 @@
         &::after {
             content: '';
             position: absolute;
-            top: -15px;
+            top: -10px;
             right: 0;
             width: 25px;
             height: 100%;

--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -287,38 +287,25 @@
         }
     }
 
-    .funding-links {
-        .community-bridge {
+    .package-funding {
+        position: relative;
+        padding: 10px;
+        background-color: var(--package-funding-background);
+
+        p {
+            margin: 0;
         }
 
-        .custom-url {
-        }
-
-        .github {
-        }
-
-        .issue-hunt {
-        }
-
-        .ko-fi {
-        }
-
-        .lfx-crowdfunding {
-        }
-
-        .liberapay {
-        }
-
-        .open-collective {
-        }
-
-        .otechie {
-        }
-
-        .patreon {
-        }
-
-        .tide-lift {
+        &::after {
+            content: '';
+            position: absolute;
+            top: -15px;
+            right: 0;
+            width: 25px;
+            height: 100%;
+            background-repeat: no-repeat;
+            background-image: var(--image-heart);
+            transform: rotate(22deg);
         }
     }
 

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
@@ -48,6 +48,7 @@ extension API.PackageController.GetRoute {
         var documentationTarget: DocumentationTarget? = nil
         var weightedKeywords: [WeightedKeyword]
         var releaseReferences: [App.Version.Kind: App.Reference]
+        var fundingLinks: [FundingLink]
 
         internal init(packageId: Package.Id,
                       repositoryOwner: String,
@@ -78,7 +79,8 @@ extension API.PackageController.GetRoute {
                       defaultBranchReference: App.Reference,
                       releaseReference: App.Reference?,
                       preReleaseReference: App.Reference?,
-                      repository: Repository? = nil
+                      repository: Repository? = nil,
+                      fundingLinks: [FundingLink]
             ) {
             self.packageId = packageId
             self.repositoryOwner = repositoryOwner
@@ -118,6 +120,7 @@ extension API.PackageController.GetRoute {
                 }
                 return refs
             }()
+            self.fundingLinks = fundingLinks
         }
 
         init?(result: API.PackageController.PackageResult,
@@ -170,7 +173,8 @@ extension API.PackageController.GetRoute {
                 defaultBranchReference: result.defaultBranchVersion.reference,
                 releaseReference: result.releaseVersion?.reference,
                 preReleaseReference: result.preReleaseVersion?.reference,
-                repository: result.repository
+                repository: result.repository,
+                fundingLinks: result.repository.fundingLinks
             )
 
         }

--- a/Sources/App/Controllers/API/Types+WithExample.swift
+++ b/Sources/App/Controllers/API/Types+WithExample.swift
@@ -230,7 +230,8 @@ extension API.PackageController.GetRoute.Model: WithExample {
               isArchived: false,
               defaultBranchReference: .branch("main"),
               releaseReference: .tag(1, 2, 3, "1.2.3"),
-              preReleaseReference: nil)
+              preReleaseReference: nil,
+              fundingLinks: [])
     }
 }
 

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -377,11 +377,11 @@ extension Github {
                 case issueHunt = "ISSUEHUNT"
                 case koFi = "KO_FI"
                 case lfxCrowdfunding = "LFX_CROWDFUNDING"
-                case liberaPay = "LIBERAPAY"
+                case liberapay = "LIBERAPAY"
                 case openCollective = "OPEN_COLLECTIVE"
                 case otechie = "OTECHIE"
                 case patreon = "PATREON"
-                case tideLift = "TIDELIFT"
+                case tidelift = "TIDELIFT"
             }
 
             var platform: Platform

--- a/Sources/App/Models/FundingLink.swift
+++ b/Sources/App/Models/FundingLink.swift
@@ -23,11 +23,11 @@ struct FundingLink: Codable, Equatable {
         case issueHunt
         case koFi
         case lfxCrowdfunding
-        case liberaPay
+        case liberapay
         case openCollective
         case otechie
         case patreon
-        case tideLift
+        case tidelift
     }
 
     var platform: Platform
@@ -58,16 +58,16 @@ extension FundingLink.Platform {
                 self = .koFi
             case .lfxCrowdfunding:
                 self = .lfxCrowdfunding
-            case .liberaPay:
-                self = .liberaPay
+            case .liberapay:
+                self = .liberapay
             case .openCollective:
                 self = .openCollective
             case .otechie:
                 self = .otechie
             case .patreon:
                 self = .patreon
-            case .tideLift:
-                self = .tideLift
+            case .tidelift:
+                self = .tidelift
         }
     }
 }

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -367,22 +367,6 @@ extension FundingLink {
 }
 
 extension FundingLink.Platform {
-    var cssClass: String {
-        switch self {
-            case .communityBridge: return "community-bridge"
-            case .customUrl: return "custom-url"
-            case .gitHub: return "github"
-            case .issueHunt: return "issue-hunt"
-            case .koFi: return "ko-fi"
-            case .lfxCrowdfunding: return "lfx-crowdfunding"
-            case .liberapay: return "liberapay"
-            case .openCollective: return "open-collective"
-            case .otechie: return "otechie"
-            case .patreon: return "patreon"
-            case .tidelift: return "tide-lift"
-        }
-    }
-
     var name: String {
         switch self {
             case .communityBridge: return "LFX Mentorship"

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -380,11 +380,11 @@ extension FundingLink.Platform {
             case .issueHunt: return "issue-hunt"
             case .koFi: return "ko-fi"
             case .lfxCrowdfunding: return "lfx-crowdfunding"
-            case .liberaPay: return "liberapay"
+            case .liberapay: return "liberapay"
             case .openCollective: return "open-collective"
             case .otechie: return "otechie"
             case .patreon: return "patreon"
-            case .tideLift: return "tide-lift"
+            case .tidelift: return "tide-lift"
         }
     }
 
@@ -394,12 +394,12 @@ extension FundingLink.Platform {
             case .gitHub: return "GitHub"
             case .issueHunt: return "IssueHunt"
             case .koFi: return "Ko-fi"
-            case .lfxCrowdfunding: return "lfx-crowdfunding"
-            case .liberaPay: return "Liberapay"
+            case .lfxCrowdfunding: return "LFX Crowdfunding"
+            case .liberapay: return "Liberapay"
             case .openCollective: return "Open Collective"
             case .otechie: return "Otechie"
             case .patreon: return "Patreon"
-            case .tideLift: return "Tidelift"
+            case .tidelift: return "Tidelift"
 
             // The `name` for the `customUrl` case should never be used, as we display the domain name instead of static text.
             // The only situation where this wording would be displayed is if the `fundingUrl` was not able to be parsed as a URL.

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -178,31 +178,28 @@ extension PackageShow {
         }
 
         func packageSponsorship() -> Node<HTML.BodyContext> {
-            .div(
-                .class("package-sponsorship"),
-                
-                .text("This package accepts sponsorship via "),
-                .a(
-                    .class("github"),
-                    .href("https://example.com/sponsor-url"),
-                    .text("GitHub Sponsors")
+            guard model.fundingLinks.count > 0
+            else { return .empty }
+
+            return .section(
+                .class("package-funding"),
+                .p(
+                    .text(model.repositoryOwnerName),
+                    .text(" accepts support for "),
+                    .text(model.title),
+                    .text(" through "),
+                    .group(
+                        listPhrase(nodes: model.fundingLinks.map { fundingLink in
+                                .a(
+                                    .href(fundingLink.url),
+                                    .unwrap(fundingLink.customUrlDomain, { .text($0) },
+                                            else: .text(fundingLink.platform.name))
+                                )
+                        }, closing: .text(". "))
+                    ),
+                    .text("If you find this package useful, please consider supporting it.")
                 )
             )
-
-            if  {
-                // Multiple links in a list
-                return .div(
-                    .class("package-sponsorship"),
-                    .text("This package accepts sponsorship via "),
-                    .a(
-                        .class("github"),
-                        .href("https://example.com/sponsor-url"),
-                        .text("GitHub Sponsors")
-                    )
-                )
-            } else {
-                return .p()
-            }
         }
 
         func mainColumnCompatibility() -> Node<HTML.BodyContext> {
@@ -360,23 +357,6 @@ extension PackageShow {
 }
 
 // TODO: Test this
-extension API.PackageController.GetRoute.Model {
-    func fundingLinkListNodes() -> Node<HTML.ListContext> {
-        .group(
-            fundingLinks.map { fundingLink in
-                    .li(
-                        .class(fundingLink.platform.cssClass),
-                        .a(
-                            .href(fundingLink.url),
-                            .unwrap(fundingLink.customUrlDomain, { .text($0) },
-                                    else: .text(fundingLink.platform.name))
-                        )
-                    )
-            })
-    }
-}
-
-// TODO: Test this
 extension FundingLink {
     var customUrlDomain: String? {
         guard platform == .customUrl,
@@ -406,7 +386,7 @@ extension FundingLink.Platform {
     var name: String {
         switch self {
             case .communityBridge: return "LFX Mentorship"
-            case .gitHub: return "GitHub"
+            case .gitHub: return "GitHub Sponsors"
             case .issueHunt: return "IssueHunt"
             case .koFi: return "Ko-fi"
             case .lfxCrowdfunding: return "LFX Crowdfunding"

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -178,9 +178,9 @@ extension PackageShow {
         }
 
         func packageSponsorship() -> Node<HTML.BodyContext> {
-            // For only one sponsorship link
-            .p(
+            .div(
                 .class("package-sponsorship"),
+                
                 .text("This package accepts sponsorship via "),
                 .a(
                     .class("github"),
@@ -188,6 +188,21 @@ extension PackageShow {
                     .text("GitHub Sponsors")
                 )
             )
+
+            if  {
+                // Multiple links in a list
+                return .div(
+                    .class("package-sponsorship"),
+                    .text("This package accepts sponsorship via "),
+                    .a(
+                        .class("github"),
+                        .href("https://example.com/sponsor-url"),
+                        .text("GitHub Sponsors")
+                    )
+                )
+            } else {
+                return .p()
+            }
         }
 
         func mainColumnCompatibility() -> Node<HTML.BodyContext> {

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -136,6 +136,7 @@ extension PackageShow {
                 .class("details two-column"),
                 .section(
                     mainColumnMetadata(),
+                    packageSponsorship(),
                     .hr(
                         .class("minor")
                     ),
@@ -172,6 +173,19 @@ extension PackageShow {
                     model.productTypeListItem(.plugin),
                     model.targetTypeListItem(.macro),
                     model.keywordsListItem()
+                )
+            )
+        }
+
+        func packageSponsorship() -> Node<HTML.BodyContext> {
+            // For only one sponsorship link
+            .p(
+                .class("package-sponsorship"),
+                .text("This package accepts sponsorship via "),
+                .a(
+                    .class("github"),
+                    .href("https://example.com/sponsor-url"),
+                    .text("GitHub Sponsors")
                 )
             )
         }
@@ -326,6 +340,70 @@ extension PackageShow {
                                         .releases).relativeURL(),
                 .div(.spinner())
             )
+        }
+    }
+}
+
+// TODO: Test this
+extension API.PackageController.GetRoute.Model {
+    func fundingLinkListNodes() -> Node<HTML.ListContext> {
+        .group(
+            fundingLinks.map { fundingLink in
+                    .li(
+                        .class(fundingLink.platform.cssClass),
+                        .a(
+                            .href(fundingLink.url),
+                            .unwrap(fundingLink.customUrlDomain, { .text($0) },
+                                    else: .text(fundingLink.platform.name))
+                        )
+                    )
+            })
+    }
+}
+
+// TODO: Test this
+extension FundingLink {
+    var customUrlDomain: String? {
+        guard platform == .customUrl,
+              let parsedUrl = URL(string: url)
+        else { return nil }
+        return parsedUrl.host
+    }
+}
+
+extension FundingLink.Platform {
+    var cssClass: String {
+        switch self {
+            case .communityBridge: return "community-bridge"
+            case .customUrl: return "custom-url"
+            case .gitHub: return "github"
+            case .issueHunt: return "issue-hunt"
+            case .koFi: return "ko-fi"
+            case .lfxCrowdfunding: return "lfx-crowdfunding"
+            case .liberaPay: return "liberapay"
+            case .openCollective: return "open-collective"
+            case .otechie: return "otechie"
+            case .patreon: return "patreon"
+            case .tideLift: return "tide-lift"
+        }
+    }
+
+    var name: String {
+        switch self {
+            case .communityBridge: return "LFX Mentorship"
+            case .gitHub: return "GitHub"
+            case .issueHunt: return "IssueHunt"
+            case .koFi: return "Ko-fi"
+            case .lfxCrowdfunding: return "lfx-crowdfunding"
+            case .liberaPay: return "Liberapay"
+            case .openCollective: return "Open Collective"
+            case .otechie: return "Otechie"
+            case .patreon: return "Patreon"
+            case .tideLift: return "Tidelift"
+
+            // The `name` for the `customUrl` case should never be used, as we display the domain name instead of static text.
+            // The only situation where this wording would be displayed is if the `fundingUrl` was not able to be parsed as a URL.
+            case .customUrl: return "Link"
         }
     }
 }

--- a/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
+++ b/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
@@ -124,7 +124,8 @@ extension API.PackageController.GetRoute.Model {
             isArchived: false,
             defaultBranchReference: .branch("main"),
             releaseReference: .tag(5, 2, 0),
-            preReleaseReference: .tag(5, 3, 0, "beta.1")
+            preReleaseReference: .tag(5, 3, 0, "beta.1"),
+            fundingLinks: []
         )
     }
 }


### PR DESCRIPTION
This is not ready for merging yet, but wanted to get some initial feedback on the styling and wording. I'm not a big fan of it saying "accepts" funding. It's very "flat" wording, and I'd like it to be a little more exciting, but not too over the top!

![Screenshot 2024-01-15 at 14 11 22@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/a481d3c2-6f5d-4bf3-8a8a-13b878c6e0d2)

Bear in mind that some packages have a significant number of links:

![Screenshot 2024-01-15 at 15 25 34@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/82ef21a1-2564-42f2-9ad3-34179a5b904b)

There's a possibility that the list may look as if it's displaying incorrectly if/when people have two links to the same sponsorship platform but with two different usernames. In that case, it looks like this:

![Screenshot 2024-01-15 at 15 30 19@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/75e48d9f-bbe5-4332-a744-a903b0ce08e2)

I don't think we should cope with this situation explicitly, we would need to parse out the username and it's such an edge case.