### PR TITLE
Add missing space on "Information for Maintainers" page

### DIFF
--- a/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
+++ b/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
@@ -179,7 +179,7 @@ enum MaintainerInfoIndex {
                         .href(SiteURL.validateSPIManifest.relativeURL()),
                         .text("online manifest validation helper")
                     ),
-                    " to validate your ", .code(".spi.yml"), "file."
+                    " to validate your ", .code(".spi.yml"), " file."
                 ),
                 .div(
                     .id("package-score"),

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MaintainerInfoIndex.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_MaintainerInfoIndex.1.html
@@ -144,7 +144,7 @@
           <p>See the 
             <a href="/SwiftPackageIndex/SPIManifest/~/documentation/spimanifest">SPIManifest package documentation</a> for more details, or use our 
             <a href="/validate-spi-manifest">online manifest validation helper</a> to validate your 
-            <code>.spi.yml</code>file.
+            <code>.spi.yml</code> file.
           </p>
           <div id="package-score">
             <h3>Package Score</h3>


### PR DESCRIPTION
Before string rendered as "validate your .spi.ymlfile". Fix it in PR.