### PR TITLE
Give `DocumentationTarget` references some type safety

### DIFF
--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -465,7 +465,7 @@ extension PackageController {
     static func canonicalDocumentationUrl(from url: String,
                                           owner: String,
                                           repository: String,
-                                          docVersion: DocRoute.DocVersion,
+                                          docVersion: DocVersion,
                                           toTarget target: DocumentationTarget) -> String? {
         // It's important to use `docVersion.reference` here to make sure we match with true reference urls and not ~
         let urlPrefix = "/\(owner)/\(repository)/\(docVersion.reference.pathEncoded)/"

--- a/Sources/App/Core/CurrentReferenceCache.swift
+++ b/Sources/App/Core/CurrentReferenceCache.swift
@@ -1,13 +1,13 @@
 import Cache
 
 
-typealias CurrentReferenceCache = ExpiringCache<String, DocumentationTarget.Reference>
+typealias CurrentReferenceCache = ExpiringCache<String, String>
 
 
 extension CurrentReferenceCache {
     static let live = CurrentReferenceCache(duration: .minutes(5))
 
-    subscript(owner owner: String, repository repository: String) -> DocumentationTarget.Reference? {
+    subscript(owner owner: String, repository repository: String) -> String? {
         get {
             let key = "\(owner)/\(repository)".lowercased()
             return self[key]

--- a/Sources/App/Core/CurrentReferenceCache.swift
+++ b/Sources/App/Core/CurrentReferenceCache.swift
@@ -1,13 +1,13 @@
 import Cache
 
 
-typealias CurrentReferenceCache = ExpiringCache<String, String>
+typealias CurrentReferenceCache = ExpiringCache<String, DocumentationTarget.Reference>
 
 
 extension CurrentReferenceCache {
     static let live = CurrentReferenceCache(duration: .minutes(5))
 
-    subscript(owner owner: String, repository repository: String) -> String? {
+    subscript(owner owner: String, repository repository: String) -> DocumentationTarget.Reference? {
         get {
             let key = "\(owner)/\(repository)".lowercased()
             return self[key]

--- a/Sources/App/Core/DocRoute.swift
+++ b/Sources/App/Core/DocRoute.swift
@@ -22,38 +22,6 @@ struct DocRoute: Equatable {
 
     var contentType: String { fragment.contentType }
 
-    enum DocVersion: Codable, CustomStringConvertible, Equatable {
-        case current(referencing: String? = nil)
-        case reference(String)
-
-        var description: String {
-            switch self {
-                case .current:
-                    return String.current
-                case .reference(let string):
-                    return string
-            }
-        }
-
-        var reference: String {
-            switch self {
-                case .current(.none):
-                    return String.current
-                case .current(.some(let reference)):
-                    return reference
-                case .reference(let reference):
-                    return reference
-            }
-        }
-
-        var pathEncoded: String {
-            switch self {
-                case .current: String.current
-                case .reference( let reference): reference.pathEncoded
-            }
-        }
-    }
-
     enum Fragment: String, CustomStringConvertible {
         case css
         case data

--- a/Sources/App/Core/DocRoute.swift
+++ b/Sources/App/Core/DocRoute.swift
@@ -29,7 +29,7 @@ struct DocRoute: Equatable {
         var description: String {
             switch self {
                 case .current:
-                    return "~"
+                    return String.current
                 case .reference(let string):
                     return string
             }

--- a/Sources/App/Core/DocRoute.swift
+++ b/Sources/App/Core/DocRoute.swift
@@ -22,8 +22,8 @@ struct DocRoute: Equatable {
 
     var contentType: String { fragment.contentType }
 
-    enum DocVersion: CustomStringConvertible, Equatable {
-        case current(referencing: String)
+    enum DocVersion: Codable, CustomStringConvertible, Equatable {
+        case current(referencing: String? = nil)
         case reference(String)
 
         var description: String {
@@ -37,10 +37,19 @@ struct DocRoute: Equatable {
 
         var reference: String {
             switch self {
-                case .current(let reference):
+                case .current(.none):
+                    return String.current
+                case .current(.some(let reference)):
                     return reference
                 case .reference(let reference):
                     return reference
+            }
+        }
+
+        var pathEncoded: String {
+            switch self {
+                case .current: String.current
+                case .reference( let reference): reference.pathEncoded
             }
         }
     }

--- a/Sources/App/Core/DocVersion.swift
+++ b/Sources/App/Core/DocVersion.swift
@@ -1,0 +1,49 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+enum DocVersion: Codable, Equatable {
+    case current(referencing: String? = nil)
+    case reference(String)
+
+    var reference: String {
+        switch self {
+            case .current(.none):
+                return String.current
+            case .current(.some(let reference)):
+                return reference
+            case .reference(let reference):
+                return reference
+        }
+    }
+
+    var pathEncoded: String {
+        switch self {
+            case .current: String.current
+            case .reference( let reference): reference.pathEncoded
+        }
+    }
+}
+
+
+extension DocVersion: CustomStringConvertible {
+    var description: String {
+        switch self {
+            case .current:
+                return String.current
+            case .reference(let string):
+                return string
+        }
+    }
+}

--- a/Sources/App/Core/DocumentationTarget.swift
+++ b/Sources/App/Core/DocumentationTarget.swift
@@ -20,8 +20,8 @@ enum DocumentationTarget: Equatable, Codable {
     case `internal`(reference: Reference, archive: String)
 
     enum Reference: Equatable, Codable {
-        case canonical
-        case named(ref: String)
+        case current
+        case reference(String)
     }
 
     /// Fetch DocumentationTarget for a given package.
@@ -97,20 +97,20 @@ extension DocumentationTarget {
     }
 }
 
-extension DocumentationTarget.Reference {
-    var pathEncoded: String {
+extension DocumentationTarget.Reference: CustomStringConvertible {
+    var description: String {
         switch self {
-            case .canonical: String.current
-            case .named(ref: let reference): reference.pathEncoded
+            case .current: String.current
+            case .reference( let reference): reference
         }
     }
 }
 
-extension DocumentationTarget.Reference: CustomStringConvertible {
-    var description: String {
+extension DocumentationTarget.Reference {
+    var pathEncoded: String {
         switch self {
-            case .canonical: String.current
-            case .named(ref: let reference): reference
+            case .current: String.current
+            case .reference( let reference): reference.pathEncoded
         }
     }
 }

--- a/Sources/App/Core/DocumentationTarget.swift
+++ b/Sources/App/Core/DocumentationTarget.swift
@@ -17,7 +17,7 @@ import Fluent
 
 enum DocumentationTarget: Equatable, Codable {
     case external(url: String)
-    case `internal`(docVersion: DocRoute.DocVersion, archive: String)
+    case `internal`(docVersion: DocVersion, archive: String)
 
     /// Fetch DocumentationTarget for a given package.
     /// - Parameters:
@@ -58,7 +58,7 @@ enum DocumentationTarget: Equatable, Codable {
     ///   - repository: Repository name
     ///   - reference: Version reference
     /// - Returns: DocumentationTarget or nil
-    static func query(on database: Database, owner: String, repository: String, docVersion: DocRoute.DocVersion) async throws -> Self? {
+    static func query(on database: Database, owner: String, repository: String, docVersion: DocVersion) async throws -> Self? {
         let archive = try await Joined3<Version, Package, Repository>
             .query(on: database,
                    join: \Version.$package.$id == \Package.$id, method: .inner,
@@ -82,7 +82,7 @@ enum DocumentationTarget: Equatable, Codable {
 
 
 extension DocumentationTarget {
-    var `internal`: (docVersion: DocRoute.DocVersion, archive: String)? {
+    var `internal`: (docVersion: DocVersion, archive: String)? {
         switch self {
             case .external:
                 return nil

--- a/Sources/App/Core/DocumentationTarget.swift
+++ b/Sources/App/Core/DocumentationTarget.swift
@@ -17,7 +17,12 @@ import Fluent
 
 enum DocumentationTarget: Equatable, Codable {
     case external(url: String)
-    case `internal`(reference: String, archive: String)
+    case `internal`(reference: Reference, archive: String)
+
+    enum Reference: Equatable, Codable {
+        case canonical
+        case named(ref: String)
+    }
 
     /// Fetch DocumentationTarget for a given package.
     /// - Parameters:
@@ -75,19 +80,37 @@ enum DocumentationTarget: Equatable, Codable {
             .flatMap { $0.model.docArchives?.first?.name }
 
         return archive.map {
-            .internal(reference: "\(reference)", archive: $0)
+            .internal(reference: reference, archive: $0)
         }
     }
 }
 
 
 extension DocumentationTarget {
-    var `internal`: (reference: String, archive: String)? {
+    var `internal`: (reference: Reference, archive: String)? {
         switch self {
             case .external:
                 return nil
             case .internal(let reference, let archive):
                 return (reference, archive)
+        }
+    }
+}
+
+extension DocumentationTarget.Reference {
+    var pathEncoded: String {
+        switch self {
+            case .canonical: String.current
+            case .named(ref: let reference): reference.pathEncoded
+        }
+    }
+}
+
+extension DocumentationTarget.Reference: CustomStringConvertible {
+    var description: String {
+        switch self {
+            case .canonical: String.current
+            case .named(ref: let reference): reference
         }
     }
 }

--- a/Sources/App/Core/Extensions/Array+Version.swift
+++ b/Sources/App/Core/Extensions/Array+Version.swift
@@ -28,19 +28,19 @@ extension [Version] {
         // Ideal case is that we have a stable release documentation.
         if let version = releaseVersion,
            let archive = version.docArchives?.first?.name {
-            return .internal(reference: .reference("\(version.reference)"), archive: archive)
+            return .internal(docVersion: .reference("\(version.reference)"), archive: archive)
         }
 
         // Then a pre-release is second best.
         if let version = preReleaseVersion,
            let archive = version.docArchives?.first?.name {
-            return .internal(reference: .reference("\(version.reference)"), archive: archive)
+            return .internal(docVersion: .reference("\(version.reference)"), archive: archive)
         }
 
         // Finally, fallback to the default branch documentation.
         if let version = defaultBranchVersion,
            let archive = version.docArchives?.first?.name {
-            return .internal(reference: .reference("\(version.reference)"), archive: archive)
+            return .internal(docVersion: .reference("\(version.reference)"), archive: archive)
         }
 
         // There is no default dodcumentation.

--- a/Sources/App/Core/Extensions/Array+Version.swift
+++ b/Sources/App/Core/Extensions/Array+Version.swift
@@ -28,19 +28,19 @@ extension [Version] {
         // Ideal case is that we have a stable release documentation.
         if let version = releaseVersion,
            let archive = version.docArchives?.first?.name {
-            return .internal(reference: .named(ref: "\(version.reference)"), archive: archive)
+            return .internal(reference: .reference("\(version.reference)"), archive: archive)
         }
 
         // Then a pre-release is second best.
         if let version = preReleaseVersion,
            let archive = version.docArchives?.first?.name {
-            return .internal(reference: .named(ref: "\(version.reference)"), archive: archive)
+            return .internal(reference: .reference("\(version.reference)"), archive: archive)
         }
 
         // Finally, fallback to the default branch documentation.
         if let version = defaultBranchVersion,
            let archive = version.docArchives?.first?.name {
-            return .internal(reference: .named(ref: "\(version.reference)"), archive: archive)
+            return .internal(reference: .reference("\(version.reference)"), archive: archive)
         }
 
         // There is no default dodcumentation.

--- a/Sources/App/Core/Extensions/Array+Version.swift
+++ b/Sources/App/Core/Extensions/Array+Version.swift
@@ -28,19 +28,19 @@ extension [Version] {
         // Ideal case is that we have a stable release documentation.
         if let version = releaseVersion,
            let archive = version.docArchives?.first?.name {
-            return .internal(reference: "\(version.reference)", archive: archive)
+            return .internal(reference: .named(ref: "\(version.reference)"), archive: archive)
         }
 
         // Then a pre-release is second best.
         if let version = preReleaseVersion,
            let archive = version.docArchives?.first?.name {
-            return .internal(reference: "\(version.reference)", archive: archive)
+            return .internal(reference: .named(ref: "\(version.reference)"), archive: archive)
         }
 
         // Finally, fallback to the default branch documentation.
         if let version = defaultBranchVersion,
            let archive = version.docArchives?.first?.name {
-            return .internal(reference: "\(version.reference)", archive: archive)
+            return .internal(reference: .named(ref: "\(version.reference)"), archive: archive)
         }
 
         // There is no default dodcumentation.

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -134,7 +134,7 @@ struct DocumentationPageProcessor {
                         SiteURL.relativeURL(
                             owner: repositoryOwner,
                             repository: repositoryName,
-                            documentation: .internal(reference: version.reference,
+                            documentation: .internal(reference: .named(ref: version.reference),
                                                      archive: currentArchive.name),
                             fragment: .documentation
                         )
@@ -171,7 +171,7 @@ struct DocumentationPageProcessor {
                                     SiteURL.relativeURL(
                                         owner: repositoryOwner,
                                         repository: repositoryName,
-                                        documentation: .internal(reference: docVersion.reference, archive: archive.name),
+                                        documentation: .internal(reference: .named(ref: docVersion.reference), archive: archive.name),
                                         fragment: .documentation
                                     )
                                 ),
@@ -210,7 +210,7 @@ struct DocumentationPageProcessor {
                                                         SiteURL.relativeURL(
                                                             owner: repositoryOwner,
                                                             repository: repositoryName,
-                                                            documentation: .internal(reference: latestStable.reference,
+                                                            documentation: .internal(reference: .named(ref: latestStable.reference),
                                                                                      archive: docArchive.name),
                                                             fragment: .documentation
                                                         )

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -134,7 +134,7 @@ struct DocumentationPageProcessor {
                         SiteURL.relativeURL(
                             owner: repositoryOwner,
                             repository: repositoryName,
-                            documentation: .internal(reference: .reference( version.reference),
+                            documentation: .internal(docVersion: .reference(version.reference),
                                                      archive: currentArchive.name),
                             fragment: .documentation
                         )
@@ -171,7 +171,7 @@ struct DocumentationPageProcessor {
                                     SiteURL.relativeURL(
                                         owner: repositoryOwner,
                                         repository: repositoryName,
-                                        documentation: .internal(reference: .reference( docVersion.reference), archive: archive.name),
+                                        documentation: .internal(docVersion: docVersion, archive: archive.name),
                                         fragment: .documentation
                                     )
                                 ),
@@ -210,7 +210,7 @@ struct DocumentationPageProcessor {
                                                         SiteURL.relativeURL(
                                                             owner: repositoryOwner,
                                                             repository: repositoryName,
-                                                            documentation: .internal(reference: .reference( latestStable.reference),
+                                                            documentation: .internal(docVersion: .reference(latestStable.reference),
                                                                                      archive: docArchive.name),
                                                             fragment: .documentation
                                                         )
@@ -328,11 +328,13 @@ struct DocumentationPageProcessor {
                         let path = "/\(owner)/\(repository)/\(String.current)/".lowercased()
                         try e.html(#"var baseUrl = "\#(path)""#)
                     }
-                    let fullyQualifiedPrefix = "/\(owner)/\(repository)/\(reference)".lowercased()
-                    if value == #"var baseUrl = "\#(fullyQualifiedPrefix)/""# {
-                        //   /a/b/1.2.3 -> /a/b/~   (current)
-                        let path = "/\(owner)/\(repository)/\(String.current)/".lowercased()
-                        try e.html(#"var baseUrl = "\#(path)""#)
+                    if let reference {
+                        let fullyQualifiedPrefix = "/\(owner)/\(repository)/\(reference)".lowercased()
+                        if value == #"var baseUrl = "\#(fullyQualifiedPrefix)/""# {
+                            //   /a/b/1.2.3 -> /a/b/~   (current)
+                            let path = "/\(owner)/\(repository)/\(String.current)/".lowercased()
+                            try e.html(#"var baseUrl = "\#(path)""#)
+                        }
                     }
                 }
             case .reference(let reference):
@@ -360,7 +362,7 @@ struct DocumentationPageProcessor {
                         // no /{owner}/{repo}/ prefix -> it's a dynamic base url resource, i.e. a "/" resource
                         //   / -> /a/b/~            (current)
                         try e.attr(attribute, "/\(owner)/\(repository)/\(String.current)\(value)".lowercased())
-                    } else {
+                    } else if let reference {
                         let fullyQualifiedPrefix = "/\(owner)/\(repository)/\(reference)".lowercased()
                         if value.lowercased().hasPrefix(fullyQualifiedPrefix) {
                             // matches expected fully qualified resource path

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -134,7 +134,7 @@ struct DocumentationPageProcessor {
                         SiteURL.relativeURL(
                             owner: repositoryOwner,
                             repository: repositoryName,
-                            documentation: .internal(reference: .named(ref: version.reference),
+                            documentation: .internal(reference: .reference( version.reference),
                                                      archive: currentArchive.name),
                             fragment: .documentation
                         )
@@ -171,7 +171,7 @@ struct DocumentationPageProcessor {
                                     SiteURL.relativeURL(
                                         owner: repositoryOwner,
                                         repository: repositoryName,
-                                        documentation: .internal(reference: .named(ref: docVersion.reference), archive: archive.name),
+                                        documentation: .internal(reference: .reference( docVersion.reference), archive: archive.name),
                                         fragment: .documentation
                                     )
                                 ),
@@ -210,7 +210,7 @@ struct DocumentationPageProcessor {
                                                         SiteURL.relativeURL(
                                                             owner: repositoryOwner,
                                                             repository: repositoryName,
-                                                            documentation: .internal(reference: .named(ref: latestStable.reference),
+                                                            documentation: .internal(reference: .reference( latestStable.reference),
                                                                                      archive: docArchive.name),
                                                             fragment: .documentation
                                                         )

--- a/Sources/App/Views/DocumentationPageProcessor.swift
+++ b/Sources/App/Views/DocumentationPageProcessor.swift
@@ -22,7 +22,7 @@ struct DocumentationPageProcessor {
     let repositoryOwnerName: String
     let repositoryName: String
     let packageName: String
-    let docVersion: DocRoute.DocVersion
+    let docVersion: DocVersion
     let referenceLatest: Version.Kind?
     let referenceKind: Version.Kind
     let canonicalUrl: String?
@@ -49,7 +49,7 @@ struct DocumentationPageProcessor {
           repositoryOwnerName: String,
           repositoryName: String,
           packageName: String,
-          docVersion: DocRoute.DocVersion,
+          docVersion: DocVersion,
           referenceLatest: Version.Kind?,
           referenceKind: Version.Kind,
           canonicalUrl: String?,
@@ -308,13 +308,13 @@ struct DocumentationPageProcessor {
         )
     }
 
-    static func rewriteBaseUrls(document: SwiftSoup.Document, owner: String, repository: String, docVersion: DocRoute.DocVersion) throws {
+    static func rewriteBaseUrls(document: SwiftSoup.Document, owner: String, repository: String, docVersion: DocVersion) throws {
         try rewriteScriptBaseUrl(document: document, owner: owner, repository: repository, docVersion: docVersion)
         try rewriteAttribute("href", document: document, owner: owner, repository: repository, docVersion: docVersion)
         try rewriteAttribute("src", document: document, owner: owner, repository: repository, docVersion: docVersion)
     }
 
-    static func rewriteScriptBaseUrl(document: SwiftSoup.Document, owner: String, repository: String, docVersion: DocRoute.DocVersion) throws {
+    static func rewriteScriptBaseUrl(document: SwiftSoup.Document, owner: String, repository: String, docVersion: DocVersion) throws {
         // Possible rewrite strategies
         //   / -> /a/b/1.2.3        (toReference)
         //   / -> /a/b/~            (current)
@@ -349,7 +349,7 @@ struct DocumentationPageProcessor {
         }
     }
 
-    static func rewriteAttribute(_ attribute: String, document: SwiftSoup.Document, owner: String, repository: String, docVersion: DocRoute.DocVersion) throws {
+    static func rewriteAttribute(_ attribute: String, document: SwiftSoup.Document, owner: String, repository: String, docVersion: DocVersion) throws {
         // Possible rewrite strategies
         //   / -> /a/b/1.2.3        (toReference)
         //   / -> /a/b/~            (current)

--- a/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
+++ b/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
@@ -57,7 +57,7 @@ enum MaintainerInfoIndex {
         static func spiManifestCommonUseCasesDocLink(_ anchor: Anchor) -> String {
             SiteURL.relativeURL(owner: "SwiftPackageIndex",
                                 repository: "SPIManifest",
-                                documentation: .internal(reference: .current, archive: "spimanifest"),
+                                documentation: .internal(reference: .canonical, archive: "spimanifest"),
                                 fragment: .documentation,
                                 path: "spimanifest/commonusecases#\(anchor)")
         }
@@ -65,7 +65,7 @@ enum MaintainerInfoIndex {
         static func spiManifestDocLink() -> String {
             SiteURL.relativeURL(owner: "SwiftPackageIndex",
                                 repository: "SPIManifest",
-                                documentation: .internal(reference: .current, archive: "spimanifest"),
+                                documentation: .internal(reference: .canonical, archive: "spimanifest"),
                                 fragment: .documentation)
         }
 

--- a/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
+++ b/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
@@ -57,7 +57,7 @@ enum MaintainerInfoIndex {
         static func spiManifestCommonUseCasesDocLink(_ anchor: Anchor) -> String {
             SiteURL.relativeURL(owner: "SwiftPackageIndex",
                                 repository: "SPIManifest",
-                                documentation: .internal(reference: .canonical, archive: "spimanifest"),
+                                documentation: .internal(reference: .current, archive: "spimanifest"),
                                 fragment: .documentation,
                                 path: "spimanifest/commonusecases#\(anchor)")
         }
@@ -65,7 +65,7 @@ enum MaintainerInfoIndex {
         static func spiManifestDocLink() -> String {
             SiteURL.relativeURL(owner: "SwiftPackageIndex",
                                 repository: "SPIManifest",
-                                documentation: .internal(reference: .canonical, archive: "spimanifest"),
+                                documentation: .internal(reference: .current, archive: "spimanifest"),
                                 fragment: .documentation)
         }
 

--- a/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
+++ b/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
@@ -57,7 +57,7 @@ enum MaintainerInfoIndex {
         static func spiManifestCommonUseCasesDocLink(_ anchor: Anchor) -> String {
             SiteURL.relativeURL(owner: "SwiftPackageIndex",
                                 repository: "SPIManifest",
-                                documentation: .internal(reference: .current, archive: "spimanifest"),
+                                documentation: .internal(docVersion: .current(), archive: "spimanifest"),
                                 fragment: .documentation,
                                 path: "spimanifest/commonusecases#\(anchor)")
         }
@@ -65,7 +65,7 @@ enum MaintainerInfoIndex {
         static func spiManifestDocLink() -> String {
             SiteURL.relativeURL(owner: "SwiftPackageIndex",
                                 repository: "SPIManifest",
-                                documentation: .internal(reference: .current, archive: "spimanifest"),
+                                documentation: .internal(docVersion: .current(), archive: "spimanifest"),
                                 fragment: .documentation)
         }
 

--- a/Sources/App/routes+documentation.swift
+++ b/Sources/App/routes+documentation.swift
@@ -162,17 +162,15 @@ extension Request {
 
         let docVersion = try await { () -> DocRoute.DocVersion in
             if reference == String.current {
-                if let ref = Current.currentReferenceCache()?[owner: owner, repository: repository],
-                   case .named(let namedRef) = ref {
-                    return .current(referencing: namedRef)
+                if let ref = Current.currentReferenceCache()?[owner: owner, repository: repository] {
+                    return .current(referencing: ref)
                 }
 
-                guard let params = try await DocumentationTarget.query(on: db, owner: owner, repository: repository)?.internal,
-                      case .named(let paramsReference) = params.reference
+                guard let params = try await DocumentationTarget.query(on: db, owner: owner, repository: repository)?.internal
                 else { throw Abort(.notFound) }
 
-                Current.currentReferenceCache()?[owner: owner, repository: repository] = params.reference
-                return .current(referencing: paramsReference)
+                Current.currentReferenceCache()?[owner: owner, repository: repository] = "\(params.reference)"
+                return .current(referencing: "\(params.reference)")
             } else {
                 return .reference(reference)
             }

--- a/Sources/App/routes+documentation.swift
+++ b/Sources/App/routes+documentation.swift
@@ -140,7 +140,7 @@ extension Request {
                     target = try await DocumentationTarget.query(on: db, owner: owner, repository: repository)
                 } else {
                     target = try await DocumentationTarget.query(on: db, owner: owner, repository: repository,
-                                                                 reference: .named(ref: ref))
+                                                                 reference: .reference( ref))
                 }
                 
             case .none:

--- a/Sources/App/routes+documentation.swift
+++ b/Sources/App/routes+documentation.swift
@@ -160,7 +160,7 @@ extension Request {
         if fragment.requiresArchive && archive == nil { throw Abort(.badRequest) }
         let pathElements = parameters.pathElements(for: fragment, archive: archive)
 
-        let docVersion = try await { () -> DocRoute.DocVersion in
+        let docVersion = try await { () -> DocVersion in
             if reference == String.current {
                 if let ref = Current.currentReferenceCache()?[owner: owner, repository: repository] {
                     return .current(referencing: ref)

--- a/Sources/App/routes+documentation.swift
+++ b/Sources/App/routes+documentation.swift
@@ -140,7 +140,7 @@ extension Request {
                     target = try await DocumentationTarget.query(on: db, owner: owner, repository: repository)
                 } else {
                     target = try await DocumentationTarget.query(on: db, owner: owner, repository: repository,
-                                                                 reference: .reference( ref))
+                                                                 docVersion: .reference(ref))
                 }
                 
             case .none:
@@ -169,8 +169,8 @@ extension Request {
                 guard let params = try await DocumentationTarget.query(on: db, owner: owner, repository: repository)?.internal
                 else { throw Abort(.notFound) }
 
-                Current.currentReferenceCache()?[owner: owner, repository: repository] = "\(params.reference)"
-                return .current(referencing: "\(params.reference)")
+                Current.currentReferenceCache()?[owner: owner, repository: repository] = "\(params.docVersion)"
+                return .current(referencing: "\(params.docVersion)")
             } else {
                 return .reference(reference)
             }

--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -86,7 +86,7 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                                        weightedKeywords: []))
 
         // validate
-        XCTAssertEqual(model.documentationTarget, .internal(reference: "main", archive: "archive1"))
+        XCTAssertEqual(model.documentationTarget, .internal(reference: .named(ref: "main"), archive: "archive1"))
     }
 
     func test_init_external_documentation() async throws {

--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -86,7 +86,7 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                                        weightedKeywords: []))
 
         // validate
-        XCTAssertEqual(model.documentationTarget, .internal(reference: .reference("main"), archive: "archive1"))
+        XCTAssertEqual(model.documentationTarget, .internal(docVersion: .reference("main"), archive: "archive1"))
     }
 
     func test_init_external_documentation() async throws {

--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -86,7 +86,7 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                                        weightedKeywords: []))
 
         // validate
-        XCTAssertEqual(model.documentationTarget, .internal(reference: .named(ref: "main"), archive: "archive1"))
+        XCTAssertEqual(model.documentationTarget, .internal(reference: .reference("main"), archive: "archive1"))
     }
 
     func test_init_external_documentation() async throws {

--- a/Tests/AppTests/ArrayExtensionTests.swift
+++ b/Tests/AppTests/ArrayExtensionTests.swift
@@ -167,7 +167,7 @@ class ArrayExtensionTests: XCTestCase {
                 Version(id: .id0, latest: .release, reference: .tag(1, 2, 3),
                         docArchives: [.init(name: "foo", title: "Foo")]),
             ].canonicalDocumentationTarget(),
-            .internal(reference: "1.2.3", archive: "foo")
+            .internal(reference: .named(ref: "1.2.3"), archive: "foo")
         )
 
         // Test default branch fallback
@@ -177,7 +177,7 @@ class ArrayExtensionTests: XCTestCase {
                 Version(id: .id0, latest: .defaultBranch, reference: .branch("main"),
                         docArchives: [.init(name: "foo", title: "Foo")]),
             ].canonicalDocumentationTarget(),
-            .internal(reference: "main", archive: "foo")
+            .internal(reference: .named(ref: "main"), archive: "foo")
         )
 
         // No default branch version available

--- a/Tests/AppTests/ArrayExtensionTests.swift
+++ b/Tests/AppTests/ArrayExtensionTests.swift
@@ -167,7 +167,7 @@ class ArrayExtensionTests: XCTestCase {
                 Version(id: .id0, latest: .release, reference: .tag(1, 2, 3),
                         docArchives: [.init(name: "foo", title: "Foo")]),
             ].canonicalDocumentationTarget(),
-            .internal(reference: .reference("1.2.3"), archive: "foo")
+            .internal(docVersion: .reference("1.2.3"), archive: "foo")
         )
 
         // Test default branch fallback
@@ -177,7 +177,7 @@ class ArrayExtensionTests: XCTestCase {
                 Version(id: .id0, latest: .defaultBranch, reference: .branch("main"),
                         docArchives: [.init(name: "foo", title: "Foo")]),
             ].canonicalDocumentationTarget(),
-            .internal(reference: .reference("main"), archive: "foo")
+            .internal(docVersion: .reference("main"), archive: "foo")
         )
 
         // No default branch version available

--- a/Tests/AppTests/ArrayExtensionTests.swift
+++ b/Tests/AppTests/ArrayExtensionTests.swift
@@ -167,7 +167,7 @@ class ArrayExtensionTests: XCTestCase {
                 Version(id: .id0, latest: .release, reference: .tag(1, 2, 3),
                         docArchives: [.init(name: "foo", title: "Foo")]),
             ].canonicalDocumentationTarget(),
-            .internal(reference: .named(ref: "1.2.3"), archive: "foo")
+            .internal(reference: .reference("1.2.3"), archive: "foo")
         )
 
         // Test default branch fallback
@@ -177,7 +177,7 @@ class ArrayExtensionTests: XCTestCase {
                 Version(id: .id0, latest: .defaultBranch, reference: .branch("main"),
                         docArchives: [.init(name: "foo", title: "Foo")]),
             ].canonicalDocumentationTarget(),
-            .internal(reference: .named(ref: "main"), archive: "foo")
+            .internal(reference: .reference("main"), archive: "foo")
         )
 
         // No default branch version available

--- a/Tests/AppTests/ArrayVersionExtensionTests.swift
+++ b/Tests/AppTests/ArrayVersionExtensionTests.swift
@@ -40,7 +40,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .reference("main"), archive: "foo"))
+                           .internal(docVersion: .reference("main"), archive: "foo"))
         }
 
         do {
@@ -61,7 +61,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .reference("main"), archive: "foo"))
+                           .internal(docVersion: .reference("main"), archive: "foo"))
         }
 
         do {
@@ -82,7 +82,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .reference("1.2.3"), archive: "foo"))
+                           .internal(docVersion: .reference("1.2.3"), archive: "foo"))
         }
 
         do {
@@ -103,7 +103,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .reference("1.2.3-b1"), archive: "foo"))
+                           .internal(docVersion: .reference("1.2.3-b1"), archive: "foo"))
         }
 
         do {
@@ -127,7 +127,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .reference("1.2.3"), archive: "foo"))
+                           .internal(docVersion: .reference("1.2.3"), archive: "foo"))
         }
 
         do {
@@ -148,7 +148,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .reference("1.2.3"), archive: "foo"))
+                           .internal(docVersion: .reference("1.2.3"), archive: "foo"))
         }
 
         do {

--- a/Tests/AppTests/ArrayVersionExtensionTests.swift
+++ b/Tests/AppTests/ArrayVersionExtensionTests.swift
@@ -40,7 +40,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: "main", archive: "foo"))
+                           .internal(reference: .named(ref: "main"), archive: "foo"))
         }
 
         do {
@@ -61,7 +61,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: "main", archive: "foo"))
+                           .internal(reference: .named(ref: "main"), archive: "foo"))
         }
 
         do {
@@ -82,7 +82,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: "1.2.3", archive: "foo"))
+                           .internal(reference: .named(ref: "1.2.3"), archive: "foo"))
         }
 
         do {
@@ -103,7 +103,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: "1.2.3-b1", archive: "foo"))
+                           .internal(reference: .named(ref: "1.2.3-b1"), archive: "foo"))
         }
 
         do {
@@ -127,7 +127,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: "1.2.3", archive: "foo"))
+                           .internal(reference: .named(ref: "1.2.3"), archive: "foo"))
         }
 
         do {
@@ -148,7 +148,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: "1.2.3", archive: "foo"))
+                           .internal(reference: .named(ref: "1.2.3"), archive: "foo"))
         }
 
         do {

--- a/Tests/AppTests/ArrayVersionExtensionTests.swift
+++ b/Tests/AppTests/ArrayVersionExtensionTests.swift
@@ -40,7 +40,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .named(ref: "main"), archive: "foo"))
+                           .internal(reference: .reference("main"), archive: "foo"))
         }
 
         do {
@@ -61,7 +61,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .named(ref: "main"), archive: "foo"))
+                           .internal(reference: .reference("main"), archive: "foo"))
         }
 
         do {
@@ -82,7 +82,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .named(ref: "1.2.3"), archive: "foo"))
+                           .internal(reference: .reference("1.2.3"), archive: "foo"))
         }
 
         do {
@@ -103,7 +103,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .named(ref: "1.2.3-b1"), archive: "foo"))
+                           .internal(reference: .reference("1.2.3-b1"), archive: "foo"))
         }
 
         do {
@@ -127,7 +127,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .named(ref: "1.2.3"), archive: "foo"))
+                           .internal(reference: .reference("1.2.3"), archive: "foo"))
         }
 
         do {
@@ -148,7 +148,7 @@ class ArrayVersionExtensionTests: AppTestCase {
             ]
 
             XCTAssertEqual(versions.canonicalDocumentationTarget(),
-                           .internal(reference: .named(ref: "1.2.3"), archive: "foo"))
+                           .internal(reference: .reference("1.2.3"), archive: "foo"))
         }
 
         do {

--- a/Tests/AppTests/DocumentationTargetTests.swift
+++ b/Tests/AppTests/DocumentationTargetTests.swift
@@ -98,7 +98,7 @@ final class DocumentationTargetTests: AppTestCase {
         let res = try await DocumentationTarget.query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
-        XCTAssertEqual(res, .internal(reference: .reference("main"),
+        XCTAssertEqual(res, .internal(docVersion: .reference("main"),
                                       archive: "archive1"))
     }
 
@@ -131,7 +131,7 @@ final class DocumentationTargetTests: AppTestCase {
         let res = try await DocumentationTarget.query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
-        XCTAssertEqual(res, .internal(reference: .reference("1.0.0"),
+        XCTAssertEqual(res, .internal(docVersion: .reference("1.0.0"),
                                       archive: "archive2"))
     }
 

--- a/Tests/AppTests/DocumentationTargetTests.swift
+++ b/Tests/AppTests/DocumentationTargetTests.swift
@@ -98,7 +98,7 @@ final class DocumentationTargetTests: AppTestCase {
         let res = try await DocumentationTarget.query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
-        XCTAssertEqual(res, .internal(reference: "main",
+        XCTAssertEqual(res, .internal(reference: .named(ref: "main"),
                                       archive: "archive1"))
     }
 
@@ -131,7 +131,7 @@ final class DocumentationTargetTests: AppTestCase {
         let res = try await DocumentationTarget.query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
-        XCTAssertEqual(res, .internal(reference: "1.0.0",
+        XCTAssertEqual(res, .internal(reference: .named(ref: "1.0.0"),
                                       archive: "archive2"))
     }
 

--- a/Tests/AppTests/DocumentationTargetTests.swift
+++ b/Tests/AppTests/DocumentationTargetTests.swift
@@ -98,7 +98,7 @@ final class DocumentationTargetTests: AppTestCase {
         let res = try await DocumentationTarget.query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
-        XCTAssertEqual(res, .internal(reference: .named(ref: "main"),
+        XCTAssertEqual(res, .internal(reference: .reference("main"),
                                       archive: "archive1"))
     }
 
@@ -131,7 +131,7 @@ final class DocumentationTargetTests: AppTestCase {
         let res = try await DocumentationTarget.query(on: app.db, owner: "foo", repository: "bar")
 
         // validate
-        XCTAssertEqual(res, .internal(reference: .named(ref: "1.0.0"),
+        XCTAssertEqual(res, .internal(reference: .reference("1.0.0"),
                                       archive: "archive2"))
     }
 

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -401,28 +401,28 @@ class PackageController_routesTests: SnapshotTestCase {
                                                                  toTarget: .external(url: "https://example.com")))
 
         XCTAssertNil(PackageController.canonicalDocumentationUrl(from: "", owner: "", repository: "", docVersion: .reference(""),
-                                                                 toTarget: .internal(reference: .reference(""), archive: "")))
+                                                                 toTarget: .internal(docVersion: .reference(""), archive: "")))
 
         // There should be no canonical URL if the package owner/repo/ref prefix doesn't match even with a valid canonical target.
         XCTAssertNil(PackageController.canonicalDocumentationUrl(from: "/some/random/url/without/matching/prefix",
                                                                  owner: "owner",
                                                                  repository: "repo",
                                                                  docVersion: .reference("non-canonical-ref"),
-                                                                 toTarget: .internal(reference: .reference("canonical-ref"), archive: "archive")))
+                                                                 toTarget: .internal(docVersion: .reference("canonical-ref"), archive: "archive")))
 
         // Switching a non-canonical reference for a canonical one at the root of the documentation
         XCTAssertEqual(PackageController.canonicalDocumentationUrl(from: "/owner/repo/non-canonical-ref/documentation/archive",
                                                                    owner: "owner",
                                                                    repository: "repo",
                                                                    docVersion: .reference("non-canonical-ref"),
-                                                                   toTarget: .internal(reference: .reference("canonical-ref"), archive: "archive")),
+                                                                   toTarget: .internal(docVersion: .reference("canonical-ref"), archive: "archive")),
                        "/owner/repo/canonical-ref/documentation/archive")
 
         XCTAssertEqual(PackageController.canonicalDocumentationUrl(from: "/owner/repo/non-canonical-ref/documentation/archive/symbol:$-%",
                                                                    owner: "owner",
                                                                    repository: "repo",
                                                                    docVersion: .reference("non-canonical-ref"),
-                                                                   toTarget: .internal(reference: .reference("canonical-ref"), archive: "archive")),
+                                                                   toTarget: .internal(docVersion: .reference("canonical-ref"), archive: "archive")),
                        "/owner/repo/canonical-ref/documentation/archive/symbol:$-%")
     }
 

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -401,28 +401,28 @@ class PackageController_routesTests: SnapshotTestCase {
                                                                  toTarget: .external(url: "https://example.com")))
 
         XCTAssertNil(PackageController.canonicalDocumentationUrl(from: "", owner: "", repository: "", docVersion: .reference(""),
-                                                                 toTarget: .internal(reference: .named(ref: ""), archive: "")))
+                                                                 toTarget: .internal(reference: .reference(""), archive: "")))
 
         // There should be no canonical URL if the package owner/repo/ref prefix doesn't match even with a valid canonical target.
         XCTAssertNil(PackageController.canonicalDocumentationUrl(from: "/some/random/url/without/matching/prefix",
                                                                  owner: "owner",
                                                                  repository: "repo",
                                                                  docVersion: .reference("non-canonical-ref"),
-                                                                 toTarget: .internal(reference: .named(ref: "canonical-ref"), archive: "archive")))
+                                                                 toTarget: .internal(reference: .reference("canonical-ref"), archive: "archive")))
 
         // Switching a non-canonical reference for a canonical one at the root of the documentation
         XCTAssertEqual(PackageController.canonicalDocumentationUrl(from: "/owner/repo/non-canonical-ref/documentation/archive",
                                                                    owner: "owner",
                                                                    repository: "repo",
                                                                    docVersion: .reference("non-canonical-ref"),
-                                                                   toTarget: .internal(reference: .named(ref: "canonical-ref"), archive: "archive")),
+                                                                   toTarget: .internal(reference: .reference("canonical-ref"), archive: "archive")),
                        "/owner/repo/canonical-ref/documentation/archive")
 
         XCTAssertEqual(PackageController.canonicalDocumentationUrl(from: "/owner/repo/non-canonical-ref/documentation/archive/symbol:$-%",
                                                                    owner: "owner",
                                                                    repository: "repo",
                                                                    docVersion: .reference("non-canonical-ref"),
-                                                                   toTarget: .internal(reference: .named(ref: "canonical-ref"), archive: "archive")),
+                                                                   toTarget: .internal(reference: .reference("canonical-ref"), archive: "archive")),
                        "/owner/repo/canonical-ref/documentation/archive/symbol:$-%")
     }
 
@@ -1437,7 +1437,7 @@ class PackageController_routesTests: SnapshotTestCase {
             XCTFail("unexpected error: \(error)")
         }
 
-        cache[owner: "owner", repository: "repo"] = .named(ref: "1.2.3")
+        cache[owner: "owner", repository: "repo"] = "1.2.3"
 
         do { // Now with the cache in place this resolves
             let route = try await req.getDocRoute(fragment: .documentation)

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -401,28 +401,28 @@ class PackageController_routesTests: SnapshotTestCase {
                                                                  toTarget: .external(url: "https://example.com")))
 
         XCTAssertNil(PackageController.canonicalDocumentationUrl(from: "", owner: "", repository: "", docVersion: .reference(""),
-                                                                 toTarget: .internal(reference: "", archive: "")))
+                                                                 toTarget: .internal(reference: .named(ref: ""), archive: "")))
 
         // There should be no canonical URL if the package owner/repo/ref prefix doesn't match even with a valid canonical target.
         XCTAssertNil(PackageController.canonicalDocumentationUrl(from: "/some/random/url/without/matching/prefix",
                                                                  owner: "owner",
                                                                  repository: "repo",
                                                                  docVersion: .reference("non-canonical-ref"),
-                                                                 toTarget: .internal(reference: "canonical-ref", archive: "archive")))
+                                                                 toTarget: .internal(reference: .named(ref: "canonical-ref"), archive: "archive")))
 
         // Switching a non-canonical reference for a canonical one at the root of the documentation
         XCTAssertEqual(PackageController.canonicalDocumentationUrl(from: "/owner/repo/non-canonical-ref/documentation/archive",
                                                                    owner: "owner",
                                                                    repository: "repo",
                                                                    docVersion: .reference("non-canonical-ref"),
-                                                                   toTarget: .internal(reference: "canonical-ref", archive: "archive")),
+                                                                   toTarget: .internal(reference: .named(ref: "canonical-ref"), archive: "archive")),
                        "/owner/repo/canonical-ref/documentation/archive")
 
         XCTAssertEqual(PackageController.canonicalDocumentationUrl(from: "/owner/repo/non-canonical-ref/documentation/archive/symbol:$-%",
                                                                    owner: "owner",
                                                                    repository: "repo",
                                                                    docVersion: .reference("non-canonical-ref"),
-                                                                   toTarget: .internal(reference: "canonical-ref", archive: "archive")),
+                                                                   toTarget: .internal(reference: .named(ref: "canonical-ref"), archive: "archive")),
                        "/owner/repo/canonical-ref/documentation/archive/symbol:$-%")
     }
 
@@ -1437,7 +1437,7 @@ class PackageController_routesTests: SnapshotTestCase {
             XCTFail("unexpected error: \(error)")
         }
 
-        cache[owner: "owner", repository: "repo"] = "1.2.3"
+        cache[owner: "owner", repository: "repo"] = .named(ref: "1.2.3")
 
         do { // Now with the cache in place this resolves
             let route = try await req.getDocRoute(fragment: .documentation)

--- a/Tests/AppTests/PackageResultTests.swift
+++ b/Tests/AppTests/PackageResultTests.swift
@@ -273,7 +273,7 @@ class PackageResultTests: AppTestCase {
                 .query(on: app.db, owner: "foo", repository: "bar1")
 
             // validate
-            XCTAssertEqual(res.canonicalDocumentationTarget(), .internal(reference: .reference("main"), archive: "foo"))
+            XCTAssertEqual(res.canonicalDocumentationTarget(), .internal(docVersion: .reference("main"), archive: "foo"))
         }
 
         do {

--- a/Tests/AppTests/PackageResultTests.swift
+++ b/Tests/AppTests/PackageResultTests.swift
@@ -273,7 +273,7 @@ class PackageResultTests: AppTestCase {
                 .query(on: app.db, owner: "foo", repository: "bar1")
 
             // validate
-            XCTAssertEqual(res.canonicalDocumentationTarget(), .internal(reference: "main", archive: "foo"))
+            XCTAssertEqual(res.canonicalDocumentationTarget(), .internal(reference: .named(ref: "main"), archive: "foo"))
         }
 
         do {

--- a/Tests/AppTests/PackageResultTests.swift
+++ b/Tests/AppTests/PackageResultTests.swift
@@ -273,7 +273,7 @@ class PackageResultTests: AppTestCase {
                 .query(on: app.db, owner: "foo", repository: "bar1")
 
             // validate
-            XCTAssertEqual(res.canonicalDocumentationTarget(), .internal(reference: .named(ref: "main"), archive: "foo"))
+            XCTAssertEqual(res.canonicalDocumentationTarget(), .internal(reference: .reference("main"), archive: "foo"))
         }
 
         do {

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -176,7 +176,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     func test_PackageShowView_with_documentation_link() throws {
         var model = API.PackageController.GetRoute.Model.mock
-        model.documentationTarget = .internal(reference: .reference("main"), archive: "archive")
+        model.documentationTarget = .internal(docVersion: .reference("main"), archive: "archive")
         let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
 
         assertSnapshot(matching: page, as: .html)

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -176,7 +176,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     func test_PackageShowView_with_documentation_link() throws {
         var model = API.PackageController.GetRoute.Model.mock
-        model.documentationTarget = .internal(reference: .named(ref: "main"), archive: "archive")
+        model.documentationTarget = .internal(reference: .reference("main"), archive: "archive")
         let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
 
         assertSnapshot(matching: page, as: .html)

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -176,7 +176,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
 
     func test_PackageShowView_with_documentation_link() throws {
         var model = API.PackageController.GetRoute.Model.mock
-        model.documentationTarget = .internal(reference: "main", archive: "archive")
+        model.documentationTarget = .internal(reference: .named(ref: "main"), archive: "archive")
         let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
 
         assertSnapshot(matching: page, as: .html)


### PR DESCRIPTION
Just a little refactor. I see you did something similar in `DocRoute` @finestructure .

Ideally, we could get rid of the constant string and keep ie encapsulated. This does not do that, but it moves us a little closer.