### PR TITLE
Remove outdated Ready for Swift 6 FAQ question

### DIFF
--- a/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
+++ b/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
@@ -70,11 +70,11 @@ extension ReadyForSwift6Show {
                 ),
                 .p(
                     .strong(.text("Q: ")),
-                    .text("What does “compatible” mean in the chart of compatible packages?")
+                    .text("What is a “data race safety error”?")
                 ),
                 .p(
                     .strong(.text("A: ")),
-                    .text("We define compatibility in the same way we do on package pages. If any build of the package completes successfully on any of our tested platforms (macOS via SwiftPM, macOS via XcodeBuild, iOS, visionOS, watchOS, tvOS, or Linux) then that build is deemed compatible with the Swift version.")
+                    .text("Swift 6 introduces complete concurrency checking, a compiler feature that checks your code for data-race safety. The number of data race safety errors reflects how many issues the compiler detected relating to these concurrency or data-race checks. The total errors chart plots the total number of these errors summed across all packages.")
                 ),
                 .hr(
                     .class("minor")
@@ -111,17 +111,6 @@ extension ReadyForSwift6Show {
                     .text("Data-race safety diagnostics are determined in different stages of the compiler. For example, type checking produces some data-race safety errors, and others are diagnosed during control-flow analysis after code generation. If type checking produces errors, the compiler will not proceed to code generation, so testing with "),
                     .code("-swift-version 6"),
                     .text(" would show fewer errors than really exist across the package ecosystem.")
-                ),
-                .hr(
-                    .class("minor")
-                ),
-                .p(
-                    .strong(.text("Q: ")),
-                    .text("What does “total concurrency errors” mean?")
-                ),
-                .p(
-                    .strong(.text("A: ")),
-                    .text("Swift 6 introduces complete concurrency checking, a compiler feature that checks your code for data-race safety. The number of concurrency errors reflects how many issues the compiler detected relating to these concurrency or data-race checks. The total errors chart plots the total number of these errors summed across all packages.")
                 ),
                 .hr(
                     .class("minor")

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
@@ -96,10 +96,10 @@
         <p>Couldn’t load chart data.</p>
         <h3 id="faq">Frequently asked questions</h3>
         <p>
-          <strong>Q: </strong>What does “compatible” mean in the chart of compatible packages?
+          <strong>Q: </strong>What is a “data race safety error”?
         </p>
         <p>
-          <strong>A: </strong>We define compatibility in the same way we do on package pages. If any build of the package completes successfully on any of our tested platforms (macOS via SwiftPM, macOS via XcodeBuild, iOS, visionOS, watchOS, tvOS, or Linux) then that build is deemed compatible with the Swift version.
+          <strong>A: </strong>Swift 6 introduces complete concurrency checking, a compiler feature that checks your code for data-race safety. The number of data race safety errors reflects how many issues the compiler detected relating to these concurrency or data-race checks. The total errors chart plots the total number of these errors summed across all packages.
         </p>
         <hr class="minor"/>
         <p>
@@ -121,13 +121,6 @@
         <p>
           <strong>A: </strong>Data-race safety diagnostics are determined in different stages of the compiler. For example, type checking produces some data-race safety errors, and others are diagnosed during control-flow analysis after code generation. If type checking produces errors, the compiler will not proceed to code generation, so testing with 
           <code>-swift-version 6</code> would show fewer errors than really exist across the package ecosystem.
-        </p>
-        <hr class="minor"/>
-        <p>
-          <strong>Q: </strong>What does “total concurrency errors” mean?
-        </p>
-        <p>
-          <strong>A: </strong>Swift 6 introduces complete concurrency checking, a compiler feature that checks your code for data-race safety. The number of concurrency errors reflects how many issues the compiler detected relating to these concurrency or data-race checks. The total errors chart plots the total number of these errors summed across all packages.
         </p>
         <hr class="minor"/>
         <p>


### PR DESCRIPTION
https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/3144#issuecomment-2175571525 made me give the FAQ another look and there was a question in there that was no longer relevant. It also needed a few language updates from the recent chart changes.