### PR TITLE
More swift 6 fixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:5.10
 
 // Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
 //
@@ -109,7 +109,9 @@ let package = Package(
                     ],
                     swiftSettings: swiftSettings)
     ],
-    swiftLanguageVersions: [.v6]
+    swiftLanguageVersions: [.v5]
 )
 
-var swiftSettings: [SwiftSetting] { [] }
+var swiftSettings: [SwiftSetting] { [
+    .enableExperimentalFeature("StrictConcurrency"),
+] }

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 
 // Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
 //
@@ -109,9 +109,7 @@ let package = Package(
                     ],
                     swiftSettings: swiftSettings)
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageVersions: [.v6]
 )
 
-var swiftSettings: [SwiftSetting] { [
-    .enableExperimentalFeature("StrictConcurrency"),
-] }
+var swiftSettings: [SwiftSetting] { [] }

--- a/Package.swift
+++ b/Package.swift
@@ -113,5 +113,5 @@ let package = Package(
 )
 
 var swiftSettings: [SwiftSetting] { [
-//    .enableExperimentalFeature("StrictConcurrency"),
+    .enableExperimentalFeature("StrictConcurrency"),
 ] }

--- a/Package.swift
+++ b/Package.swift
@@ -114,4 +114,5 @@ let package = Package(
 
 var swiftSettings: [SwiftSetting] { [
     .enableExperimentalFeature("StrictConcurrency"),
+    .enableUpcomingFeature("StrictConcurrency")
 ] }

--- a/Sources/App/Core/CurrentReferenceCache.swift
+++ b/Sources/App/Core/CurrentReferenceCache.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Cache
+@preconcurrency import Cache
 
 typealias CurrentReferenceCache = ExpiringCache<String, String>
 

--- a/Sources/App/Core/SwiftVersion.swift
+++ b/Sources/App/Core/SwiftVersion.swift
@@ -30,9 +30,9 @@ struct SwiftVersion: Content, Equatable, Hashable {
 
 extension SwiftVersion: LosslessStringConvertible {
     init?(_ string: String) {
-        let groups = swiftVerRegex.matchGroups(string)
+        let groups = Self.swiftVerRegex.matchGroups(string)
         guard
-            groups.count == swiftVerRegex.numberOfCaptureGroups,
+            groups.count == Self.swiftVerRegex.numberOfCaptureGroups,
             let major = Int(groups[0])
         else { return nil }
         self = .init(major, Int(groups[1]) ?? 0, Int(groups[2]) ?? 0)
@@ -71,6 +71,24 @@ extension SwiftVersion: LosslessStringConvertible {
 
         }
     }
+
+    static var swiftVerRegex: NSRegularExpression {
+        NSRegularExpression(
+            #"""
+            ^
+            v?                              # SPI extension: allow leading 'v'
+            (?<major>0|[1-9]\d*)
+            (?:\.
+              (?<minor>0|[1-9]\d*)
+            )?
+            (?:\.
+              (?<patch>0|[1-9]\d*)
+            )?
+            $
+            """#, options: [.allowCommentsAndWhitespace]
+        )
+    }
+
 }
 
 
@@ -100,17 +118,3 @@ extension SwiftVersion {
 extension SwiftVersion {
     static var latest: Self { allActive.sorted().last! }
 }
-
-
-let swiftVerRegex = NSRegularExpression(#"""
-^
-v?                              # SPI extension: allow leading 'v'
-(?<major>0|[1-9]\d*)
-(?:\.
-  (?<minor>0|[1-9]\d*)
-)?
-(?:\.
-  (?<patch>0|[1-9]\d*)
-)?
-$
-"""#, options: [.allowCommentsAndWhitespace])

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -198,6 +198,7 @@ class AnalyzerTests: AppTestCase {
         XCTAssertEqual(pkg2.score, 40)
 
         // ensure stats, recent packages, and releases are refreshed
+        let app = self.app!
         try await XCTAssertEqualAsync(try await Stats.fetch(on: app.db).get(), .init(packageCount: 2))
         try await XCTAssertEqualAsync(try await RecentPackage.fetch(on: app.db).count, 2)
         try await XCTAssertEqualAsync(try await RecentRelease.fetch(on: app.db).count, 2)
@@ -310,6 +311,7 @@ class AnalyzerTests: AppTestCase {
         Current.git.shortlog = { @Sendable _ in "" }
 
         // Ensure candidate selection is as expected
+        let app = self.app!
         try await XCTAssertEqualAsync( try await Package.fetchCandidates(app.db, for: .ingestion, limit: 10).count, 0)
         try await XCTAssertEqualAsync( try await Package.fetchCandidates(app.db, for: .analysis, limit: 10).count, 1)
 
@@ -682,6 +684,7 @@ class AnalyzerTests: AppTestCase {
         ))
 
         do {  // validate
+            let app = self.app!
             try await XCTAssertEqualAsync(try await Version.query(on: app.db).count(), 1)
             let v = try await XCTUnwrapAsync(await Version.query(on: app.db).first())
             XCTAssertEqual(v.docArchives, [.init(name: "foo", title: "Foo")])
@@ -705,6 +708,7 @@ class AnalyzerTests: AppTestCase {
         ))
 
         do {  // validate
+            let app = self.app!
             try await XCTAssertEqualAsync(try await Version.query(on: app.db).count(), 2)
             let versions = try await XCTUnwrapAsync(await Version.query(on: app.db).sort(\.$commit).all())
             XCTAssertEqual(versions[0].docArchives, [.init(name: "foo", title: "Foo")])

--- a/Tests/AppTests/ApiTests.swift
+++ b/Tests/AppTests/ApiTests.swift
@@ -577,6 +577,7 @@ class ApiTests: AppTestCase {
         let buildId = try b.requireID()
         let dto: API.PostDocReportDTO = .init(status: .ok)
         let body: ByteBuffer = .init(data: try JSONEncoder().encode(dto))
+        let app = self.app!
 
         // MUT - no auth header
         try await app.test(

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -1026,6 +1026,7 @@ class BuildTriggerTests: AppTestCase {
 
         // validate
         XCTAssertEqual(deleteCount, 1)
+        let app = self.app!
         try await XCTAssertEqualAsync(try await Build.query(on: app.db).all().map(\.id), [.id1, .id2])
     }
 
@@ -1061,6 +1062,7 @@ class BuildTriggerTests: AppTestCase {
 
         // validate
         XCTAssertEqual(deleteCount, 2)
+        let app = self.app!
         try await XCTAssertEqualAsync(try await Build.query(on: app.db).all().map(\.id), [.id1])
     }
 

--- a/Tests/AppTests/DocUploadTests.swift
+++ b/Tests/AppTests/DocUploadTests.swift
@@ -66,6 +66,8 @@ final class DocUploadTests: AppTestCase {
         let docUploadId = UUID()
         try await DocUpload(id: docUploadId, status: .ok)
             .attach(to: b, on: app.db)
+        let app = self.app!
+
         try await XCTAssertEqualAsync(try await Version.query(on: app.db).count(), 1)
         try await XCTAssertEqualAsync(try await Build.query(on: app.db).count(), 1)
         try await XCTAssertEqualAsync(try await DocUpload.query(on: app.db).count(), 1)
@@ -95,6 +97,7 @@ final class DocUploadTests: AppTestCase {
         try await b.save(on: app.db)
         try await DocUpload(id: UUID(), status: .ok)
             .attach(to: b, on: app.db)
+        let app = self.app!
 
         try await XCTAssertEqualAsync(try await Version.query(on: app.db).count(), 1)
         try await XCTAssertEqualAsync(try await Build.query(on: app.db).count(), 1)
@@ -120,6 +123,8 @@ final class DocUploadTests: AppTestCase {
         try await b.save(on: app.db)
         try await DocUpload(id: UUID(), status: .ok)
             .attach(to: b, on: app.db)
+        let app = self.app!
+
         try await XCTAssertEqualAsync(try await Version.query(on: app.db).count(), 1)
         try await XCTAssertEqualAsync(try await Build.query(on: app.db).count(), 1)
         try await XCTAssertEqualAsync(try await DocUpload.query(on: app.db).count(), 1)

--- a/Tests/AppTests/GitLiveTests.swift
+++ b/Tests/AppTests/GitLiveTests.swift
@@ -54,20 +54,24 @@ class GitLiveTests: XCTestCase {
 extension GitLiveTests {
 
     func test_commitCount() async throws {
+        let path = self.path
         try await XCTAssertEqualAsync(try await Git.commitCount(at: path), 57)
     }
 
     func test_firstCommitDate() async throws {
+        let path = self.path
         try await XCTAssertEqualAsync(try await Git.firstCommitDate(at: path),
                                       Date(timeIntervalSince1970: 1426918070))  // Sat, 21 March 2015
     }
 
     func test_lastCommitDate() async throws {
+        let path = self.path
         try await XCTAssertEqualAsync(try await Git.lastCommitDate(at: path),
                                       Date(timeIntervalSince1970: 1554248253))  // Sat, 21 March 2015
     }
 
     func test_getTags() async throws {
+        let path = self.path
         try await XCTAssertEqualAsync(
             try await Git.getTags(at: path),
             [.tag(0,2,0),
@@ -93,11 +97,13 @@ extension GitLiveTests {
     }
 
     func test_hasBranch() async throws {
+        let path = self.path
         try await XCTAssertEqualAsync(try await Git.hasBranch(.branch("master"), at: path), true)
         try await XCTAssertEqualAsync(try await Git.hasBranch(.branch("main"), at: path), false)
     }
 
     func test_revisionInfo() async throws {
+        let path = self.path
         try await XCTAssertEqualAsync(try await Git.revisionInfo(.tag(0,5,2), at: path),
                                       .init(commit: "178566b112afe6bef3770678f1bbab6e5c626993",
                                             date: .init(timeIntervalSince1970: 1554248253)))
@@ -107,6 +113,7 @@ extension GitLiveTests {
     }
 
     func test_shortlog() async throws {
+        let path = self.path
         try await XCTAssertEqualAsync(try await Git.shortlog(at: path), """
                 36\tNeil Pankey
                 21\tJacob Williams

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -100,6 +100,7 @@ class IngestorTests: AppTestCase {
 
         // validate
         do {
+            let app = self.app!
             try await XCTAssertEqualAsync(try await Repository.query(on: app.db).count(), 1)
             let repo = try await Repository.query(on: app.db).first().unwrap()
             XCTAssertEqual(repo.summary, "This is package foo/bar")
@@ -158,6 +159,7 @@ class IngestorTests: AppTestCase {
 
         // validate
         do {
+            let app = self.app!
             try await XCTAssertEqualAsync(try await Repository.query(on: app.db).count(), 1)
             let repo = try await Repository.query(on: app.db).first().unwrap()
             XCTAssertEqual(repo.defaultBranch, "main")
@@ -400,6 +402,7 @@ class IngestorTests: AppTestCase {
 
     func test_ingest_storeS3Readme() async throws {
         // setup
+        let app = self.app!
         let pkg = Package(url: "https://github.com/foo/bar".url, processingStage: .reconciliation)
         try await pkg.save(on: app.db)
         Current.fetchMetadata = { _, owner, repository in .mock(owner: owner, repository: repository) }
@@ -542,6 +545,7 @@ class IngestorTests: AppTestCase {
             try await ingest(client: app.client, database: app.db, mode: .limit(1))
 
             // validate
+            let app = self.app!
             try await XCTAssertEqualAsync(await Repository.query(on: app.db).count(), 1)
             let repo = try await XCTUnwrapAsync(await Repository.query(on: app.db).first())
             XCTAssertEqual(storeCalls.value, 1)

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -225,6 +225,7 @@ class PackageController_routesTests: SnapshotTestCase {
               </p>
             </turbo-frame>
             """)
+        let app = self.app!
         try await XCTAssertEqualAsync(try await Repository.query(on: app.db).count(), 1)
         let s3Readme = try await XCTUnwrapAsync(try await Repository.query(on: app.db).first()?.s3Readme)
         XCTAssert(s3Readme.isError)

--- a/Tests/AppTests/QueryPlanTests.swift
+++ b/Tests/AppTests/QueryPlanTests.swift
@@ -14,7 +14,7 @@
 
 @testable import App
 
-import Parsing
+@preconcurrency import Parsing
 import XCTest
 
 

--- a/Tests/AppTests/SwiftVersionTests.swift
+++ b/Tests/AppTests/SwiftVersionTests.swift
@@ -20,13 +20,13 @@ import XCTest
 class SwiftVersionTests: XCTestCase {
 
     func test_swiftVerRegex() throws {
-        XCTAssert(swiftVerRegex.matches("1"))
-        XCTAssert(swiftVerRegex.matches("1.2"))
-        XCTAssert(swiftVerRegex.matches("1.2.3"))
-        XCTAssert(swiftVerRegex.matches("v1"))
-        XCTAssertFalse(swiftVerRegex.matches("1."))
-        XCTAssertFalse(swiftVerRegex.matches("1.2."))
-        XCTAssertFalse(swiftVerRegex.matches("1.2.3-pre"))
+        XCTAssert(SwiftVersion.swiftVerRegex.matches("1"))
+        XCTAssert(SwiftVersion.swiftVerRegex.matches("1.2"))
+        XCTAssert(SwiftVersion.swiftVerRegex.matches("1.2.3"))
+        XCTAssert(SwiftVersion.swiftVerRegex.matches("v1"))
+        XCTAssertFalse(SwiftVersion.swiftVerRegex.matches("1."))
+        XCTAssertFalse(SwiftVersion.swiftVerRegex.matches("1.2."))
+        XCTAssertFalse(SwiftVersion.swiftVerRegex.matches("1.2.3-pre"))
     }
 
     func test_init() throws {


### PR DESCRIPTION
I noticed we were still showing build errors in the latest run even though it was building with the [Swift 6 fixes merged](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3156) in:

![CleanShot 2024-07-15 at 14 28 10@2x](https://github.com/user-attachments/assets/2e812846-7349-44ca-846f-62de17bd7187)

This addresses a lot of them in a first pass. These are fixes that @gwynne had already applied and which I accidentally rolled back, because they didn't trigger warnings in my runs.

That was because for some reason we'd actually disabled the concurrency check in the package manifest. It's not clear to me why/how it still showed _some_ Swift 6 warnings. That's why that omission wasn't obvious.

With these fixes, Xcode 16b3 shows exactly 34 warnings:

  1. 1 dependency 'swift-case-paths' is not used by any target (temporary)
  2. 32 Converting non-sendable function value
  3. 1 Static property 'json' is not concurrency-safe (in SwiftOpenAPI dependency)

Item 1. is not Swift 6 related, 3. should go away once the compiler stops applying Swift 6 warnings to dependencies (assuming that's the reason - either way, it's beyond our direct control).

That leaves 32 concurrency warnings in our code base. These are all of a type that is likely a false positive (has been reported) and should go away in a future compiler release. We _can_ fix this in the meantime by expanding all function parameters into closures.

Since there are quite a few and it's going to make things more verbose we may want to hold off on that. (We've done a bit of this in the previous Swift 6 PR but it was in the dependency code that's going to to away soon.)

Note that the count of 32 warnings is higher than the 5 warnings reported by the preview processing, because a) the 32 warnings also include test targets and b) the stats reporting we use in the preview builds has some aggregation mechanism that deduplicates warnings, I believe.

I've reproduced the number of 5 warnings running the same build command as we do in the preview build, so the reporting is correct. It's just not aligning 1:1 with what Xcode shows.