### PR TITLE
Avoid redirect to migration guide

### DIFF
--- a/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
+++ b/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
@@ -43,7 +43,7 @@ extension ReadyForSwift6Show {
                 .p(
                     .text("For help migrating your project's code, see the "),
                     .a(
-                        .href("http://swift.org/migration"),
+                        .href("https://www.swift.org/migration/documentation/migrationguide/"),
                         .text("Swift 6 language mode migration guide")
                     ),
                     .text(".")

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
@@ -84,7 +84,7 @@
         <p>The Swift 6 language mode prevents data-races at compile time. When you opt into Swift 6 mode, the compiler will produce errors when your code has a risk of concurrent access, turning hard-to-debug runtime failures into compiler errors.</p>
         <p>To track the progress of the Swift package ecosystem, the Swift Package Index is running regular package compatibility checks across all packages in the index.</p>
         <p>For help migrating your project's code, see the 
-          <a href="http://swift.org/migration">Swift 6 language mode migration guide</a>.
+          <a href="https://www.swift.org/migration/documentation/migrationguide/">Swift 6 language mode migration guide</a>.
         </p>
         <h3 id="total-zero-errors">Total packages with Swift 6 zero data-race safety errors</h3>
         <p>Packages with zero data-race safety compiler diagnostics during a successful build on at least one tested platform.</p>


### PR DESCRIPTION
I'm getting a "page has moved" interstitial that can stay up as long as a second, so we may want to link to the redirect target instead.