### PR TITLE
Removed unused `Decodable` from `Github.Readme`

### DIFF
--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -242,7 +242,7 @@ extension Github {
         var htmlUrl: String
     }
 
-    struct Readme: Decodable, Equatable {
+    struct Readme: Equatable {
         var etag: String?
         var html: String
         var htmlUrl: String


### PR DESCRIPTION
Trivial change here discovered by, but not directly related to what I'm working on.

`Github.Readme ` is not used to decode an API response. There's possibly a better place for it, given that the type above *is* used for that purpose, but I couldn't spot an obvious place it would fit better.

Removing decodable is a nice clue that it's not used for this purpose, though.