### PR TITLE
Add run 06 results

### DIFF
--- a/Resources/ChartData/rfs6-errors.json
+++ b/Resources/ChartData/rfs6-errors.json
@@ -2,31 +2,31 @@
   {
     "id" : "all",
     "name" : "All packages",
-    "total" : 3396,
+    "total" : 3395,
     "values" : [
       {
         "date" : "2024-05-04",
         "toolchainId" : "org.swift.600202404221a",
         "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-04-22 (a)",
-        "value" : 56917
+        "value" : 56911
       },
       {
         "date" : "2024-05-19",
         "toolchainId" : "org.swift.600202405141a",
         "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-14 (a)",
-        "value" : 55304
+        "value" : 55298
       },
       {
         "date" : "2024-06-02",
         "toolchainId" : "org.swift.600202405261a",
         "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-26 (a)",
-        "value" : 53456
+        "value" : 53450
       },
       {
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 18068
+        "value" : 61184
       }
     ]
   },
@@ -57,7 +57,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 631
+        "value" : 1547
       }
     ]
   },
@@ -88,7 +88,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 571
+        "value" : 597
       }
     ]
   }

--- a/Resources/ChartData/rfs6-errors.json
+++ b/Resources/ChartData/rfs6-errors.json
@@ -2,54 +2,93 @@
   {
     "id" : "all",
     "name" : "All packages",
+    "total" : 3396,
     "values" : [
       {
         "date" : "2024-05-04",
+        "toolchainId" : "org.swift.600202404221a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-04-22 (a)",
         "value" : 56917
       },
       {
         "date" : "2024-05-19",
+        "toolchainId" : "org.swift.600202405141a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-14 (a)",
         "value" : 55304
       },
       {
         "date" : "2024-06-02",
+        "toolchainId" : "org.swift.600202405261a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-26 (a)",
         "value" : 53456
+      },
+      {
+        "date" : "2024-06-18",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
+        "value" : 24433
       }
     ]
   },
   {
     "id" : "apple",
     "name" : "Apple packages",
+    "total" : 65,
     "values" : [
       {
         "date" : "2024-05-04",
+        "toolchainId" : "org.swift.600202404221a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-04-22 (a)",
         "value" : 1392
       },
       {
         "date" : "2024-05-19",
+        "toolchainId" : "org.swift.600202405141a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-14 (a)",
         "value" : 1416
       },
       {
         "date" : "2024-06-02",
+        "toolchainId" : "org.swift.600202405261a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-26 (a)",
         "value" : 1375
+      },
+      {
+        "date" : "2024-06-18",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
+        "value" : 891
       }
     ]
   },
   {
     "id" : "sswg",
     "name" : "SSWG incubated packages",
+    "total" : 32,
     "values" : [
       {
         "date" : "2024-05-04",
+        "toolchainId" : "org.swift.600202404221a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-04-22 (a)",
         "value" : 567
       },
       {
         "date" : "2024-05-19",
+        "toolchainId" : "org.swift.600202405141a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-14 (a)",
         "value" : 881
       },
       {
         "date" : "2024-06-02",
+        "toolchainId" : "org.swift.600202405261a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-26 (a)",
         "value" : 878
+      },
+      {
+        "date" : "2024-06-18",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
+        "value" : 876
       }
     ]
   }

--- a/Resources/ChartData/rfs6-errors.json
+++ b/Resources/ChartData/rfs6-errors.json
@@ -26,7 +26,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 24433
+        "value" : 18068
       }
     ]
   },
@@ -57,7 +57,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 891
+        "value" : 631
       }
     ]
   },
@@ -88,7 +88,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 876
+        "value" : 571
       }
     ]
   }

--- a/Resources/ChartData/rfs6-packages.json
+++ b/Resources/ChartData/rfs6-packages.json
@@ -26,7 +26,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 313
+        "value" : 304
       }
     ]
   },
@@ -57,7 +57,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 9
+        "value" : 8
       }
     ]
   },

--- a/Resources/ChartData/rfs6-packages.json
+++ b/Resources/ChartData/rfs6-packages.json
@@ -2,19 +2,31 @@
   {
     "id" : "all",
     "name" : "All packages",
-    "total": 3396,
+    "total" : 3396,
     "values" : [
       {
         "date" : "2024-05-04",
+        "toolchainId" : "org.swift.600202404221a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-04-22 (a)",
         "value" : 1295
       },
       {
         "date" : "2024-05-19",
+        "toolchainId" : "org.swift.600202405141a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-14 (a)",
         "value" : 1298
       },
       {
         "date" : "2024-06-02",
+        "toolchainId" : "org.swift.600202405261a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-26 (a)",
         "value" : 1359
+      },
+      {
+        "date" : "2024-06-18",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
+        "value" : 313
       }
     ]
   },
@@ -25,15 +37,27 @@
     "values" : [
       {
         "date" : "2024-05-04",
+        "toolchainId" : "org.swift.600202404221a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-04-22 (a)",
         "value" : 18
       },
       {
         "date" : "2024-05-19",
+        "toolchainId" : "org.swift.600202405141a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-14 (a)",
         "value" : 18
       },
       {
         "date" : "2024-06-02",
+        "toolchainId" : "org.swift.600202405261a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-26 (a)",
         "value" : 18
+      },
+      {
+        "date" : "2024-06-18",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
+        "value" : 9
       }
     ]
   },
@@ -44,15 +68,27 @@
     "values" : [
       {
         "date" : "2024-05-04",
+        "toolchainId" : "org.swift.600202404221a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-04-22 (a)",
         "value" : 7
       },
       {
         "date" : "2024-05-19",
+        "toolchainId" : "org.swift.600202405141a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-14 (a)",
         "value" : 6
       },
       {
         "date" : "2024-06-02",
+        "toolchainId" : "org.swift.600202405261a",
+        "toolchainLabel" : "Swift 6.0 Development Snapshot 2024-05-26 (a)",
         "value" : 7
+      },
+      {
+        "date" : "2024-06-18",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
+        "value" : 5
       }
     ]
   }

--- a/Resources/ChartData/rfs6-packages.json
+++ b/Resources/ChartData/rfs6-packages.json
@@ -2,7 +2,7 @@
   {
     "id" : "all",
     "name" : "All packages",
-    "total" : 3396,
+    "total" : 3395,
     "values" : [
       {
         "date" : "2024-05-04",
@@ -26,7 +26,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 304
+        "value" : 1477
       }
     ]
   },
@@ -57,7 +57,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 8
+        "value" : 19
       }
     ]
   },
@@ -88,7 +88,7 @@
         "date" : "2024-06-18",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 1 (16A5171c)",
-        "value" : 5
+        "value" : 8
       }
     ]
   }

--- a/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
+++ b/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
@@ -121,7 +121,7 @@ extension ReadyForSwift6Show {
                 ),
                 .p(
                     .strong(.text("A: ")),
-                    .text("We are not testing every package in the index. Instead, we are testing packages that are under some kind of active development. For this test, we define “all packages” in the chart to be any package having at least one commit to their repository in the last year. We took a snapshot of active packages on the 19th of March 2024, and the “all packages” data set includes 3,396 packages. The data set also excludes any new packages added after the 19th March.")
+                    .text("We are not testing every package in the index. Instead, we are testing packages that are under some kind of active development. For this test, we define “all packages” in the chart to be any package having at least one commit to their repository in the last year. We took a snapshot of active packages on the 19th of March 2024, and the “all packages” data set includes 3,395 packages. The data set also excludes any new packages added after the 19th March.")
                 ),
                 .hr(
                     .class("minor")

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
@@ -127,7 +127,7 @@
           <strong>Q: </strong>What packages are in the “all packages” data set?
         </p>
         <p>
-          <strong>A: </strong>We are not testing every package in the index. Instead, we are testing packages that are under some kind of active development. For this test, we define “all packages” in the chart to be any package having at least one commit to their repository in the last year. We took a snapshot of active packages on the 19th of March 2024, and the “all packages” data set includes 3,396 packages. The data set also excludes any new packages added after the 19th March.
+          <strong>A: </strong>We are not testing every package in the index. Instead, we are testing packages that are under some kind of active development. For this test, we define “all packages” in the chart to be any package having at least one commit to their repository in the last year. We took a snapshot of active packages on the 19th of March 2024, and the “all packages” data set includes 3,395 packages. The data set also excludes any new packages added after the 19th March.
         </p>
         <hr class="minor"/>
         <p>


### PR DESCRIPTION
~~Numbers are currently broken, because analysis package IDs are based on dev package ids which have diverged from prod package ids. I need to create a new package id map for production ids to fix them.~~