### PR TITLE
Bump Loki to 3.1.0

### DIFF
--- a/infrastructure/loki.yml
+++ b/infrastructure/loki.yml
@@ -62,15 +62,15 @@ storage_config:
 
 compactor:
   working_directory: /tmp/loki/boltdb-shipper-compactor
+  compaction_interval: 10m
+  retention_enabled: true
+  retention_delete_delay: 2h
+  retention_delete_worker_count: 150
+  delete_request_store: filesystem
 
-limits_config:
-  reject_old_samples: true
-  reject_old_samples_max_age: 168h
-  split_queries_by_interval: 24h
-
-table_manager:
-  retention_deletes_enabled: true
-  retention_period: 168h
+# https://grafana.com/docs/loki/latest/operations/storage/retention/#configuring-the-retention-period
+  limits_config:
+    retention_period: 336h # 14 days
 
 ruler:
   storage:

--- a/infrastructure/loki.yml
+++ b/infrastructure/loki.yml
@@ -69,8 +69,8 @@ compactor:
   delete_request_store: filesystem
 
 # https://grafana.com/docs/loki/latest/operations/storage/retention/#configuring-the-retention-period
-  limits_config:
-    retention_period: 336h # 14 days
+limits_config:
+  retention_period: 336h # 14 days
 
 ruler:
   storage:

--- a/infrastructure/loki.yml
+++ b/infrastructure/loki.yml
@@ -29,7 +29,6 @@ ingester:
   max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
   chunk_target_size: 1048576  # Loki will attempt to build chunks up to 1.5MB, flushing first if chunk_idle_period or max_chunk_age is reached first
   chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
-  max_transfer_retries: 0     # Chunk transfers disabled
   wal:
     dir: "/tmp/wal"
 
@@ -42,27 +41,32 @@ schema_config:
       index:
         prefix: index_
         period: 24h
+    - from: 2024-07-23
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
 
 storage_config:
   boltdb_shipper:
     active_index_directory: /tmp/loki/boltdb-shipper-active
     cache_location: /tmp/loki/boltdb-shipper-cache
     cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
-    shared_store: filesystem
+  tsdb_shipper:
+    active_index_directory: /tmp/loki/tsdb-index
+    cache_location: /tmp/loki/tsdb-cache
   filesystem:
     directory: /tmp/loki/chunks
 
 compactor:
   working_directory: /tmp/loki/boltdb-shipper-compactor
-  shared_store: filesystem
 
 limits_config:
   reject_old_samples: true
   reject_old_samples_max_age: 168h
   split_queries_by_interval: 24h
-
-chunk_store_config:
-  max_look_back_period: 168h
 
 table_manager:
   retention_deletes_enabled: true

--- a/mon.yml
+++ b/mon.yml
@@ -42,7 +42,7 @@ services:
 
   loki:
     # https://github.com/grafana/loki/releases
-    image: grafana/loki:2.9.9
+    image: grafana/loki:3.1.0
     command: -config.file=/loki.yml
     configs:
       - source: loki_cfg
@@ -54,7 +54,7 @@ services:
   promtail:
     # https://github.com/grafana/loki/releases
     # (promtail is released in parallel with loki)
-    image: grafana/promtail:2.9.9
+    image: grafana/promtail:3.1.0
     command: -config.file=/promtail.yml
     configs:
       - source: promtail_cfg


### PR DESCRIPTION
Ad hoc deploying first for testing.

Config is valid now.

```
❯ docker run --rm -t -v $PWD:/config grafana/loki:3.1.0 -config.file=/config/loki.yml -verify-config=true
level=info ts=2024-07-23T09:53:45.478581965Z caller=main.go:87 msg="config is valid"
```

Fixes #3244 