### PR TITLE
Moved Plot fork into our organisation

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ad3306d0afdd23d58b150ced6647c0dc782784b82d8caa70b06c722d7246074b",
+  "originHash" : "223c7ccc369c3e65877308b03456beb266b139bc1c753b713ba77b40dc4b6e6f",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -121,10 +121,10 @@
     {
       "identity" : "plot",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/daveverwer/Plot.git",
+      "location" : "https://github.com/SwiftPackageIndex/Plot.git",
       "state" : {
-        "branch" : "sitemapindex",
-        "revision" : "d4a416a8eca17485b93470bc86ae9b26d30ee6a2"
+        "branch" : "main",
+        "revision" : "3ee6fa631a22401643b21146a68c953b87a0a752"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/0xLeif/Cache.git", from: "2.1.0"),
         .package(url: "https://github.com/JohnSundell/Ink.git", from: "0.5.1"),
-        .package(url: "https://github.com/daveverwer/Plot.git", branch: "sitemapindex"),
+        .package(url: "https://github.com/SwiftPackageIndex/Plot.git", branch: "main"),
         .package(url: "https://github.com/MrLotU/SwiftPrometheus.git", from: "1.0.0-alpha"),
         .package(url: "https://github.com/SwiftPackageIndex/CanonicalPackageURL.git", from: "0.0.8"),
         .package(url: "https://github.com/SwiftPackageIndex/DependencyResolution.git", from: "1.1.2"),


### PR DESCRIPTION
I am still tracking `main` here rather than tagging versions as I don't really want to overwrite any future version tags that John might make, and no one else should be using this fork, so it's not super important that we won't make releases.