### PR TITLE
Switch to self-hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,8 @@ on:
 jobs:
   test-linux:
     name: Test
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: self-hosted
     container:
       image: registry.gitlab.com/finestructure/spi-base:0.15.2
     services:

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -21,7 +21,8 @@ on:
 jobs:
   test-linux:
     name: Query Performance Test
-    runs-on: ubuntu-latest
+    # runs-on: ubuntu-latest
+    runs-on: self-hosted
     continue-on-error: true
     container:
       image: registry.gitlab.com/finestructure/spi-base:0.15.2


### PR DESCRIPTION
This is a work-around. The GH runners run in addition to the Gitlab runners on lb1 and lb2 and they're not aware of each other's build queue. I.e. they compete for resources running Linux builds. However, our Linux build pipeline typically isn't very deep so this should be fine and it shouldn't be a big deal if we over-stress the two machines a bit.

If this becomes a longer term thing we can resize the machines.