### PR TITLE
More cleanup

### DIFF
--- a/Sources/App/Controllers/API/API+PackageController+BuildInfo.swift
+++ b/Sources/App/Controllers/API/API+PackageController+BuildInfo.swift
@@ -19,7 +19,7 @@ extension API.PackageController {
     struct BuildInfo: Equatable {
         typealias ModelBuildInfo = GetRoute.Model.BuildInfo
         typealias NamedBuildResults = GetRoute.Model.NamedBuildResults
-        typealias PlatformResults = GetRoute.Model.PlatformResults
+        typealias PlatformResults = CompatibilityMatrix.PlatformCompatibility
         typealias SwiftVersionResults = GetRoute.Model.SwiftVersionResults
         typealias Swift6Readiness = GetRoute.Model.Swift6Readiness
 

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
@@ -325,6 +325,7 @@ extension API.PackageController.GetRoute.Model {
         }
     }
 
+    @available(*, deprecated, renamed: "CompatibilityMatrix.PlatformCompatibility")
     enum PlatformCompatibility: String, Codable, Comparable, CaseIterable {
         case iOS
         case linux

--- a/Sources/App/Controllers/CompatibilityMatrix.swift
+++ b/Sources/App/Controllers/CompatibilityMatrix.swift
@@ -14,6 +14,20 @@
 
 
 enum CompatibilityMatrix {
+    enum Compatibility: String, Codable, Equatable {
+        case compatible
+        case incompatible
+        case unknown
+    }
+
+    struct BuildResult<T: Codable & Equatable>: Codable, Equatable {
+        var parameter: T
+        var status: Compatibility
+    }
+}
+
+
+extension CompatibilityMatrix {
     enum Platform: String, Codable, Comparable, CaseIterable {
         // NB: case order is significant - it determines CaseInterable's allCases and is used to order entries in the matrix
         case iOS
@@ -52,16 +66,4 @@ enum CompatibilityMatrix {
             results[platform]
         }
     }
-
-    enum Compatibility: String, Codable, Equatable {
-        case compatible
-        case incompatible
-        case unknown
-    }
-
-    struct BuildResult<T: Codable & Equatable>: Codable, Equatable {
-        var parameter: T
-        var status: Compatibility
-    }
-
 }

--- a/Sources/App/Controllers/CompatibilityMatrix.swift
+++ b/Sources/App/Controllers/CompatibilityMatrix.swift
@@ -43,9 +43,9 @@ enum CompatibilityMatrix {
             // The order of this array defines the order of the platforms in the build matrix on the package page.
             // Keep this aligned with the order in Build.Platform.allActive (which is the order of the builds on
             // the BuildIndex page).
-            let all = Platform.allCases.compactMap { platform in results[platform].map { BuildResult(parameter: platform, status: $0) }  }
-            assert(all.count == Platform.allCases.count, "mismatch in CompatibilityMatrix.Platform and all platform results count")
-            return all
+            Platform.allCases.map { platform in
+                BuildResult(parameter: platform, status: results[platform] ?? .unknown)
+            }
         }
 
         subscript(platform: Platform) -> Compatibility? {

--- a/Sources/App/Controllers/CompatibilityMatrix.swift
+++ b/Sources/App/Controllers/CompatibilityMatrix.swift
@@ -1,0 +1,70 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+enum CompatibilityMatrix {
+    enum Platform: String, Codable, Comparable, CaseIterable {
+        case iOS
+        case linux
+        case macOS
+        case tvOS
+        case visionOS
+        case watchOS
+
+#warning("sort by CaseIterable instead")
+        static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+    }
+
+    struct PlatformCompatibility: Codable, Equatable {
+        var results: [Platform: Compatibility] = [:]
+
+        init(results: [Platform: Compatibility] = [:]) {
+            self.results = results
+        }
+
+        init(builds: [PackageController.BuildsRoute.BuildInfo]) {
+            for platform in Self.allPlatforms {
+                self.results[platform] = builds.filter { $0.platform.isCompatible(with:  platform) }.compatibility
+            }
+        }
+
+#warning("use Platform.allCases instead")
+        static let allPlatforms: [Platform] = [.iOS, .macOS, .visionOS, .watchOS, .tvOS, .linux]
+
+        var all: [BuildResult<Platform>] {
+            // The order of this array defines the order of the platforms in the build matrix on the package page.
+            // Keep this aligned with the order in Build.Platform.allActive (which is the order of the builds on
+            // the BuildIndex page).
+            let all = Self.allPlatforms.compactMap { platform in results[platform].map { BuildResult(parameter: platform, status: $0) }  }
+            assert(all.count == Platform.allCases.count, "mismatch in CompatibilityMatrix.Platform and all platform results count")
+            return all
+        }
+
+        subscript(platform: Platform) -> Compatibility? {
+            results[platform]
+        }
+    }
+
+    enum Compatibility: String, Codable, Equatable {
+        case compatible
+        case incompatible
+        case unknown
+    }
+
+    struct BuildResult<T: Codable & Equatable>: Codable, Equatable {
+        var parameter: T
+        var status: Compatibility
+    }
+
+}

--- a/Sources/App/Controllers/CompatibilityMatrix.swift
+++ b/Sources/App/Controllers/CompatibilityMatrix.swift
@@ -15,15 +15,15 @@
 
 enum CompatibilityMatrix {
     enum Platform: String, Codable, Comparable, CaseIterable {
+        // NB: case order is significant - it determines CaseInterable's allCases and is used to order entries in the matrix
         case iOS
-        case linux
         case macOS
-        case tvOS
         case visionOS
         case watchOS
+        case tvOS
+        case linux
 
-#warning("sort by CaseIterable instead")
-        static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+        static func <(lhs: Self, rhs: Self) -> Bool { allCases.firstIndex(of: lhs)! < allCases.firstIndex(of: rhs)! }
     }
 
     struct PlatformCompatibility: Codable, Equatable {
@@ -34,19 +34,16 @@ enum CompatibilityMatrix {
         }
 
         init(builds: [PackageController.BuildsRoute.BuildInfo]) {
-            for platform in Self.allPlatforms {
+            for platform in Platform.allCases {
                 self.results[platform] = builds.filter { $0.platform.isCompatible(with:  platform) }.compatibility
             }
         }
-
-#warning("use Platform.allCases instead")
-        static let allPlatforms: [Platform] = [.iOS, .macOS, .visionOS, .watchOS, .tvOS, .linux]
 
         var all: [BuildResult<Platform>] {
             // The order of this array defines the order of the platforms in the build matrix on the package page.
             // Keep this aligned with the order in Build.Platform.allActive (which is the order of the builds on
             // the BuildIndex page).
-            let all = Self.allPlatforms.compactMap { platform in results[platform].map { BuildResult(parameter: platform, status: $0) }  }
+            let all = Platform.allCases.compactMap { platform in results[platform].map { BuildResult(parameter: platform, status: $0) }  }
             assert(all.count == Platform.allCases.count, "mismatch in CompatibilityMatrix.Platform and all platform results count")
             return all
         }

--- a/Sources/App/Controllers/PackageController+ShowRoute.swift
+++ b/Sources/App/Controllers/PackageController+ShowRoute.swift
@@ -21,7 +21,7 @@ import Vapor
 // Ideally these would be declared "private" but we need access from tests
 
 extension Array where Element == PackageController.BuildsRoute.BuildInfo {
-    @available(*, deprecated)
+    @available(*, deprecated, renamed: "compatibility")
     var buildStatus: API.PackageController.GetRoute.Model.BuildStatus {
         guard !isEmpty else { return .unknown }
         if anySucceeded {

--- a/Sources/App/Controllers/PackageController+ShowRoute.swift
+++ b/Sources/App/Controllers/PackageController+ShowRoute.swift
@@ -21,7 +21,17 @@ import Vapor
 // Ideally these would be declared "private" but we need access from tests
 
 extension Array where Element == PackageController.BuildsRoute.BuildInfo {
+    @available(*, deprecated)
     var buildStatus: API.PackageController.GetRoute.Model.BuildStatus {
+        guard !isEmpty else { return .unknown }
+        if anySucceeded {
+            return .compatible
+        } else {
+            return anyPending ? .unknown : .incompatible
+        }
+    }
+
+    var compatibility: CompatibilityMatrix.Compatibility {
         guard !isEmpty else { return .unknown }
         if anySucceeded {
             return .compatible
@@ -49,7 +59,7 @@ extension Array where Element == PackageController.BuildsRoute.BuildInfo {
 
 
 extension Build.Platform {
-    func isCompatible(with other: API.PackageController.GetRoute.Model.PlatformCompatibility) -> Bool {
+    func isCompatible(with other: CompatibilityMatrix.Platform) -> Bool {
         switch self {
             case .iOS:
                 return other == .iOS

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -503,9 +503,32 @@ extension API.PackageController.GetRoute.Model {
         )
     }
 
+    @available(*, deprecated)
     func compatibilityListItem<T: BuildResultPresentable>(
         _ labelParagraphNode: Node<HTML.BodyContext>,
         cells: [API.PackageController.GetRoute.Model.BuildResult<T>]
+    ) -> Node<HTML.ListContext> {
+        return .li(
+            .class("row"),
+            .div(
+                .class("row-labels"),
+                labelParagraphNode
+            ),
+            // Matrix CSS should include *both* the column labels, and the column values status boxes in *every* row.
+            .div(
+                .class("column-labels"),
+                .forEach(cells) { $0.headerNode }
+            ),
+            .div(
+                .class("results"),
+                .forEach(cells) { $0.cellNode }
+            )
+        )
+    }
+
+    func compatibilityListItem<T: BuildResultPresentable>(
+        _ labelParagraphNode: Node<HTML.BodyContext>,
+        cells: [CompatibilityMatrix.BuildResult<T>]
     ) -> Node<HTML.ListContext> {
         return .li(
             .class("row"),
@@ -556,6 +579,7 @@ private extension License.Kind {
 }
 
 
+@available(*, deprecated)
 private extension API.PackageController.GetRoute.Model.BuildResult where T: BuildResultPresentable {
     var headerNode: Node<HTML.BodyContext> {
         .div(
@@ -583,8 +607,42 @@ private extension API.PackageController.GetRoute.Model.BuildResult where T: Buil
     }
 }
 
+private extension CompatibilityMatrix.BuildResult where T: BuildResultPresentable {
+    var headerNode: Node<HTML.BodyContext> {
+        .div(
+            .text(parameter.displayName),
+            .unwrap(parameter.note) { .small(.text("(\($0))")) }
+        )
+    }
 
+    var cellNode: Node<HTML.BodyContext> {
+        .div(
+            .class("\(status.cssClass)"),
+            .title(title)
+        )
+    }
+
+    var title: String {
+        switch status {
+            case .compatible:
+                return "Built successfully with \(parameter.longDisplayName)"
+            case .incompatible:
+                return "Build failed with \(parameter.longDisplayName)"
+            case .unknown:
+                return "No build information available for \(parameter.longDisplayName)"
+        }
+    }
+}
+
+
+@available(*, deprecated)
 private extension API.PackageController.GetRoute.Model.BuildStatus {
+    var cssClass: String {
+        self.rawValue
+    }
+}
+
+private extension CompatibilityMatrix.Compatibility {
     var cssClass: String {
         self.rawValue
     }

--- a/Sources/App/Views/PackageController/PlatformCompatibility+BuildResultParameter.swift
+++ b/Sources/App/Views/PackageController/PlatformCompatibility+BuildResultParameter.swift
@@ -13,7 +13,36 @@
 // limitations under the License.
 
 
+@available(*, deprecated)
 extension API.PackageController.GetRoute.Model.PlatformCompatibility: BuildResultPresentable {
+    var displayName: String {
+        switch self {
+            case .iOS:
+                return "iOS"
+            case .linux:
+                return "Linux"
+            case .macOS:
+                return "macOS"
+            case .tvOS:
+                return "tvOS"
+            case .visionOS:
+                return "visionOS"
+            case .watchOS:
+                return "watchOS"
+        }
+    }
+
+    var longDisplayName: String {
+        switch self {
+            case .macOS, .iOS, .linux, .tvOS, .visionOS, .watchOS:
+                return displayName
+        }
+    }
+
+    var note: String? { nil }
+}
+
+extension CompatibilityMatrix.Platform: BuildResultPresentable {
     var displayName: String {
         switch self {
             case .iOS:

--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -369,7 +369,7 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
     }
 
     func test_BuildInfo_Platform_compatibility() throws {
-        typealias Results = API.PackageController.GetRoute.Model.PlatformResults
+        typealias Results = CompatibilityMatrix.PlatformCompatibility
 
         do {
             let info = BuildInfo(stable: .some(.init(referenceName: "1.2.3",

--- a/Tests/AppTests/PackageController+BuildsRoute+BuildInfoTests.swift
+++ b/Tests/AppTests/PackageController+BuildsRoute+BuildInfoTests.swift
@@ -25,10 +25,10 @@ class PackageController_BuildsRoute_BuildInfoTests: AppTestCase {
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/666
         // setup
         // MUT & verification
-        XCTAssertEqual([mkBuildInfo(.ok), mkBuildInfo(.failed)].buildStatus, .compatible)
-        XCTAssertEqual([mkBuildInfo(.triggered), mkBuildInfo(.triggered)].buildStatus, .unknown)
-        XCTAssertEqual([mkBuildInfo(.failed), mkBuildInfo(.triggered)].buildStatus, .unknown)
-        XCTAssertEqual([mkBuildInfo(.ok), mkBuildInfo(.triggered)].buildStatus, .compatible)
+        XCTAssertEqual([mkBuildInfo(.ok), mkBuildInfo(.failed)].compatibility, .compatible)
+        XCTAssertEqual([mkBuildInfo(.triggered), mkBuildInfo(.triggered)].compatibility, .unknown)
+        XCTAssertEqual([mkBuildInfo(.failed), mkBuildInfo(.triggered)].compatibility, .unknown)
+        XCTAssertEqual([mkBuildInfo(.ok), mkBuildInfo(.triggered)].compatibility, .compatible)
     }
 
     func test_noneSucceeded() throws {

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -199,12 +199,12 @@ class WebpageSnapshotTests: SnapshotTestCase {
             )
         }
         do {
-            let compatible = API.PackageController.GetRoute.Model.PlatformResults(results: [.iOS: .compatible,
-                                                                                            .linux: .compatible,
-                                                                                            .macOS: .compatible,
-                                                                                            .tvOS: .compatible,
-                                                                                            .visionOS: .compatible,
-                                                                                            .watchOS: .compatible])
+            let compatible = CompatibilityMatrix.PlatformCompatibility(results: [.iOS: .compatible,
+                                                                                 .linux: .compatible,
+                                                                                 .macOS: .compatible,
+                                                                                 .tvOS: .compatible,
+                                                                                 .visionOS: .compatible,
+                                                                                 .watchOS: .compatible])
             model.platformBuildInfo = .init(
                 stable: .init(referenceName: "5.2.5", results: compatible),
                 beta: .init(referenceName: "6.0.0-b1", results: compatible),


### PR DESCRIPTION
This builds on top of #3084 and moves `API.PackageController.GetRoute.Model.PlatformResults` into a new type `CompatibilityMatrix.PlatformCompatibility`.

It also clean it up a little and marks a number of functions as deprecated that can't be removed entirely yet, because the Swift version compatibility, which hasn't received the cleanup treatment yet, relies on them.