### PR TITLE
Bring back run target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .macOS(.v13)
     ],
     products: [
-        .executable(name: "Run", targets: ["App"]),
+        .executable(name: "Run", targets: ["Run"]),
         .library(name: "Authentication", targets: ["Authentication"]),
         .library(name: "S3Store", targets: ["S3Store"]),
     ],
@@ -49,7 +49,8 @@ let package = Package(
         .package(url: "https://github.com/vapor/vapor.git", from: "4.92.1"),
     ],
     targets: [
-        .executableTarget(name: "App",
+        .executableTarget(name: "Run", dependencies: ["App"]),
+        .target(name: "App",
                 dependencies: [
                     .target(name: "Authentication"),
                     .product(name: "Ink", package: "Ink"),

--- a/Sources/Run/entrypoint.swift
+++ b/Sources/Run/entrypoint.swift
@@ -12,18 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Vapor
+import App
 import Logging
+import Vapor
 
 @main
 enum Entrypoint {
     static func main() async throws {
         var env = try Environment.detect()
         try LoggingSystem.bootstrap(from: &env)
-        
+
         let app = Application(env)
         defer { app.shutdown() }
-        
+
         do {
             try await configure(app)
         } catch {


### PR DESCRIPTION
If we can't get #3006 to work with Xcode, this should preserve the important parts of the changes in `entrypoint.swift` while fixing the Xcode issue.