### PR TITLE
Show s6 readiness

### DIFF
--- a/Sources/App/Controllers/API/API+PackageController+BuildInfo.swift
+++ b/Sources/App/Controllers/API/API+PackageController+BuildInfo.swift
@@ -21,9 +21,11 @@ extension API.PackageController {
         typealias NamedBuildResults = GetRoute.Model.NamedBuildResults
         typealias PlatformResults = GetRoute.Model.PlatformResults
         typealias SwiftVersionResults = GetRoute.Model.SwiftVersionResults
+        typealias Swift6Readiness = GetRoute.Model.Swift6Readiness
 
         var platform: ModelBuildInfo<PlatformResults>?
         var swiftVersion: ModelBuildInfo<SwiftVersionResults>?
+        var swift6Readiness: Swift6Readiness
 
         static func query(on database: Database, owner: String, repository: String) async throws -> Self {
             // FIXME: move up from PackageController.BuildsRoute into API.PackageController.BuildsRoute
@@ -32,7 +34,8 @@ extension API.PackageController {
                                                                                  repository: repository)
             return Self.init(
                 platform: platformBuildInfo(builds: builds),
-                swiftVersion: swiftVersionBuildInfo(builds: builds)
+                swiftVersion: swiftVersionBuildInfo(builds: builds),
+                swift6Readiness: swift6Readiness(builds: builds)
             )
         }
 
@@ -110,6 +113,14 @@ extension API.PackageController {
                                      status5_9: v5_9.buildStatus,
                                      status5_10: v5_10.buildStatus)
                 )
+        }
+
+        static func swift6Readiness(builds: [PackageController.BuildsRoute.BuildInfo]) -> Swift6Readiness {
+            var readiness = Swift6Readiness()
+            for build in builds where build.swiftVersion == .v6_0 {
+                readiness.errorCounts[build.platform] = build.buildErrors?.numSwift6Errors
+            }
+            return readiness
         }
     }
 }

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute.swift
@@ -54,7 +54,8 @@ extension API.PackageController {
                     targets: targets.compactMap(Model.Target.init(name:targetType:)),
                     swiftVersionBuildInfo: buildInfo.swiftVersion,
                     platformBuildInfo: buildInfo.platform,
-                    weightedKeywords: weightedKeywords
+                    weightedKeywords: weightedKeywords,
+                    swift6Readiness: buildInfo.swift6Readiness
                 ),
                 let schema = API.PackageSchema(result: packageResult)
             else {

--- a/Sources/App/Controllers/API/Types+WithExample.swift
+++ b/Sources/App/Controllers/API/Types+WithExample.swift
@@ -230,7 +230,8 @@ extension API.PackageController.GetRoute.Model: WithExample {
               isArchived: false,
               defaultBranchReference: .branch("main"),
               releaseReference: .tag(1, 2, 3, "1.2.3"),
-              preReleaseReference: nil)
+              preReleaseReference: nil,
+              swift6Readiness: nil)
     }
 }
 

--- a/Sources/App/Controllers/PackageController+BuildsRoute.swift
+++ b/Sources/App/Controllers/PackageController+BuildsRoute.swift
@@ -54,6 +54,7 @@ extension PackageController {
             var platform: Build.Platform
             var status: Build.Status
             var docStatus: DocUpload.Status?
+            var buildErrors: BuildErrors?
 
             static func query(on database: Database, owner: String, repository: String) async throws -> [BuildInfo] {
                 try await Joined5<Build, Version, Package, Repository, DocUpload>
@@ -62,6 +63,7 @@ extension PackageController {
                     .field(\.$swiftVersion)
                     .field(\.$platform)
                     .field(\.$status)
+                    .field(\.$buildErrors)
                     .field(Version.self, \.$latest)
                     .field(Version.self, \.$packageName)
                     .field(Version.self, \.$reference)
@@ -79,7 +81,8 @@ extension PackageController {
                                              swiftVersion: build.swiftVersion,
                                              platform: build.platform,
                                              status: build.status,
-                                             docStatus: res.docUpload?.status)
+                                             docStatus: res.docUpload?.status,
+                                             buildErrors: build.buildErrors)
                     }
             }
         }

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -311,11 +311,12 @@ extension API.PackageController.GetRoute.Model {
 
     func dataRaceSafeListItem() -> Node<HTML.ListContext> {
         guard Current.environment() != .production else { return .empty }
-        guard let swift6Readiness, swift6Readiness.dataRaceSafety == .safe else { return .empty }
+        guard let swift6Readiness else { return .empty }
 
         return .li(
             .class("data-race-safe"),
-            .text("Safe from data races")
+            .text(swift6Readiness.text),
+            .title(swift6Readiness.title)
         )
     }
 
@@ -635,5 +636,28 @@ private extension API.PackageController.GetRoute.Model.Target.TargetType {
             case .macro: return "macros"
             case .test: return "tests"
         }
+    }
+}
+
+
+extension API.PackageController.GetRoute.Model.Swift6Readiness {
+    var text: String {
+        switch dataRaceSafety {
+            case .safe:
+                return "Safe from data races"
+            case .unsafe:
+                return "Has data race errors"
+            case .unknown:
+                return "No data race information available"
+        }
+    }
+
+    var title: String {
+        guard !errorCounts.isEmpty else { return "No data available" }
+        var lines = ["Error counts:"]
+        for platform in errorCounts.keys.sorted() {
+            lines.append("\(platform.displayName): \(errorCounts[platform].map { "\($0)" } ?? "no data")")
+        }
+        return lines.joined(separator: "\n")
     }
 }

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -310,8 +310,8 @@ extension API.PackageController.GetRoute.Model {
     }
 
     func dataRaceSafeListItem() -> Node<HTML.ListContext> {
-        guard Current.environment() != .production
-        else { return .empty }
+        guard Current.environment() != .production else { return .empty }
+        guard let swift6Readiness, swift6Readiness.dataRaceSafety == .safe else { return .empty }
 
         return .li(
             .class("data-race-safe"),

--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -41,7 +41,8 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                      targets: [],
                                                      swiftVersionBuildInfo: nil,
                                                      platformBuildInfo: nil,
-                                                     weightedKeywords: [])
+                                                     weightedKeywords: [],
+                                                     swift6Readiness: nil)
 
         // validate
         XCTAssertNotNil(m)
@@ -62,7 +63,8 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                                        targets: [],
                                                                        swiftVersionBuildInfo: nil,
                                                                        platformBuildInfo: nil,
-                                                                       weightedKeywords: []))
+                                                                       weightedKeywords: [],
+                                                                       swift6Readiness: nil))
 
         // validate
         XCTAssertEqual(model.packageIdentity, "swift-bar")
@@ -83,7 +85,8 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                                        targets: [],
                                                                        swiftVersionBuildInfo: nil,
                                                                        platformBuildInfo: nil,
-                                                                       weightedKeywords: []))
+                                                                       weightedKeywords: [],
+                                                                       swift6Readiness: nil))
 
         // validate
         XCTAssertEqual(model.documentationTarget, .internal(docVersion: .reference("main"), archive: "archive1"))
@@ -108,7 +111,8 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                                        targets: [],
                                                                        swiftVersionBuildInfo: nil,
                                                                        platformBuildInfo: nil,
-                                                                       weightedKeywords: []))
+                                                                       weightedKeywords: [],
+                                                                       swift6Readiness: nil))
 
         // validate
         XCTAssertEqual(model.documentationTarget, .external(url: "https://example.com/package/documentation"))
@@ -542,9 +546,16 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
         )
     }
 
+    func test_Swift6Readiness_dataRaceSafety() {
+        XCTAssertEqual(Swift6Readiness(errorCounts: [:]).dataRaceSafety, .unknown)
+        XCTAssertEqual(Swift6Readiness(errorCounts: [.iOS: 1]).dataRaceSafety, .unsafe)
+        XCTAssertEqual(Swift6Readiness(errorCounts: [.iOS: 1, .linux: 0]).dataRaceSafety, .safe)
+    }
+
 }
 
 
 // local typealiases / references to make tests more readable
 fileprivate typealias BuildInfo = API.PackageController.GetRoute.Model.BuildInfo
 fileprivate typealias BuildResults = API.PackageController.GetRoute.Model.SwiftVersionResults
+fileprivate typealias Swift6Readiness = API.PackageController.GetRoute.Model.Swift6Readiness

--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -552,6 +552,19 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
         XCTAssertEqual(Swift6Readiness(errorCounts: [.iOS: 1, .linux: 0]).dataRaceSafety, .safe)
     }
 
+    func test_Swift6Readiness_title() {
+        XCTAssertEqual(Swift6Readiness(errorCounts: [:]).title, "No data available")
+        XCTAssertEqual(Swift6Readiness(errorCounts: [.iOS: 1]).title, """
+            Error counts:
+            iOS: 1
+            """)
+        XCTAssertEqual(Swift6Readiness(errorCounts: [.iOS: 1, .macosSpm: 0]).title, """
+            Error counts:
+            iOS: 1
+            macOS (SPM): 0
+            """)
+    }
+
 }
 
 

--- a/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
+++ b/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
@@ -124,7 +124,8 @@ extension API.PackageController.GetRoute.Model {
             isArchived: false,
             defaultBranchReference: .branch("main"),
             releaseReference: .tag(5, 2, 0),
-            preReleaseReference: .tag(5, 3, 0, "beta.1")
+            preReleaseReference: .tag(5, 3, 0, "beta.1"),
+            swift6Readiness: nil
         )
     }
 }


### PR DESCRIPTION
I've made it so we always show the node with the S6 readiness status, not just when it's "ready" so people can always inspect the details via the tooltip.

Before taking this live on prod we should probably link to a details page rather than stick it in the tooltip but this is a quick way to get the info across.

![CleanShot 2024-05-24 at 10 13 16@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/65520/4a131f62-a010-469e-8eeb-b42e1630635e)

![CleanShot 2024-05-24 at 10 13 45@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/65520/b38d352e-92a7-4841-b64f-73b86bbe7174)

![CleanShot 2024-05-24 at 10 06 16@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/65520/caa70d03-9303-41b8-9dae-773739400aef)
