### PR TITLE
Ready for Swift 6 scaffolding

### DIFF
--- a/Sources/App/Controllers/ReadyForSwift6Controller.swift
+++ b/Sources/App/Controllers/ReadyForSwift6Controller.swift
@@ -1,0 +1,24 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Vapor
+import Plot
+
+enum ReadyForSwift6Controller {
+
+    static func show(req: Request) async throws -> HTML {
+        let model = ReadyForSwift6Show.Model()
+        return ReadyForSwift6Show.View(path: req.url.string, model: model).document()
+    }
+}

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -123,6 +123,7 @@ enum SiteURL: Resourceable {
     case packageCollection(_ owner: Parameter<String>)
     case packageCollections
     case privacy
+    case readyForSwift6
     case rssPackages
     case rssReleases
     case search
@@ -212,6 +213,9 @@ enum SiteURL: Resourceable {
             case .privacy:
                 return "privacy"
 
+            case .readyForSwift6:
+                return "ready-for-swift-6"
+
             case .rssPackages:
                 return "packages.rss"
 
@@ -243,8 +247,21 @@ enum SiteURL: Resourceable {
 
     var pathComponents: [PathComponent] {
         switch self {
-            case .addAPackage, .blog, .buildMonitor, .faq, .home, .packageCollections, .privacy, .rssPackages,
-                    .rssReleases, .search, .siteMapIndex, .siteMapStaticPages, .supporters, .tryInPlayground,
+            case .addAPackage,
+                    .blog,
+                    .buildMonitor,
+                    .faq,
+                    .home,
+                    .packageCollections,
+                    .privacy,
+                    .readyForSwift6,
+                    .rssPackages,
+                    .rssReleases,
+                    .search,
+                    .siteMapIndex,
+                    .siteMapStaticPages,
+                    .supporters,
+                    .tryInPlayground,
                     .validateSPIManifest:
                 return [.init(stringLiteral: path)]
 

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -314,7 +314,7 @@ class PublicPage {
 
         return .p(
             .class("announcement"),
-            .text("How many packages are compatible with Swift 6? Find out Check out which packages are  "),
+            .text("How many packages are compatible with Swift 6? Find out which packages are "),
             .a(
                 .href(SiteURL.readyForSwift6.relativeURL()),
                 .text("Ready for Swift 6")

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -309,12 +309,18 @@ class PublicPage {
     }
 
     func announcementBanner() -> Node<HTML.BodyContext> {
-        return .empty
+        guard Current.environment() == .development
+        else { return .empty }
 
-//        .p(
-//            .class("announcement"),
-//            .text("No current announcement.")
-//        )
+        return .p(
+            .class("announcement"),
+            .text("How many packages are compatible with Swift 6? Find out Check out which packages are  "),
+            .a(
+                .href(SiteURL.readyForSwift6.relativeURL()),
+                .text("Ready for Swift 6")
+            ),
+            .text("!")
+        )
     }
 
     /// Optional content that will be inserted in between the page header and the main content for the page.

--- a/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+Model.swift
+++ b/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+Model.swift
@@ -1,0 +1,20 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Plot
+
+enum ReadyForSwift6Show {
+    struct Model {
+    }
+}

--- a/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
+++ b/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
@@ -1,0 +1,47 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Plot
+
+extension ReadyForSwift6Show {
+    class View: PublicPage {
+        let model: Model
+
+        init(path: String, model: Model) {
+            self.model = model
+            super.init(path: path)
+        }
+
+        override func pageTitle() -> String? {
+            return "Ready for Swift 6"
+        }
+
+        override func breadcrumbs() -> [Breadcrumb] {
+            [
+                Breadcrumb(title: "Home", url: SiteURL.home.relativeURL()),
+                Breadcrumb(title: "Ready for Swift 6")
+            ]
+        }
+
+        override func content() -> Node<HTML.BodyContext> {
+            .div(
+                .class("supporters"),
+                .h2("Ready for Swift 6"),
+                .p(
+                    .text("A summary of what Swift 6 is and brings, links to the transition guide and other documentation, and an introduction to the charts and other information below.")
+                )
+            )
+        }
+    }
+}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -167,13 +167,17 @@ func routes(_ app: Application) throws {
 
     do {  // Supporters
         app.get(SiteURL.supporters.pathComponents, use: SupportersController.show).excludeFromOpenAPI()
-
     }
 
     do {  // spi.yml validation page
         app.get(SiteURL.validateSPIManifest.pathComponents, use: ValidateSPIManifestController.show)
             .excludeFromOpenAPI()
         app.post(SiteURL.validateSPIManifest.pathComponents, use: ValidateSPIManifestController.validate)
+            .excludeFromOpenAPI()
+    }
+
+    do { // Readu for Swift 6 reporting
+        app.get(SiteURL.readyForSwift6.pathComponents, use: ReadyForSwift6Controller.show)
             .excludeFromOpenAPI()
     }
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -176,7 +176,7 @@ func routes(_ app: Application) throws {
             .excludeFromOpenAPI()
     }
 
-    do { // Readu for Swift 6 reporting
+    if Current.environment() == .development { // Ready for Swift 6 reporting page
         app.get(SiteURL.readyForSwift6.pathComponents, use: ReadyForSwift6Controller.show)
             .excludeFromOpenAPI()
     }

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -536,6 +536,13 @@ class WebpageSnapshotTests: SnapshotTestCase {
         assertSnapshot(matching: page, as: .html)
     }
 
+    func test_ReadyForSwift6Show() throws {
+        let model = ReadyForSwift6Show.Model()
+        let page = { ReadyForSwift6Show.View(path: "", model: model).document() }
+
+        assertSnapshot(matching: page, as: .html)
+    }
+
     func test_ValidateSPIManifest_show() throws {
         let manifest = try SPIManifest.Manifest(yml: ValidateSPIManifest.Model.placeholderManifest)
         let model = ValidateSPIManifest.Model(validationResult: .valid(manifest))

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_HomeIndexView_development.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_HomeIndexView_development.1.html
@@ -56,7 +56,7 @@
         </nav>
       </div>
     </header>
-    <p class="announcement">How many packages are compatible with Swift 6? Find out Check out which packages are  
+    <p class="announcement">How many packages are compatible with Swift 6? Find out which packages are 
       <a href="/ready-for-swift-6">Ready for Swift 6</a>!
     </p>
     <section class="search home">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_HomeIndexView_development.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_HomeIndexView_development.1.html
@@ -56,6 +56,9 @@
         </nav>
       </div>
     </header>
+    <p class="announcement">How many packages are compatible with Swift 6? Find out Check out which packages are  
+      <a href="/ready-for-swift-6">Ready for Swift 6</a>!
+    </p>
     <section class="search home">
       <div class="inner">
         <h3>The place to find Swift packages.</h3>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en"><!--Version: test--><!--DB Id: db-id-->
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="UTF-8"/>
+    <meta property="og:site_name" content="The Swift Package Index"/>
+    <link rel="canonical" href="http://localhost:8080/"/>
+    <meta name="twitter:url" content="http://localhost:8080/"/>
+    <meta property="og:url" content="http://localhost:8080/"/>
+    <title>Ready for Swift 6 &ndash; Swift Package Index</title>
+    <meta name="twitter:title" content="Ready for Swift 6 &ndash; Swift Package Index"/>
+    <meta property="og:title" content="Ready for Swift 6 &ndash; Swift Package Index"/>
+    <meta name="description" content="The Swift Package Index is the place to find the best Swift packages."/>
+    <meta name="twitter:description" content="The Swift Package Index is the place to find the best Swift packages."/>
+    <meta property="og:description" content="The Swift Package Index is the place to find the best Swift packages."/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:image" content="http://localhost:8080/images/logo.png"/>
+    <meta property="og:image" content="http://localhost:8080/images/logo.png"/>
+    <link rel="shortcut icon" href="/images/logo-tiny.png" type="image/png"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index Blog" href="http://localhost:8080/blog/feed.xml"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added Packages" href="http://localhost:8080/packages.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Package Releases" href="http://localhost:8080/releases.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Package Releases" href="http://localhost:8080/releases.rss?major=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Package Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Package Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
+    <link rel="stylesheet" href="/main.css?test" data-turbolinks-track="reload"/>
+    <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
+<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+  </head>
+  <body>
+    <header>
+      <div class="inner">
+        <a href="/">
+          <h1>
+            <img alt="The Swift Package Index logo." src="/images/logo.svg"/>Swift Package Index
+          </h1>
+        </a>
+        <nav>
+          <ul>
+            <li>
+              <a class="supporters" href="/supporters">Supporters</a>
+            </li>
+            <li>
+              <a href="/add-a-package">Add a Package</a>
+            </li>
+            <li>
+              <a href="/blog">Blog</a>
+            </li>
+            <li>
+              <a href="/faq">FAQ</a>
+            </li>
+            <li class="search">
+              <form action="/search">
+                <input id="query" name="query" type="search" placeholder="Search" spellcheck="false" autocomplete="off" data-gramm="false" data-focus="false"/>
+                <button type="submit">
+                  <div title="Search"></div>
+                </button>
+              </form>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <nav class="breadcrumbs">
+      <div class="inner">
+        <ul>
+          <li>
+            <a href="/">
+              <span>Home</span>
+            </a>
+          </li>
+          <li>
+            <span>Ready for Swift 6</span>
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <main>
+      <div class="inner">
+        <div class="supporters">
+          <h2>Ready for Swift 6</h2>
+          <p>A summary of what Swift 6 is and brings, links to the transition guide and other documentation, and an introduction to the charts and other information below.</p>
+        </div>
+      </div>
+    </main>
+    <footer>
+      <div class="inner">
+        <nav>
+          <ul>
+            <li>
+              <a href="/blog">Blog</a>
+            </li>
+            <li>
+              <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a>
+            </li>
+            <li>
+              <a href="/privacy">Privacy and Cookies</a>
+            </li>
+            <li>
+              <a href="https://swiftpackageindex.statuspage.io">Uptime and System Status</a>
+            </li>
+            <li>
+              <a href="/build-monitor">Build System Monitor</a>
+            </li>
+            <li>
+              <a href="https://mas.to/@SwiftPackageIndex">Mastodon</a>
+            </li>
+          </ul>
+          <small>The Swift Package Index is entirely funded by community sponsorship. Thank you to 
+            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server#funding-and-sponsorship">all our sponsors for their generosity</a>.
+          </small>
+          <small>The Swift Package Index is operated by SPI Operations Limited, a company registered in the UK with company number 13466692.</small>
+          <a rel="me" href="https://mas.to/@SwiftPackageIndex"></a>
+          <a rel="me" href="https://mas.to/@SwiftPackageUpdates"></a>
+        </nav>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
I thought I'd do this piece by piece rather than in one huge PR. This adds the page, a basic snapshot, and an announcement on the home page (which we may want to use a different design for, but this gives us an easy link while testing).

Everything gated to dev/staging right now, so it's safe to merge.