### PR TITLE
Revert "Disable swiftlang/swift-docc-plugin doc test for now"

### DIFF
--- a/restfiles/doc-test.restfile
+++ b/restfiles/doc-test.restfile
@@ -550,12 +550,10 @@ requests:
     url: ${base_url}/swiftcsv/SwiftCSV/documentation
     validation:
       status: .regex((2|3)\d\d)
-  # Temporarily disabled, tracked here:
-  # https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3201
-  # /swiftlang/swift-docc-plugin/documentation:
-  #   url: ${base_url}/swiftlang/swift-docc-plugin/documentation
-  #   validation:
-  #     status: .regex((2|3)\d\d)
+  /swiftlang/swift-docc-plugin/documentation:
+    url: ${base_url}/swiftlang/swift-docc-plugin/documentation
+    validation:
+      status: .regex((2|3)\d\d)
   /swiftlang/swift-docc/documentation:
     url: ${base_url}/swiftlang/swift-docc/documentation
     validation:


### PR DESCRIPTION
This reverts commit 40fa306ae6c8e7aebdfaec5a43e1111922249fc2.