### PR TITLE
Enable data race safety label on package pages

### DIFF
--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -310,7 +310,6 @@ extension API.PackageController.GetRoute.Model {
     }
 
     func dataRaceSafeListItem() -> Node<HTML.ListContext> {
-        guard Current.environment() != .production else { return .empty }
         guard let swift6Readiness else { return .empty }
 
         return .li(


### PR DESCRIPTION
We want this to go live with the blog post, don't we?