### PR TITLE
Distinct group names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       interval: "weekly"
       time: "02:00"
     groups:
-      dependencies:
+      gh-dependencies:
         patterns:
           - "*"
   - package-ecosystem: "swift"
@@ -33,10 +33,10 @@ updates:
     commit-message:
       prefix: "Swift:"
     schedule:
-      interval: "weekly"
+      interval: "daily"
       time: "02:00"
     groups:
-      dependencies:
+      swift-dependencies:
         patterns:
           - "*"
   - package-ecosystem: "npm"
@@ -47,7 +47,7 @@ updates:
       interval: "weekly"
       time: "02:00"
     groups:
-      dependencies:
+      npm-dependencies:
         patterns:
           - "*"
     ignore:


### PR DESCRIPTION
Apparently it's still working, just not for us: https://github.com/vapor/toolbox/pull/454

The only obvious difference I see in the yml file is that we're using the same group name across all three categories. Perhaps they're suddenly conflicting and npm "wins" the race?

There doesn't seem to be a way to test this on a branch, so this is making the change and running the Swift check every day for now.