### PR TITLE
Update Vapor entrypoint

### DIFF
--- a/Sources/Run/entrypoint.swift
+++ b/Sources/Run/entrypoint.swift
@@ -22,15 +22,16 @@ enum Entrypoint {
         var env = try Environment.detect()
         try LoggingSystem.bootstrap(from: &env)
 
-        let app = Application(env)
-        defer { app.shutdown() }
+        let app = try await Application.make(env)
 
         do {
             try await configure(app)
         } catch {
             app.logger.report(error: error)
+            try? await app.asyncShutdown()
             throw error
         }
         try await app.execute()
+        try await app.asyncShutdown()
     }
 }


### PR DESCRIPTION
As discussed, this cherry-picks the entry point update out of #3156, because we won't be able to merge that until there are compiler changes enabling the tests to run.