### PR TITLE
Removed the word “Compatibility” from the shields.io badges

### DIFF
--- a/Sources/App/Core/Extensions/Badge.swift
+++ b/Sources/App/Core/Extensions/Badge.swift
@@ -41,7 +41,7 @@ struct Badge: Content, Equatable {
         let label: String
         switch badgeType {
             case .platforms:
-                label = "Platform"
+                label = "Platforms"
             case .swiftVersions:
                 label = "Swift"
         }

--- a/Sources/App/Core/Extensions/Badge.swift
+++ b/Sources/App/Core/Extensions/Badge.swift
@@ -41,9 +41,9 @@ struct Badge: Content, Equatable {
         let label: String
         switch badgeType {
             case .platforms:
-                label = "Platform Compatibility"
+                label = "Platform"
             case .swiftVersions:
-                label = "Swift Compatibility"
+                label = "Swift"
         }
 
         let (message, success) = Self.badgeMessage(significantBuilds: significantBuilds,

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -671,7 +671,7 @@ class ApiTests: AppTestCase {
 
                 let badge = try res.content.decode(Badge.self)
                 XCTAssertEqual(badge.schemaVersion, 1)
-                XCTAssertEqual(badge.label, "Swift Compatibility")
+                XCTAssertEqual(badge.label, "Swift")
                 XCTAssertEqual(badge.message, "5.7 | 5.6")
                 XCTAssertEqual(badge.isError, false)
                 XCTAssertEqual(badge.color, "F05138")
@@ -689,7 +689,7 @@ class ApiTests: AppTestCase {
 
                 let badge = try res.content.decode(Badge.self)
                 XCTAssertEqual(badge.schemaVersion, 1)
-                XCTAssertEqual(badge.label, "Platform Compatibility")
+                XCTAssertEqual(badge.label, "Platform")
                 XCTAssertEqual(badge.message, "macOS | Linux")
                 XCTAssertEqual(badge.isError, false)
                 XCTAssertEqual(badge.color, "F05138")

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -689,7 +689,7 @@ class ApiTests: AppTestCase {
 
                 let badge = try res.content.decode(Badge.self)
                 XCTAssertEqual(badge.schemaVersion, 1)
-                XCTAssertEqual(badge.label, "Platform")
+                XCTAssertEqual(badge.label, "Platforms")
                 XCTAssertEqual(badge.message, "macOS | Linux")
                 XCTAssertEqual(badge.isError, false)
                 XCTAssertEqual(badge.color, "F05138")


### PR DESCRIPTION
Fixes #2863

I'll ad-hoc deploy this to staging before we merge it so I can double-check it works, but I can't see how even I would make a mistake with this one.
