### PR TITLE
Run 09 results

### DIFF
--- a/Resources/ChartData/rfs6-errors.json
+++ b/Resources/ChartData/rfs6-errors.json
@@ -35,10 +35,16 @@
         "value" : 68515
       },
       {
-        "date" : "2024-07-14",
+        "date" : "2024-07-17",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 3 (16A5202i)",
         "value" : 63883
+      },
+      {
+        "date" : "2024-08-04",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 4 (16A5211f)",
+        "value" : 61858
       }
     ]
   },
@@ -78,10 +84,16 @@
         "value" : 1610
       },
       {
-        "date" : "2024-07-14",
+        "date" : "2024-07-17",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 3 (16A5202i)",
         "value" : 1625
+      },
+      {
+        "date" : "2024-08-04",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 4 (16A5211f)",
+        "value" : 1510
       }
     ]
   },
@@ -121,10 +133,16 @@
         "value" : 550
       },
       {
-        "date" : "2024-07-14",
+        "date" : "2024-07-17",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 3 (16A5202i)",
         "value" : 462
+      },
+      {
+        "date" : "2024-08-04",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 4 (16A5211f)",
+        "value" : 473
       }
     ]
   }

--- a/Resources/ChartData/rfs6-events.json
+++ b/Resources/ChartData/rfs6-events.json
@@ -10,5 +10,9 @@
     {
         "date": "2024-07-08",
         "value": "Xcode 16 beta 3 released"
+    },
+    {
+        "date": "2024-07-23",
+        "value": "Xcode 16 beta 4 released"
     }
 ]

--- a/Resources/ChartData/rfs6-packages.json
+++ b/Resources/ChartData/rfs6-packages.json
@@ -35,10 +35,16 @@
         "value" : 1501
       },
       {
-        "date" : "2024-07-14",
+        "date" : "2024-07-17",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 3 (16A5202i)",
         "value" : 1522
+      },
+      {
+        "date" : "2024-08-04",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 4 (16A5211f)",
+        "value" : 1543
       }
     ]
   },
@@ -78,9 +84,15 @@
         "value" : 22
       },
       {
-        "date" : "2024-07-14",
+        "date" : "2024-07-17",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 3 (16A5202i)",
+        "value" : 22
+      },
+      {
+        "date" : "2024-08-04",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 4 (16A5211f)",
         "value" : 22
       }
     ]
@@ -121,9 +133,15 @@
         "value" : 10
       },
       {
-        "date" : "2024-07-14",
+        "date" : "2024-07-17",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 3 (16A5202i)",
+        "value" : 10
+      },
+      {
+        "date" : "2024-08-04",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 4 (16A5211f)",
         "value" : 10
       }
     ]


### PR DESCRIPTION
![CleanShot 2024-08-04 at 10 14 18@2x](https://github.com/user-attachments/assets/b5e1f803-ee88-4ca9-aced-423dea4defcb)
