### PR TITLE
Move doc routes to own file

### DIFF
--- a/Sources/App/routes+documentation.swift
+++ b/Sources/App/routes+documentation.swift
@@ -1,0 +1,80 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import Vapor
+
+
+func docRoutes(_ app: Application) throws {
+    // temporary, hacky docc-proxy
+    // default handlers (no ref)
+    app.get(":owner", ":repository", "documentation") {
+        try await PackageController.defaultDocumentation(req: $0, fragment: .documentation)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", "documentation", "**") {
+        try await PackageController.defaultDocumentation(req: $0, fragment: .documentation)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", "tutorials", "**") {
+        try await PackageController.defaultDocumentation(req: $0, fragment: .tutorials)
+    }.excludeFromOpenAPI()
+
+    // targeted handlers (with ref)
+    app.get(":owner", ":repository", ":reference", "documentation") {
+        try await PackageController.documentation(req: $0)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", "documentation", ":archive") {
+        try await PackageController.documentation(req: $0, fragment: .documentation)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", "documentation", ":archive", "**") {
+        try await PackageController.documentation(req: $0, fragment: .documentation)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", .fragment(.faviconIco)) {
+        try await PackageController.documentation(req: $0, fragment: .faviconIco)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", .fragment(.faviconSvg)) {
+        try await PackageController.documentation(req: $0, fragment: .faviconSvg)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", "css", "**") {
+        try await PackageController.documentation(req: $0, fragment: .css)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", "data", "**") {
+        try await PackageController.documentation(req: $0, fragment: .data)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", "images", "**") {
+        try await PackageController.documentation(req: $0, fragment: .images)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", "img", "**") {
+        try await PackageController.documentation(req: $0, fragment: .img)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", "index", "**") {
+        try await PackageController.documentation(req: $0, fragment: .index)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", "js", "**") {
+        try await PackageController.documentation(req: $0, fragment: .js)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", .fragment(.linkablePaths)) {
+        try await PackageController.documentation(req: $0, fragment: .linkablePaths)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", .fragment(.themeSettings)) {
+        try await PackageController.documentation(req: $0, fragment: .themeSettings)
+    }.excludeFromOpenAPI()
+    app.get(":owner", ":repository", ":reference", "tutorials", "**") {
+        try await PackageController.documentation(req: $0, fragment: .tutorials)
+    }.excludeFromOpenAPI()
+}
+
+
+private extension PathComponent {
+    static func fragment(_ fragment: PackageController.Fragment) -> Self { "\(fragment)" }
+}

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -54,64 +54,9 @@ func routes(_ app: Application) throws {
         }.excludeFromOpenAPI()
     }
 
+    try docRoutes(app)
+
     do {  // package pages
-        do {  // temporary, hacky docc-proxy
-            // default handlers (no ref)
-            app.get(":owner", ":repository", "documentation") {
-                try await PackageController.defaultDocumentation(req: $0, fragment: .documentation)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", "documentation", "**") {
-                try await PackageController.defaultDocumentation(req: $0, fragment: .documentation)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", "tutorials", "**") {
-                try await PackageController.defaultDocumentation(req: $0, fragment: .tutorials)
-            }.excludeFromOpenAPI()
-
-            // targeted handlers (with ref)
-            app.get(":owner", ":repository", ":reference", "documentation") {
-                try await PackageController.documentation(req: $0)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", "documentation", ":archive") {
-                try await PackageController.documentation(req: $0, fragment: .documentation)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", "documentation", ":archive", "**") {
-                try await PackageController.documentation(req: $0, fragment: .documentation)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", .fragment(.faviconIco)) {
-                try await PackageController.documentation(req: $0, fragment: .faviconIco)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", .fragment(.faviconSvg)) {
-                try await PackageController.documentation(req: $0, fragment: .faviconSvg)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", "css", "**") {
-                try await PackageController.documentation(req: $0, fragment: .css)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", "data", "**") {
-                try await PackageController.documentation(req: $0, fragment: .data)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", "images", "**") {
-                try await PackageController.documentation(req: $0, fragment: .images)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", "img", "**") {
-                try await PackageController.documentation(req: $0, fragment: .img)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", "index", "**") {
-                try await PackageController.documentation(req: $0, fragment: .index)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", "js", "**") {
-                try await PackageController.documentation(req: $0, fragment: .js)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", .fragment(.linkablePaths)) {
-                try await PackageController.documentation(req: $0, fragment: .linkablePaths)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", .fragment(.themeSettings)) {
-                try await PackageController.documentation(req: $0, fragment: .themeSettings)
-            }.excludeFromOpenAPI()
-            app.get(":owner", ":repository", ":reference", "tutorials", "**") {
-                try await PackageController.documentation(req: $0, fragment: .tutorials)
-            }.excludeFromOpenAPI()
-        }
-
         app.get(SiteURL.package(.key, .key, .none).pathComponents,
                 use: PackageController.show).excludeFromOpenAPI()
         app.get(SiteURL.package(.key, .key, .readme).pathComponents,
@@ -332,9 +277,4 @@ func routes(_ app: Application) throws {
             return promise.futureResult
         }.excludeFromOpenAPI()
     }
-}
-
-
-private extension PathComponent {
-    static func fragment(_ fragment: PackageController.Fragment) -> Self { "\(fragment)" }
 }


### PR DESCRIPTION
This is a very simple change to move all the doc routes to their own function. This is to prepare swapping them out for the new doc-rewrite-based routes on dev subsequently, like so:

```swift
    if Current.environment() == .production {
        try docRoutes(app)
    } else {
        try docRoutesDev(app)
    }
```