### PR TITLE
Convert project to the modern Vapor entrypoint

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@ let package = Package(
         .macOS(.v13)
     ],
     products: [
+        .executable(name: "Run", targets: ["App"]),
         .library(name: "Authentication", targets: ["Authentication"]),
         .library(name: "S3Store", targets: ["S3Store"]),
     ],
@@ -48,8 +49,7 @@ let package = Package(
         .package(url: "https://github.com/vapor/vapor.git", from: "4.92.1"),
     ],
     targets: [
-        .executableTarget(name: "Run", dependencies: ["App"]),
-        .target(name: "App",
+        .executableTarget(name: "App",
                 dependencies: [
                     .target(name: "Authentication"),
                     .product(name: "Ink", package: "Ink"),

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -17,7 +17,7 @@ import FluentPostgresDriver
 import Vapor
 
 @discardableResult
-public func configure(_ app: Application) throws -> String {
+public func configure(_ app: Application) async throws -> String {
     #if DEBUG && os(macOS)
     // The bundle is only loaded if /Applications/InjectionIII.app exists on the local development machine.
     // Requires InjectionIII 4.7.3 or higher to be loaded for compatibility with Package.swift files.

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -25,7 +25,7 @@ enum Entrypoint {
         defer { app.shutdown() }
         
         do {
-            try await configure(app)
+            try configure(app)
         } catch {
             app.logger.report(error: error)
             throw error

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -25,7 +25,7 @@ enum Entrypoint {
         defer { app.shutdown() }
         
         do {
-            try configure(app)
+            try await configure(app)
         } catch {
             app.logger.report(error: error)
             throw error

--- a/Sources/App/entrypoint.swift
+++ b/Sources/App/entrypoint.swift
@@ -12,44 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import App
 import Vapor
-import Dispatch
 import Logging
-
-/// This extension is temporary and can be removed once Vapor gets this support.
-private extension Vapor.Application {
-    static let baseExecutionQueue = DispatchQueue(label: "vapor.codes.entrypoint")
-
-    func runFromAsyncMainEntrypoint() async throws {
-        try await withCheckedThrowingContinuation { continuation in
-            Vapor.Application.baseExecutionQueue.async { [self] in
-                do {
-                    try self.run()
-                    continuation.resume()
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
-    }
-}
 
 @main
 enum Entrypoint {
     static func main() async throws {
         var env = try Environment.detect()
         try LoggingSystem.bootstrap(from: &env)
-
+        
         let app = Application(env)
         defer { app.shutdown() }
-
+        
         do {
-            try configure(app)
+            try await configure(app)
         } catch {
             app.logger.report(error: error)
             throw error
         }
-        try await app.runFromAsyncMainEntrypoint()
+        try await app.execute()
     }
 }

--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -22,8 +22,8 @@ import XCTest
 class QueryPerformanceTests: XCTestCase {
     var app: Application!
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    override func setUp() async throws {
+        try await super.setUp()
 
         try XCTSkipUnless(runQueryPerformanceTests)
 

--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -33,7 +33,7 @@ class QueryPerformanceTests: XCTestCase {
         self.app = Application(.staging)
         self.app.logger.logLevel = Environment.get("LOG_LEVEL")
             .flatMap(Logger.Level.init(rawValue:)) ?? .warning
-        let host = try configure(app)
+        let host = try await configure(app)
 
         XCTAssert(host.hasPrefix("spi-dev-db"), "was: \(host)")
         XCTAssert(host.hasSuffix("postgres.database.azure.com"), "was: \(host)")

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -26,7 +26,7 @@ private var _schemaCreated = false
 
 func setup(_ environment: Environment, resetDb: Bool = true) async throws -> Application {
     let app = Application(environment)
-    let host = try configure(app)
+    let host = try await configure(app)
 
     // Ensure `.testing` refers to "postgres" or "localhost"
     precondition(["localhost", "postgres", "host.docker.internal"].contains(host),


### PR DESCRIPTION
Swaps out the old issue-prone `Dispatch`-based async entrypoint in favor of the newer async entrypoint now available upstream, matching the logic used by the latest version of the Vapor project template. Removes the separate `Run` target (redundant since Swift 5.7), making sure to keep the name of the final executable the same.