### PR TITLE
Removed front-matter from all blog posts

### DIFF
--- a/Resources/Blog/Posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation.md
+++ b/Resources/Blog/Posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation.md
@@ -1,8 +1,3 @@
----
-date: 2022-06-03 12:00
-title: Auto-generating, Auto-hosting, and Auto-updating DocC Documentation
-description: DocC is Apple’s recommended way to provide documentation for your packages, and launching today, the Swift Package Index can generate, host, and update package documentation for any package in the index!
----
 
 > **UPDATE:** The information in this blog post is superceded by our [official documentation](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/documentation/spimanifest/commonusecases). Please refer to the documentation rather than this blog post.
 

--- a/Resources/Blog/Posts/building-3238-packages-for-apple-silicon.md
+++ b/Resources/Blog/Posts/building-3238-packages-for-apple-silicon.md
@@ -1,8 +1,3 @@
----
-date: 2020-09-09 12:00
-title: Building 3,238 Swift Packages for Apple Silicon
-description: As part of the Swift Package Index build system, we have processed what must be the most extensive test of Apple Silicon compatibility outside of Apple. Here’s what we found.
----
 
 As part of the [Swift Package Index build system](/posts/launching-language-and-platform-package-compatibility/), we have processed what must be the most extensive test of Apple Silicon compatibility outside of Apple.
 

--- a/Resources/Blog/Posts/externally-hosted-package-documentation.md
+++ b/Resources/Blog/Posts/externally-hosted-package-documentation.md
@@ -1,8 +1,3 @@
----
-date: 2022-10-17 12:00
-title: Externally hosted package documentation
-description: Using auto-hosted documentation remains the easiest way to get your package’s documentation available on the web, but we now also support documentation for projects that have more complex requirements or well-established documentation that already lives on the web.
----
 
 > **UPDATE:** The information in this blog post is superceded by our [official documentation](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/documentation/spimanifest/commonusecases). Please refer to the documentation rather than this blog post.
 

--- a/Resources/Blog/Posts/funding-the-future-of-the-swift-package-index.md
+++ b/Resources/Blog/Posts/funding-the-future-of-the-swift-package-index.md
@@ -1,9 +1,3 @@
----
-date: 2020-10-12 12:00
-title: Funding the Future of the Swift Package Index
-description: Many open-source projects are just code and don’t need constant attention. The Swift Package Index is a little different, so we are opening up GitHub sponors for the project. We'd love your support.
----
-
 It’s been almost four months since we [launched the Swift Package Index](https://iosdevweekly.com/issues/460#start), and we’ve been so happy to see so many positive reactions to it across the community. Thank you all for checking it out and spreading the word.
 
 It’s still early days for Swift Package Manager adoption but we are confident that it will become the dominant technology for Swift dependency management, and we want the Swift Package Index to grow right alongside it.

--- a/Resources/Blog/Posts/highlighting-package-funding-links.md
+++ b/Resources/Blog/Posts/highlighting-package-funding-links.md
@@ -1,8 +1,3 @@
----
-date: 2024-01-18 12:00
-title: Highlighting package funding links
-description:
----
 
 The story is as old as time, or at least as old as [`time_t`](https://www.gnu.org/software/libc/manual/html_node/Time-Types.html)! A kind developer writes some code and makes it open-source as a library, hoping it might help others. Over time, that library might gain popularity, prompting other developers to raise issues, open discussions, and sometimes even pull requests! However, it can also happen that the original developer realises they are spending all their free time working for free on a project they might not even use anymore, leading to burnout and many abandoned projects.
 

--- a/Resources/Blog/Posts/hosting-the-swift-package-index.md
+++ b/Resources/Blog/Posts/hosting-the-swift-package-index.md
@@ -1,8 +1,3 @@
----
-date: 2021-03-30 12:00
-title: Hosting the Swift Package Index
-description: Making any open-source project sustainable for the long term is challenging in many ways, but with the Swift Package Index we also need significant hardware resources to keep it available.
----
 
 ![Logo images for the Swift Package Index, MacStadium, and Microsoft Azure](/images/blog/hosted-by-macstadium-and-microsoft-azure.png)
 

--- a/Resources/Blog/Posts/how-the-swift-package-index-project-got-started.md
+++ b/Resources/Blog/Posts/how-the-swift-package-index-project-got-started.md
@@ -1,8 +1,3 @@
----
-date: 2021-05-05 12:00
-title: How the Swift Package Index project got started because of a button
-description: How did the Swift Package Index project get started, and why does a button feature so prominently in the story? Read on to find out.
----
 
 It’s been [one year since we made the first commit](https://twitter.com/_sa_s/status/1386033811348197380) on the [Swift Package Index repository](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server), and we think that deserves a little celebration!
 

--- a/Resources/Blog/Posts/improvements-to-package-search.md
+++ b/Resources/Blog/Posts/improvements-to-package-search.md
@@ -1,8 +1,3 @@
----
-date: 2021-12-15 12:00
-title: Improvements to package search
-description: Recently, we’ve been focusing our attention on improving search here on the Swift Package Index, and it’s time to let you all know what we’ve implemented!
----
 
 Recently, we’ve been focusing our attention on improving search here on the Swift Package Index, and it’s time to let you all know what we’ve implemented!
 

--- a/Resources/Blog/Posts/inline-readme-files.md
+++ b/Resources/Blog/Posts/inline-readme-files.md
@@ -1,8 +1,3 @@
----
-date: 2020-12-24 12:00
-title: Inline README Files!
-description: Where’s the most important source of information for deciding whether a package is suitable for your needs? It’s in the README file!
----
 
 If you’ve visited the main package index site over the last week or so, you might have noticed something new. Scroll down a little, and you’ll see the README file for the package, right below all the other information that we aggregate.
 

--- a/Resources/Blog/Posts/keeping-up-to-date-with-swift-packages.md
+++ b/Resources/Blog/Posts/keeping-up-to-date-with-swift-packages.md
@@ -1,8 +1,3 @@
----
-date: 2020-11-25 12:00
-title: Keeping Up To Date with Swift Packages
-description: How do you keep up with new releases of the packages you use? How do you discover new packages? It’s a tough challenge to keep up to date with everything that the community releases, so we have some announcements today that can help you stay informed!
----
 
 How do you keep up with new releases of the packages you use? How do you discover new packages? It’s a tough challenge to keep up to date with everything that the community releases, so we have some announcements today that can help you stay informed!
 

--- a/Resources/Blog/Posts/keeping-up-with-dependency-changes.md
+++ b/Resources/Blog/Posts/keeping-up-with-dependency-changes.md
@@ -1,8 +1,3 @@
----
-date: 2022-01-25 12:00
-title: Keeping up with dependency changes
-description: How often do you update your package dependencies, and when you do, do you check what’s new or changed? We have a new tool that can help!
----
 
 How often do you update your package dependencies, and when you do, do you check what’s new or changed, or do you just run your tests to check nothing broke and move on? 😅
 

--- a/Resources/Blog/Posts/launching-language-and-platform-package-compatibility.md
+++ b/Resources/Blog/Posts/launching-language-and-platform-package-compatibility.md
@@ -1,8 +1,3 @@
----
-date: 2020-08-20 12:00
-title: Launching Language and Platform Package Compatibility
-description: We decided that one of the most important pieces of information we could provide on a package metadata page was what versions of Swift, and what platforms it was compatible with. Building that feature turned out to be quite an epic journey.
----
 
 What’s the first question you need an answer to after finding a package that fits your needs?
 

--- a/Resources/Blog/Posts/launching-swift-package-collections.md
+++ b/Resources/Blog/Posts/launching-swift-package-collections.md
@@ -1,8 +1,3 @@
----
-date: 2021-06-09 12:00
-title: Launching Swift Package Collections
-description: What are package collections? JSON descriptions of Swift package metadata. What does the Swift Package Index have in droves? Metadata about Swift packages! As soon as we heard about package collections in Swift 5.5, we knew we had to support it.
----
 
 It's probably not news that [this is a big week](https://developer.apple.com/wwdc21/) for Swift developers! On Monday, Apple kicked WWDC off by releasing the first beta of Xcode 13, including Swift 5.5. We've been following the release of the Swift Package Manager in Swift 5.5 closely as it implements package collections, a significant new feature.
 

--- a/Resources/Blog/Posts/launching-the-swift-package-index-playgrounds-app-for-macos.md
+++ b/Resources/Blog/Posts/launching-the-swift-package-index-playgrounds-app-for-macos.md
@@ -1,8 +1,3 @@
----
-date: 2021-05-05 13:00
-title: Launching the Swift Package Index Playgrounds app for macOS
-description: Try out any Swift package in Xcode with just a couple of clicks. It's the launch of the first native app from the Swift Package Index!
----
 
 From the very beginning, the main goal of this site was to do more than echo Swift package metadata. We want to enable better _decisions_ about which dependencies to use. That’s why we include information about how actively maintained a package is, and it’s why we check compatibility with the different platforms by building against them.
 

--- a/Resources/Blog/Posts/m1-pro-and-m1-max-build-and-test-benchmarks.md
+++ b/Resources/Blog/Posts/m1-pro-and-m1-max-build-and-test-benchmarks.md
@@ -1,8 +1,3 @@
----
-date: 2021-11-01 12:00
-title: M1 Pro and M1 Max Xcode Build and Test Benchmarks
-description: We’ve run real-world performance benchmarks with the new M1 MacBook Pro machines against M1 and Intel machines.
----
 
 It is a truth universally acknowledged that a developer in possession of a good project must be in [want of a fast compile](https://en.wikiquote.org/wiki/Jane_Austen#Pride_and_Prejudice). First observed some 200 years ago by Jane Austen, this still holds today as lucky developers take delivery of new M1 machines.
 

--- a/Resources/Blog/Posts/package-dependencies-step-one.md
+++ b/Resources/Blog/Posts/package-dependencies-step-one.md
@@ -1,8 +1,3 @@
----
-date: 2021-10-18 12:00
-title: Package Dependencies - Step One
-description: In pursuit of helping you make better decisions about the packages you depend on, we’re taking a step towards exposing dependency information for all packages!
----
 
 We’ve said several times on this blog that one of the primary goals of the [Swift Package Index](https://swiftpackageindex.com) is to help you make better decisions about the dependencies you include in your Swift projects.
 

--- a/Resources/Blog/Posts/progress-update-may-2021.md
+++ b/Resources/Blog/Posts/progress-update-may-2021.md
@@ -1,8 +1,3 @@
----
-date: 2021-05-18 12:00
-title: Progress Report - May 2021
-description: Three months ago, we published a list of areas that we wanted to focus on next. We’re just about to update that list for the next few months, but before we do that, let’s check-in quickly with how well we stayed on track since February!
----
 
 Around [three months ago](posts/whats-next-february-2021/), we published a list of areas that we wanted to focus on next. We’re just about to update that list for the next few months, but before we do that, let’s check in with how well we stayed on track since February!
 

--- a/Resources/Blog/Posts/recognising-package-authors.md
+++ b/Resources/Blog/Posts/recognising-package-authors.md
@@ -1,8 +1,3 @@
----
-date: 2022-12-14 12:00
-title: Recognising Package Authors
-description: The Swift Package Index now recognises primary contributors to open-source Swift packages by including author information alongside package metadata. Thank you to everyone who contributes to open-source Swift software!
----
 
 When we launched this site back [in June 2020](https://iosdevweekly.com/issues/460#start), one of the features on the “must be done before launch” list was support for showing who wrote each package. Not just a GitHub username but the names of the primary contributors.
 

--- a/Resources/Blog/Posts/revealing-and-explaining-package-scores.md
+++ b/Resources/Blog/Posts/revealing-and-explaining-package-scores.md
@@ -1,8 +1,3 @@
----
-date: 2023-10-31 12:00
-title: Revealing and explaining package scores
-description: When you search the Swift Package Index, the order in which the search results are displayed is determined by a combination of the relevance of text in the package name and description, and an internal score based on various metrics. Today, we're adding a feature that
----
 
 This guest post is from [Cyndi Chin](https://cyndichin.github.io/) and announces the results of her work for this year’s [Swift Mentorship Program](https://www.swift.org/mentorship/).
 

--- a/Resources/Blog/Posts/say-hello-to-the-swift-package-index-blog.md
+++ b/Resources/Blog/Posts/say-hello-to-the-swift-package-index-blog.md
@@ -1,8 +1,3 @@
----
-date: 2020-08-16 12:00
-title: Say Hello to the Swift Package Index Blog
-description: It’s always hard to know when to ship v1 of a project. Which features get included? Are there things that can wait? It’s a balancing act. You’re excited to show the world what you built, but is it good enough?
----
 
 Hello! 👋
 

--- a/Resources/Blog/Posts/searching-for-plugins.md
+++ b/Resources/Blog/Posts/searching-for-plugins.md
@@ -1,8 +1,3 @@
----
-date: 2022-07-12 12:00
-title: Searching for plugins?
-description: With Swift 5.6, Xcode and the Swift Package Manager gained a new product type, plugins, and we’re delighted to announce we now have support for filtering search results by whether or not they include a plugin.
----
 
 With Swift 5.6, Xcode and the Swift Package Manager gained a new product type, plugins, allowing developers to extend their build process with new build commands or processing steps.
 

--- a/Resources/Blog/Posts/supporting-swift-510.md
+++ b/Resources/Blog/Posts/supporting-swift-510.md
@@ -1,8 +1,3 @@
----
-date: 2024-02-23 12:00
-title: Support for Swift 5.10
-description: The march of Swift's progress continues, the same is true for the Swift Package Index! We're delighted to announce that compatibility results for Swift 5.10 are available on every package page!
----
 
 The march of Swift's progress continues, and beta versions of Swift 5.10 have been available for a few weeks now, both in pre-releases of Xcode 15.3 and as [nightly snapshots from Swift.org](https://www.swift.org/download/#swift-510-development).
 

--- a/Resources/Blog/Posts/supporting-swift-58.md
+++ b/Resources/Blog/Posts/supporting-swift-58.md
@@ -1,8 +1,3 @@
----
-date: 2023-04-03 12:00
-title: Supporting Swift 5.8
-description: Last Thursday, Apple released Swift 5.8, and today we are delighted to announce that the Swift Package Index already has full support for parsing and processing Swift packages using Xcode 14.3 and Swift 5.8 across all our supported platforms.
----
 
 Last Thursday, [Apple released Swift 5.8](https://www.swift.org/blog/swift-5.8-released/), and today we are delighted to announce that the Swift Package Index already has full support for parsing and processing Swift packages using Xcode 14.3 and Swift 5.8 across all our supported platforms.
 

--- a/Resources/Blog/Posts/supporting-swift-59.md
+++ b/Resources/Blog/Posts/supporting-swift-59.md
@@ -1,8 +1,3 @@
----
-date: 2023-06-12 12:00
-title: Supporting Swift 5.9 Betas
-description: How could we improve on adding support for a new Swift version after just one week of it being available? We could add support for Swift 5.9 one week after the release of the first beta version!
----
 
 Back in April, we were [proud to announce that we supported Swift 5.8 within one week of the official release](https://blog.swiftpackageindex.com/posts/supporting-swift-58/), adding it to our compatibility matrix so you could know whether the package you were considering would work with the latest version of Swift.
 

--- a/Resources/Blog/Posts/supporting-visionos.md
+++ b/Resources/Blog/Posts/supporting-visionos.md
@@ -1,8 +1,3 @@
----
-date: 2023-06-29 12:00
-title: Supporting visionOS
-description: We’ve added support for visionOS to our compatibility testing, showing it on the package pages and build badges.
----
 
 Apple was quick to release the promised visionOS SDK only a week after WWDC 2023, and today we’re happy to announce that we have already started compatibility testing for this exciting new platform.
 

--- a/Resources/Blog/Posts/the-swift-package-index-metadata-file-first-steps.md
+++ b/Resources/Blog/Posts/the-swift-package-index-metadata-file-first-steps.md
@@ -1,8 +1,3 @@
----
-date: 2020-10-30 12:00
-title: The Swift Package Index Metadata File – First Steps
-description: The Swift Package Index gathers most of the metadata about a package from external sources. The package manifest, the git repository, and GitHub. But, there are some things we need to know that are specific to the Swift Package Index. Learn how to take advantage of the extra settings available to your package.
----
 
 The vast majority of the information you see in [the package index][1] is generated from a single URL, the location of the package’s git repository.
 

--- a/Resources/Blog/Posts/two-years-of-the-swift-package-index.md
+++ b/Resources/Blog/Posts/two-years-of-the-swift-package-index.md
@@ -1,8 +1,3 @@
----
-date: 2022-04-25 12:00
-title: Two years of the Swift Package Index
-description: It’s been exactly two years since the first commit of the Swift Package Index! More than 950 pull requests and 5,000 commits later, we now index and compatibility test over 4,500 packages!
----
 
 It’s been exactly two years since the [first commit](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/commit/f4475174b83aeb5d35b567c0b6042efe8351a0d1)¹ of the Swift Package Index! More than 950 pull requests and 5,250 commits later, we now index and compatibility test over 4,500 packages!
 

--- a/Resources/Blog/Posts/using-the-spi-playgrounds-app-to-file-better-bug-reports.md
+++ b/Resources/Blog/Posts/using-the-spi-playgrounds-app-to-file-better-bug-reports.md
@@ -1,8 +1,3 @@
----
-date: 2021-05-17 12:00
-title: Using the SPI Playgrounds app to file better bug reports
-description: If you've been wondering why we created the SPI Playgrounds app, read on for a story where we used a playground to file a better bug report in the Vapor project.
----
 
 We [recently released the SPI Playgrounds app](/posts/launching-the-swift-package-index-playgrounds-app-for-macos), which allows you to try out Swift Packages in a Playground in Xcode. You can use it to quickly get up and running with a new package when evaluating dependencies. However, it can also be helpful when working with dependencies you _already_ use in your project. One such use case is creating reproducible bug reports.
 

--- a/Resources/Blog/Posts/validating-spi-manifest-files.md
+++ b/Resources/Blog/Posts/validating-spi-manifest-files.md
@@ -1,8 +1,3 @@
----
-date: 2023-04-24 12:00
-title: Validating Swift Package Index Manifest Files
-description: Swift Package Index Manifest files are YAML files that configure how the package index processes your package. With our online validator you can now confirm the format is correct without having to wait for reprocessing.
----
 
 The Swift Package Index file `.spi.yml` file allows package authors to configure some aspects of how we process your package. This file has become much more popular since we [launched hosted documentation](/posts/versioned-docc-documentation).
 

--- a/Resources/Blog/Posts/versioned-docc-documentation.md
+++ b/Resources/Blog/Posts/versioned-docc-documentation.md
@@ -1,8 +1,3 @@
----
-date: 2022-08-05 12:00
-title: Versioned DocC Documentation
-description: We rolled out auto-generating DocC documentation exactly two months ago, and now we’re rolling out phase two. Versioned documentation!
----
 
 > **UPDATE:** The information in this blog post is superceded by our [official documentation](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/documentation/spimanifest/commonusecases). Please refer to the documentation rather than this blog post.
 

--- a/Resources/Blog/Posts/we-need-your-help-to-fund-this-project.md
+++ b/Resources/Blog/Posts/we-need-your-help-to-fund-this-project.md
@@ -1,8 +1,3 @@
----
-date: 2022-07-11 12:00
-title: We need your help to fund this project
-description: As an open-source project without the backing of a big company, we need your help to keep this project going.
----
 
 As an open-source project without the backing of a big company, community donations are critical to keeping this project going.
 

--- a/Resources/Blog/Posts/we-support-ukraine.md
+++ b/Resources/Blog/Posts/we-support-ukraine.md
@@ -1,8 +1,3 @@
----
-date: 2022-02-26 12:00
-title: We support Ukraine
-description: Russia’s invasion of Ukraine is appalling and we support Ukraine.
----
 
 Russia’s invasion of Ukraine is appalling.
 

--- a/Resources/Blog/Posts/welcoming-apple-as-a-supporter-of-the-swift-package-index.md
+++ b/Resources/Blog/Posts/welcoming-apple-as-a-supporter-of-the-swift-package-index.md
@@ -1,8 +1,3 @@
----
-date: 2023-03-14 12:00
-title: Welcoming Apple as a supporter of the Swift Package Index
-description: As we approach our third anniversary working on the Swift Package Index, we are thrilled to announce that Apple is adding their public and financial support to the project.
----
 
 ![The Swift Package Index logo next to the Apple logo](/images/blog/swift-package-index-and-apple-logos.png)
 

--- a/Resources/Blog/Posts/whats-next-february-2021.md
+++ b/Resources/Blog/Posts/whats-next-february-2021.md
@@ -1,8 +1,3 @@
----
-date: 2021-02-02 12:00
-title: What’s Next? - February 2021
-description: It’s been about seven months since we launched the Swift Package Index and we’ve been hard at work implementing a few major updates. Are we done? No, we are not!
----
 
 It’s been about seven months since we [launched the Swift Package Index](https://iosdevweekly.com/issues/460#start) and we’ve been hard at work implementing a few major updates. Most significantly, [real-world package compatibility](https://blog.swiftpackageindex.com/posts/launching-language-and-platform-package-compatibility), [a comprehensive set of RSS feeds and Twitter updates](https://blog.swiftpackageindex.com/posts/keeping-up-to-date-with-swift-packages), and most recently [inline README files](https://blog.swiftpackageindex.com/posts/inline-readme-files).
 

--- a/Resources/Blog/Posts/whats-next-may-2021.md
+++ b/Resources/Blog/Posts/whats-next-may-2021.md
@@ -1,8 +1,3 @@
----
-date: 2021-05-18 13:00
-title: What’s Next? - May 2021
-description:
----
 
 You might just have finished reading our [progress report from the last three months](/posts/progress-update-may-2021/). Now it’s time to talk about what we’re planning for the next few months!
 


### PR DESCRIPTION
Front-matter is not needed any more as all metadata is now in `posts.yml`. This change should have been part of #2860.

Fixes #2908