### PR TITLE
Fix the common issue with funding URLs sent back via the GitHub API

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -183,7 +183,7 @@ func updateRepository(on database: Database,
 
     repository.defaultBranch = repoMetadata.defaultBranch
     repository.forks = repoMetadata.forkCount
-    repository.fundingLinks = repoMetadata.fundingLinks?.map(FundingLink.init(from:)) ?? []
+    repository.fundingLinks = repoMetadata.fundingLinks?.compactMap(FundingLink.init(from:)) ?? []
     repository.homepageUrl = repoMetadata.homepageUrl?.trimmed
     repository.isArchived = repoMetadata.isArchived
     repository.isInOrganization = repoMetadata.isInOrganization

--- a/Sources/App/Models/FundingLink.swift
+++ b/Sources/App/Models/FundingLink.swift
@@ -40,8 +40,8 @@ extension FundingLink {
         platform = .init(from: node.platform)
 
         // Some URLs come back from the GitHub API without a scheme. In every circumstance I have
-        // observed, this is a simple lack of any scheme. We should try a simple fix of prepending
-        // `https`, but if it's still won't parse as a URL, we should discard that funding link entirely.
+        // observed, prepending `https://` would fix the issue. We should try that simple fix, but
+        // if it's still won't parse as a URL, we should discard that funding link entirely.
         switch node.url {
             case let url where URL(string: url)?.scheme != nil:
                 self.url = url

--- a/Sources/App/Models/FundingLink.swift
+++ b/Sources/App/Models/FundingLink.swift
@@ -42,13 +42,12 @@ extension FundingLink {
         // Some URLs come back from the GitHub API without a scheme. In every circumstance I have
         // observed, prepending `https://` would fix the issue. We should try that simple fix, but
         // if it's still won't parse as a URL, we should discard that funding link entirely.
-        switch node.url {
-            case let url where URL(string: url)?.scheme != nil:
-                self.url = url
-            case let url where URL(string: "https://\(url)") != nil:
-                self.url = "https://\(url)"
-            default:
-                return nil
+        if let url = URL(string: node.url), url.scheme != nil, url.host != nil {
+            self.url = url.absoluteString
+        } else if let url = URL(string: "https://\(node.url)"), url.host != nil {
+            self.url = url.absoluteString
+        } else {
+            return nil
         }
     }
 }

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -397,4 +397,21 @@ class GithubTests: AppTestCase {
         XCTAssertEqual(res, nil)
     }
 
+    func test_fundingLink_missingSchemeFix() async throws {
+        // URL with both a scheme and a host.
+        let ghFundingLink1 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "https://example.com")
+        let dbFundingLink1 = try XCTUnwrap(FundingLink(from: ghFundingLink1))
+        XCTAssertEqual(dbFundingLink1.url, "https://example.com")
+
+        // URL with a host but no scheme.
+        let ghFundingLink2 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "example.com")
+        let dbFundingLink2 = try XCTUnwrap(FundingLink(from: ghFundingLink2))
+        XCTAssertEqual(dbFundingLink2.url, "https://example.com")
+
+        // URL with neither.
+        let ghFundingLink3 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "!@£$%")
+        let dbFundingLink3 = FundingLink(from: ghFundingLink3)
+        XCTAssertNil(dbFundingLink3)
+    }
+
 }


### PR DESCRIPTION
This one *is* ready for review.

Once merged, we will need to let this run a full ingestion cycle in production to make sure that the database is fully updated before the front-end code assumes it will find valid URLs.