### PR TITLE
Bring back package id version comment

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -51,6 +51,12 @@ extension PackageShow {
             "package"
         }
 
+        override func bodyComments() -> Node<HTML.BodyContext> {
+            .group(
+                .comment(model.packageId.uuidString)
+            )
+        }
+
         override func breadcrumbs() -> [Breadcrumb] {
             [
                 Breadcrumb(title: "Home", url: SiteURL.home.relativeURL()),

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -248,6 +248,8 @@ class PublicPage {
             .class(bodyClass() ?? ""),
             .forEach(bodyAttributes(), { .attribute($0) }),
             preBody(),
+            bodyComments(),
+
             stagingBanner(),
             header(),
             announcementBanner(),
@@ -260,6 +262,12 @@ class PublicPage {
             postBody(),
             frontEndDebugPanel()
         )
+    }
+
+    /// Any page level HTML comments for hidden metadata.
+    /// - Returns: An element, or `group` of elements.
+    func bodyComments() -> Node<HTML.BodyContext> {
+        .empty
     }
 
     /// A staging banner, which only appears on the staging/development server.

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -249,7 +249,6 @@ class PublicPage {
             .forEach(bodyAttributes(), { .attribute($0) }),
             preBody(),
             bodyComments(),
-
             stagingBanner(),
             header(),
             announcementBanner(),

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_withPackageFundingLinks.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_withPackageFundingLinks.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -29,7 +29,7 @@
     <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
 <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
   </head>
-  <body class="package">
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
     <header>
       <div class="inner">
         <a href="/">


### PR DESCRIPTION
I missed that this went away as part of the debug panel change but I'm actually using it a lot. While the debug panel is nicer and has more info, the comment is a little easier to access since I don't need to remember the JS comment.