### PR TITLE
Pin Turbo to 7.x in JavaScript dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,3 +53,7 @@ updates:
       dependencies:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: '@hotwired/turbo'
+        versions: ['^8.0.0']
+          


### PR DESCRIPTION
Turbo 8.x is a significant change I want to look into carefully before we consider adopting. The change has also been quite controversial, and while I've not paid attention to the controversy, its mere existence is enough to make me want to take this very slowly.

