### PR TITLE
Stop sending runnerId label with spi_api_build_report_total metrics

### DIFF
--- a/Sources/App/Core/AppMetrics.swift
+++ b/Sources/App/Core/AppMetrics.swift
@@ -227,7 +227,6 @@ extension DimensionLabels {
     static func buildReportLabels(_ build: App.Build) -> Self {
         .init([
             ("platform", build.platform.rawValue),
-            ("runnerId", build.runnerId ?? ""),
             ("swiftVersion", "\(build.swiftVersion)"),
         ])
     }


### PR DESCRIPTION
Fixes #3181 