### PR TITLE
Fix crash

### DIFF
--- a/Sources/App/routes+documentation.swift
+++ b/Sources/App/routes+documentation.swift
@@ -108,6 +108,10 @@ private extension Parameters {
                 // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2168
                 // and https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2172
                 // for details.
+                // ⚠️ DO NOT CHANGE THE LINE AFTER THIS COMMENT WITHOUT REVIEWING ISSUE
+                // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3021
+                // AND THE FIX
+                // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/3039
                 return [archive].compacted().map { $0.lowercased() } + catchall.map { $0.lowercased() }
             case .css, .faviconIco, .faviconSvg, .images, .img, .index, .js, .linkablePaths, .themeSettings:
                 return catchall

--- a/Sources/App/routes+documentation.swift
+++ b/Sources/App/routes+documentation.swift
@@ -108,7 +108,7 @@ private extension Parameters {
                 // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2168
                 // and https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2172
                 // for details.
-                return ([archive].compacted() + catchall).map { $0.lowercased() }
+                return [archive].compacted().map { $0.lowercased() } + catchall.map { $0.lowercased() }
             case .css, .faviconIco, .faviconSvg, .images, .img, .index, .js, .linkablePaths, .themeSettings:
                 return catchall
         }


### PR DESCRIPTION
Fixes #3021 

To do:

- [x] test on Linux
- [x] test more routes (non-documentation fragment routes)
- [x] try it with a Swift 6 preview toolchain to see if that fixes the original problem, too
  - crashes the compiler (on `main`, on `doc-route-2`, and on `fix-doc-route-crash`), only tried toolchain `org.swift.600202404221a`