### PR TITLE
Added a "more information" link to the data race safety metadata item

### DIFF
--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -136,7 +136,7 @@
                 background-image: var(--image-macros);
             }
 
-            li.data-race-safe {
+            li.data-race-safety {
                 grid-column-start: span 2;
                 background-image: var(--image-checkered-flag);
             }

--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -65,6 +65,11 @@
                 list-style: outside none none;
             }
 
+            li > .more-info {
+                display: block;
+                font-size: 11px;
+            }
+
             li.archived {
                 grid-column-start: span 2;
                 background-image: var(--image-warning);
@@ -104,11 +109,6 @@
                 .no-license {
                     color: var(--red-text);
                 }
-
-                #license-more-info {
-                    display: block;
-                    font-size: 11px;
-                }
             }
 
             li.has-binary-targets {
@@ -137,6 +137,7 @@
             }
 
             li.data-race-safe {
+                grid-column-start: span 2;
                 background-image: var(--image-checkered-flag);
             }
 

--- a/Resources/Markdown/docs/builds.md
+++ b/Resources/Markdown/docs/builds.md
@@ -92,6 +92,6 @@ You can [find more details in this issue](https://github.com/SwiftPackageIndex/S
 
 The Swift 6.0 compiler can test whether code is safe from data races at compile time when strict concurrency checks are enabled. The data race safety information we publish on package pages comes from metadata output by the compiler during our build process.
 
-Note that this does not affect package compatibility as shown in the compatibility matrix. A package can be fully compatible with Swift 6.0 without opting into struct concurrency mode provided it is not running in Swift 6.0 language mode. For more information on opting into Swift 6.0 language mode, [read this blog post on Swift.org](https://example.com).
+Note that this does not affect package compatibility as shown in the compatibility matrix. A package can be fully compatible with Swift 6.0 without opting into struct concurrency mode provided it is not running in Swift 6.0 language mode. For more information on opting into Swift 6.0 language mode, [read this for more information](https://example.com).
 
 

--- a/Resources/Markdown/docs/builds.md
+++ b/Resources/Markdown/docs/builds.md
@@ -90,7 +90,7 @@ You can [find more details in this issue](https://github.com/SwiftPackageIndex/S
 
 <h3 id="data-race-safety">What is data race safety and how is it tested?</h3>
 
-The Swift 6.0 compiler can test whether code is safe from data races at compile time when strict concurrency checks are enabled. The data race safety information we publish on package pages comes from metadata output by the compiler during our build process.
+The Swift 6.0 compiler can check whether code is safe from data races at compile time when strict concurrency checks are enabled. The data race safety information we publish on package pages comes from metadata output by the compiler during our build process.
 
 Note that this does not affect package compatibility as shown in the compatibility matrix. A package can be fully compatible with Swift 6.0 without opting into struct concurrency mode provided it is not running in Swift 6.0 language mode. For more information on opting into Swift 6.0 language mode, [read this for more information](https://example.com).
 

--- a/Resources/Markdown/docs/builds.md
+++ b/Resources/Markdown/docs/builds.md
@@ -15,6 +15,7 @@ description: Frequently Asked Questions about the Swift Package Index Build Syst
 - [If a build is showing failed incorrectly, how can I fix it?](#fix-false-negative)
 - [If a build is showing an error that seems unrelated to the build, how can I fix it?](#unrelated-error)
 - [How can I diagnose problems where dependencies can't be resolved?](#dependency-resolving-error)
+- [What is data race safety and how is it tested?](#data-race-safety)
 
 <h3 id="build-system">What is the Swift Package Index Build System?</h3>
 
@@ -86,3 +87,11 @@ In cases like this, Xcode cannot resolve package dependencies because of how it 
 ```
 
 You can [find more details in this issue](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1532).
+
+<h3 id="data-race-safety">What is data race safety and how is it tested?</h3>
+
+The Swift 6.0 compiler can test whether code is safe from data races at compile time when strict concurrency checks are enabled. The data race safety information we publish on package pages comes from metadata output by the compiler during our build process.
+
+Note that this does not affect package compatibility as shown in the compatibility matrix. A package can be fully compatible with Swift 6.0 without opting into struct concurrency mode provided it is not running in Swift 6.0 language mode. For more information on opting into Swift 6.0 language mode, [read this blog post on Swift.org](https://example.com).
+
+

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -97,19 +97,19 @@ extension API.PackageController.GetRoute.Model {
                     return .empty
                 case .incompatibleWithAppStore:
                     return .a(
-                        .id("license-more-info"),
+                        .class("more-info"),
                         .href(SiteURL.faq.relativeURL(anchor: "licenses")),
                         "Why might the \(license.shortName) be problematic?"
                     )
                 case .other:
                     return .a(
-                        .id("license-more-info"),
+                        .class("more-info"),
                         .href(SiteURL.faq.relativeURL(anchor: "licenses")),
                         "Why is this package's license unknown?"
                     )
                 case .none:
                     return .a(
-                        .id("license-more-info"),
+                        .class("more-info"),
                         .href(SiteURL.faq.relativeURL(anchor: "licenses")),
                         "Why should you not use unlicensed code?"
                     )
@@ -315,8 +315,15 @@ extension API.PackageController.GetRoute.Model {
 
         return .li(
             .class("data-race-safe"),
-            .text(swift6Readiness.text),
-            .title(swift6Readiness.title)
+            .span(
+                .text(swift6Readiness.text)
+            ),
+            .title(swift6Readiness.title),
+            .a(
+                .class("more-info"),
+                .href(SiteURL.docs(.builds).relativeURL(anchor: "data-race-safety")),
+                .text("What is data race safety and how is it tested?")
+            )
         )
     }
 
@@ -647,7 +654,7 @@ extension API.PackageController.GetRoute.Model.Swift6Readiness {
             case .unsafe:
                 return "Has data race errors"
             case .unknown:
-                return "No data race information available"
+                return "No data race safety information available"
         }
     }
 

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -314,7 +314,7 @@ extension API.PackageController.GetRoute.Model {
         guard let swift6Readiness else { return .empty }
 
         return .li(
-            .class("data-race-safe"),
+            .class("data-race-safety"),
             .span(
                 .text(swift6Readiness.text)
             ),
@@ -604,7 +604,7 @@ private extension API.PackageController.GetRoute.Model.Product.ProductType {
             case .plugin: return "plugins"
         }
     }
-    
+
     var singularForm: String {
         switch self {
             case .executable: return "executable"

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -163,7 +163,7 @@
                 <li class="dependencies">This package depends on 2 other packages.</li>
                 <li class="license warning">
                   <a href="https://example.com/license.html" title="GNU General Public License v3.0">GPL 3.0</a> licensed
-                  <a id="license-more-info" href="/faq#licenses">Why might the GPL 3.0 be problematic?</a>
+                  <a class="more-info" href="/faq#licenses">Why might the GPL 3.0 be problematic?</a>
                 </li>
                 <li class="stars">17 stars</li>
                 <li class="libraries">3 libraries</li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -163,7 +163,7 @@
                 <li class="dependencies">This package depends on 2 other packages.</li>
                 <li class="license error">
                   <span class="no-license">No license</span>
-                  <a id="license-more-info" href="/faq#licenses">Why should you not use unlicensed code?</a>
+                  <a class="more-info" href="/faq#licenses">Why should you not use unlicensed code?</a>
                 </li>
                 <li class="stars">17 stars</li>
                 <li class="libraries">3 libraries</li>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -163,7 +163,7 @@
                 <li class="dependencies">This package depends on 2 other packages.</li>
                 <li class="license warning">
                   <a href="https://example.com/license.html">Unknown license</a>
-                  <a id="license-more-info" href="/faq#licenses">Why is this package's license unknown?</a>
+                  <a class="more-info" href="/faq#licenses">Why is this package's license unknown?</a>
                 </li>
                 <li class="stars">17 stars</li>
                 <li class="libraries">3 libraries</li>


### PR DESCRIPTION
Not final wording, and we will need the URL of the blog post or documentation we want to link to before this goes live, but what about this as a starting point?

![Screenshot 2024-05-27 at 16 21 51@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/b0c2ef1d-ab76-4d03-9fa4-2fb909067620)

Which links to:

![Screenshot 2024-05-27 at 16 23 21@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/10d08a5a-c431-4846-ae22-842a64635d0a)
