### PR TITLE
Add Toolchain information to the Ready for Swift 6 chart tooltip

### DIFF
--- a/FrontEnd/scripts/controllers/vega_chart_controller.js
+++ b/FrontEnd/scripts/controllers/vega_chart_controller.js
@@ -303,9 +303,6 @@ class ReadyForSwift6Chart {
                         tooltip: {
                             signal: `{ 'Value' : datum.value + ' ${this.symbolTooltipLabelType()}', 'Date' : timeFormat(datum.date, '%b %d, %Y'), 'Toolchain' : datum.toolchainId,  '' : datum.toolchainLabel}`,
                         },
-                        // {
-                        //     signal: "'Result recorded on ' + timeFormat(datum.date, '%b %d, %Y')",
-                        // }
                     },
                 },
             },

--- a/FrontEnd/scripts/controllers/vega_chart_controller.js
+++ b/FrontEnd/scripts/controllers/vega_chart_controller.js
@@ -273,6 +273,10 @@ class ReadyForSwift6Chart {
         return ''
     }
 
+    static symbolTooltipLabelType() {
+        return ''
+    }
+
     static plotMarks(dataSet) {
         return [
             {
@@ -297,8 +301,11 @@ class ReadyForSwift6Chart {
                         size: { value: 60 },
                         fill: { value: this.colorForDataSet(dataSet.id) },
                         tooltip: {
-                            signal: "timeFormat(datum.date, '%b %d, %Y') + ' - ' + datum.value",
+                            signal: `{ 'Value' : datum.value + ' ${this.symbolTooltipLabelType()}', 'Date' : timeFormat(datum.date, '%b %d, %Y'), 'Toolchain' : datum.toolchainId,  '' : datum.toolchainLabel}`,
                         },
+                        // {
+                        //     signal: "'Result recorded on ' + timeFormat(datum.date, '%b %d, %Y')",
+                        // }
                     },
                 },
             },
@@ -371,10 +378,18 @@ class CompatiblePackagesChart extends ReadyForSwift6Chart {
     static yAxisTitle() {
         return 'Number of packages with zero data race errors'
     }
+
+    static symbolTooltipLabelType() {
+        return 'packages'
+    }
 }
 
 class TotalErrorsChart extends ReadyForSwift6Chart {
     static yAxisTitle() {
         return 'Total data race errors across all packages'
+    }
+
+    static symbolTooltipLabelType() {
+        return 'errors'
     }
 }

--- a/FrontEnd/styles/vega_charts.scss
+++ b/FrontEnd/styles/vega_charts.scss
@@ -77,4 +77,8 @@ div[data-controller='vega-chart'] {
 
 #vg-tooltip-element {
     font-size: 14px;
+
+    table tr td.value {
+        max-width: inherit;
+    }
 }

--- a/Resources/ChartData/rfs6-events.json
+++ b/Resources/ChartData/rfs6-events.json
@@ -1,6 +1,6 @@
 [
     {
-        "date": "2024-06-18",
-        "value": "Xcode 16 beta 1"
+        "date": "2024-06-10",
+        "value": "Xcode 16 beta 1 released at WWDC '24"
     }
 ]


### PR DESCRIPTION
I couldn't fix the wrapping easily, unfortunately, but apart from that I think this looks good.

![Screenshot 2024-06-18 at 15 49 11@2x](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/assets/5180/c16a7566-3966-4114-86a4-3cdf9edf2162)
