### PR TITLE
Pre process funding links

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -469,6 +469,15 @@
       }
     },
     {
+      "identity" : "tldextractswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/MarcoEidinger/TLDExtractSwift.git",
+      "state" : {
+        "revision" : "c9c2400af9a564e8ed55cf58779cfbb18e2bd695",
+        "version" : "2.3.8"
+      }
+    },
+    {
       "identity" : "vapor",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/vapor/vapor.git",

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit", from: "4.13.0"),
         .package(url: "https://github.com/vapor/vapor.git", revision: "4.89.3"),
+        .package(url: "https://github.com/MarcoEidinger/TLDExtractSwift.git", from: "2.3.8"),
     ],
     targets: [
         .executableTarget(name: "Run", dependencies: ["App"]),
@@ -69,6 +70,7 @@ let package = Package(
                     .product(name: "SwiftPMPackageCollections", package: "swift-package-manager"),
                     .product(name: "Vapor", package: "vapor"),
                     .product(name: "VaporToOpenAPI", package: "VaporToOpenAPI"),
+                    .product(name: "TLDExtract", package: "tldextractswift"),
                 ],
                 linkerSettings: [.unsafeFlags(["-Xlinker", "-interposable"],
                                               .when(platforms: [.macOS],

--- a/Sources/App/Models/FundingLink.swift
+++ b/Sources/App/Models/FundingLink.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Foundation
+import TLDExtract
 
 
 struct FundingLink: Codable, Equatable {
@@ -32,6 +33,7 @@ struct FundingLink: Codable, Equatable {
 
     var platform: Platform
     var url: String
+    var urlLabel: String
 }
 
 
@@ -49,6 +51,18 @@ extension FundingLink {
         } else {
             return nil
         }
+
+        urlLabel = Self.urlLabel(from: url)
+    }
+
+    init(platform: Platform, url: String) {
+        self.platform = platform
+        self.url = url
+        self.urlLabel = Self.urlLabel(from: url)
+    }
+
+    static func urlLabel(from url: String) -> String {
+        TLDExtract().parse(url)?.rootDomain ?? URL(string: url)?.host ?? url
     }
 }
 

--- a/Tests/AppTests/FundingLinkTests.swift
+++ b/Tests/AppTests/FundingLinkTests.swift
@@ -1,0 +1,47 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import App
+
+import Vapor
+import XCTest
+
+
+class FundingLinkTests: XCTestCase {
+
+    func test_fundingLink_urlLabel() async throws {
+        // URL with both a scheme, a host, and a subdomain.
+        let ghFundingLink1 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "https://subdomain.example.com")
+        let dbFundingLink1 = try XCTUnwrap(FundingLink(from: ghFundingLink1))
+        XCTAssertEqual(dbFundingLink1.url, "https://subdomain.example.com")
+        XCTAssertEqual(dbFundingLink1.urlLabel, "example.com")
+
+        // URL with both a scheme and a host.
+        let ghFundingLink2 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "https://example.com")
+        let dbFundingLink2 = try XCTUnwrap(FundingLink(from: ghFundingLink2))
+        XCTAssertEqual(dbFundingLink2.url, "https://example.com")
+        XCTAssertEqual(dbFundingLink2.urlLabel, "example.com")
+
+        // URL with a host but no scheme.
+        let ghFundingLink3 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "example.com")
+        let dbFundingLink3 = try XCTUnwrap(FundingLink(from: ghFundingLink3))
+        XCTAssertEqual(dbFundingLink3.url, "https://example.com")
+        XCTAssertEqual(dbFundingLink3.urlLabel, "example.com")
+
+        // URL with neither.
+        let ghFundingLink4 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "!@£$%")
+        let dbFundingLink4 = FundingLink(from: ghFundingLink4)
+        XCTAssertNil(dbFundingLink4)
+    }
+}

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -396,22 +396,4 @@ class GithubTests: AppTestCase {
         // validate
         XCTAssertEqual(res, nil)
     }
-
-    func test_fundingLink_missingSchemeFix() async throws {
-        // URL with both a scheme and a host.
-        let ghFundingLink1 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "https://example.com")
-        let dbFundingLink1 = try XCTUnwrap(FundingLink(from: ghFundingLink1))
-        XCTAssertEqual(dbFundingLink1.url, "https://example.com")
-
-        // URL with a host but no scheme.
-        let ghFundingLink2 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "example.com")
-        let dbFundingLink2 = try XCTUnwrap(FundingLink(from: ghFundingLink2))
-        XCTAssertEqual(dbFundingLink2.url, "https://example.com")
-
-        // URL with neither.
-        let ghFundingLink3 = Github.Metadata.FundingLinkNode(platform: .customUrl, url: "!@£$%")
-        let dbFundingLink3 = FundingLink(from: ghFundingLink3)
-        XCTAssertNil(dbFundingLink3)
-    }
-
 }


### PR DESCRIPTION
Separating from #2845 as this needs to process for a full ingestion cycle before the display code goes live.