### PR TITLE
Soften the data race safety wording

### DIFF
--- a/Resources/Markdown/docs/builds.md
+++ b/Resources/Markdown/docs/builds.md
@@ -90,6 +90,8 @@ You can [find more details in this issue](https://github.com/SwiftPackageIndex/S
 
 <h3 id="data-race-safety">What is data race safety and how is it tested?</h3>
 
-The Swift 6.0 compiler can check whether code is safe from data races at compile time when strict concurrency checks are enabled. The data race safety information we publish on package pages comes from metadata output by the compiler during our build process.
+The Swift 6.0 compiler can check whether code is safe from data races at compile time with “complete” concurrency checks enabled. The data race safety information we publish on package pages comes from diagnostics output by the compiler as we build each package.
 
-Note that this does not affect package compatibility as shown in the compatibility matrix. A package can be fully compatible with Swift 6.x without opting into struct concurrency mode provided it is not running in Swift 6 language mode. For more information on opting into Swift 6 language mode, [read this for more information](https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/completechecking).
+It’s not possible for us to distinguish between a package that genuinely has no data race safety errors and one where the errors are being suppressed. All we can report on is the number of data race errors reported by the compiler.
+
+Note that this does not affect package compatibility, as shown in the compatibility matrix. A package can be fully compatible with Swift 6.x without enabling strict concurrency checks, provided it is not running in Swift 6 language mode. For more information on opting into Swift 6 language mode, [read the Swift 6 migration guide for more information](https://www.swift.org/migration/documentation/swift-6-concurrency-migration-guide/completechecking).

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -649,7 +649,7 @@ extension API.PackageController.GetRoute.Model.Swift6Readiness {
     var text: String {
         switch dataRaceSafety {
             case .safe:
-                return "Safe from data races"
+                return "Zero data race errors"
             case .unsafe:
                 return "Has data race errors"
             case .unknown:

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -649,9 +649,9 @@ extension API.PackageController.GetRoute.Model.Swift6Readiness {
     var text: String {
         switch dataRaceSafety {
             case .safe:
-                return "Zero data race errors"
+                return "Zero data race safety errors"
             case .unsafe:
-                return "Has data race errors"
+                return "Has data race safety errors"
             case .unknown:
                 return "No data race safety information available"
         }

--- a/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
+++ b/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
@@ -98,6 +98,19 @@ extension ReadyForSwift6Show {
                 ),
                 .p(
                     .strong(.text("Q: ")),
+                    .text("Are packages that show zero data-race compiler diagnostics guaranteed to be safe from data-race errors?")
+                ),
+                .p(
+                    .strong(.text("A: ")),
+                    .text("No. We gather data on data-race safety from Swift compiler diagnostics with “complete” concurrency checks enabled. We can’t tell if the diagnostics produce zero errors due to a genuine lack of data-race safety errors or whether errors have been suppressed using techniques like "),
+                    .code("@unchecked Sendable"),
+                    .text(".")
+                ),
+                .hr(
+                    .class("minor")
+                ),
+                .p(
+                    .strong(.text("Q: ")),
                     .text("Why use "),
                     .code("-strict-concurrency=complete"),
                     .text(" instead of "),

--- a/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
+++ b/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
@@ -38,7 +38,7 @@ extension ReadyForSwift6Show {
         override func content() -> Node<HTML.BodyContext> {
             .group(
                 .h2("Ready for Swift 6"),
-                .p("The Swift 6 language mode prevents data-races at compile time. When you opt into Swift 6 mode, the compiler will produce errors when your code has a risk of concurrent access, turning hard-to-debug runtime failures into compiler errors."),
+                .p("The Swift 6 language mode prevents data races at compile time. When you opt into Swift 6 mode, the compiler will produce errors when your code has a risk of concurrent access, turning hard-to-debug runtime failures into compiler errors."),
                 .p("To track the progress of the Swift package ecosystem, the Swift Package Index is running regular package compatibility checks across all packages in the index."),
                 .p(
                     .text("For help migrating your project's code, see the "),
@@ -50,16 +50,16 @@ extension ReadyForSwift6Show {
                 ),
                 .h3(
                     .id("total-zero-errors"),
-                    "Total packages with Swift 6 zero data-race safety errors"
+                    "Total packages with Swift 6 zero data race safety errors"
                 ),
-                .p("This chart shows packages with zero data-race safety compiler diagnostics during a successful build on at least one tested platform."),
+                .p("This chart shows packages with zero data race safety compiler diagnostics during a successful build on at least one tested platform."),
                 model.readyForSwift6Chart(kind: .compatiblePackages, includeTotals: true),
                 .h3(
                     .id("total-errors"),
-                    "Total Swift 6 data-race safety errors"
+                    "Total Swift 6 data race safety errors"
                 ),
                 .p(
-                    .text("This chart shows the total number of all data-race safety diagnostics across "),
+                    .text("This chart shows the total number of all data race safety diagnostics across "),
                     .em("all"),
                     .text(" packages.")
                 ),
@@ -74,7 +74,7 @@ extension ReadyForSwift6Show {
                 ),
                 .p(
                     .strong(.text("A: ")),
-                    .text("Swift 6 introduces complete concurrency checking, a compiler feature that checks your code for data-race safety. The number of data race safety errors reflects how many issues the compiler detected relating to these concurrency or data-race checks. The total errors chart plots the total number of these errors summed across all packages.")
+                    .text("Swift 6 introduces complete concurrency checking, a compiler feature that checks your code for data race safety. The number of data race safety errors reflects how many issues the compiler detected relating to these concurrency or data race checks. The total errors chart plots the total number of these errors summed across all packages.")
                 ),
                 .hr(
                     .class("minor")
@@ -98,11 +98,11 @@ extension ReadyForSwift6Show {
                 ),
                 .p(
                     .strong(.text("Q: ")),
-                    .text("Are packages that show zero data-race compiler diagnostics guaranteed to be safe from data-race errors?")
+                    .text("Are packages that show zero data race compiler diagnostics guaranteed to be safe from data race errors?")
                 ),
                 .p(
                     .strong(.text("A: ")),
-                    .text("No. We gather data on data-race safety from Swift compiler diagnostics with “complete” concurrency checks enabled. We can’t tell if the diagnostics produce zero errors due to a genuine lack of data-race safety errors or whether errors have been suppressed using techniques like "),
+                    .text("No. We gather data on data race safety from Swift compiler diagnostics with “complete” concurrency checks enabled. We can’t tell if the diagnostics produce zero errors due to a genuine lack of data race safety errors or whether errors have been suppressed using techniques like "),
                     .code("@unchecked Sendable"),
                     .text(".")
                 ),
@@ -119,7 +119,7 @@ extension ReadyForSwift6Show {
                 ),
                 .p(
                     .strong(.text("A: ")),
-                    .text("Data-race safety diagnostics are determined in different stages of the compiler. For example, type checking produces some data-race safety errors, and others are diagnosed during control-flow analysis after code generation. If type checking produces errors, the compiler will not proceed to code generation, so testing with "),
+                    .text("Data race safety diagnostics are determined in different stages of the compiler. For example, type checking produces some data race safety errors, and others are diagnosed during control-flow analysis after code generation. If type checking produces errors, the compiler will not proceed to code generation, so testing with "),
                     .code("-swift-version 6"),
                     .text(" would show fewer errors than really exist across the package ecosystem.")
                 ),

--- a/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
+++ b/Sources/App/Views/ReadyForSwift6/ReadyForSwift6Show+View.swift
@@ -52,14 +52,14 @@ extension ReadyForSwift6Show {
                     .id("total-zero-errors"),
                     "Total packages with Swift 6 zero data-race safety errors"
                 ),
-                .p("Packages with zero data-race safety compiler diagnostics during a successful build on at least one tested platform."),
+                .p("This chart shows packages with zero data-race safety compiler diagnostics during a successful build on at least one tested platform."),
                 model.readyForSwift6Chart(kind: .compatiblePackages, includeTotals: true),
                 .h3(
                     .id("total-errors"),
                     "Total Swift 6 data-race safety errors"
                 ),
                 .p(
-                    .text("The total number of all data-race safety diagnostics across "),
+                    .text("This chart shows the total number of all data-race safety diagnostics across "),
                     .em("all"),
                     .text(" packages.")
                 ),

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_ReadyForSwift6Show.1.html
@@ -83,16 +83,16 @@
     <main>
       <div class="inner">
         <h2>Ready for Swift 6</h2>
-        <p>The Swift 6 language mode prevents data-races at compile time. When you opt into Swift 6 mode, the compiler will produce errors when your code has a risk of concurrent access, turning hard-to-debug runtime failures into compiler errors.</p>
+        <p>The Swift 6 language mode prevents data races at compile time. When you opt into Swift 6 mode, the compiler will produce errors when your code has a risk of concurrent access, turning hard-to-debug runtime failures into compiler errors.</p>
         <p>To track the progress of the Swift package ecosystem, the Swift Package Index is running regular package compatibility checks across all packages in the index.</p>
         <p>For help migrating your project's code, see the 
           <a href="https://www.swift.org/migration/documentation/migrationguide/">Swift 6 language mode migration guide</a>.
         </p>
-        <h3 id="total-zero-errors">Total packages with Swift 6 zero data-race safety errors</h3>
-        <p>Packages with zero data-race safety compiler diagnostics during a successful build on at least one tested platform.</p>
+        <h3 id="total-zero-errors">Total packages with Swift 6 zero data race safety errors</h3>
+        <p>This chart shows packages with zero data race safety compiler diagnostics during a successful build on at least one tested platform.</p>
         <p>Couldn’t load chart data.</p>
-        <h3 id="total-errors">Total Swift 6 data-race safety errors</h3>
-        <p>The total number of all data-race safety diagnostics across 
+        <h3 id="total-errors">Total Swift 6 data race safety errors</h3>
+        <p>This chart shows the total number of all data race safety diagnostics across 
           <em>all</em> packages.
         </p>
         <p>Couldn’t load chart data.</p>
@@ -101,7 +101,7 @@
           <strong>Q: </strong>What is a “data race safety error”?
         </p>
         <p>
-          <strong>A: </strong>Swift 6 introduces complete concurrency checking, a compiler feature that checks your code for data-race safety. The number of data race safety errors reflects how many issues the compiler detected relating to these concurrency or data-race checks. The total errors chart plots the total number of these errors summed across all packages.
+          <strong>A: </strong>Swift 6 introduces complete concurrency checking, a compiler feature that checks your code for data race safety. The number of data race safety errors reflects how many issues the compiler detected relating to these concurrency or data race checks. The total errors chart plots the total number of these errors summed across all packages.
         </p>
         <hr class="minor"/>
         <p>
@@ -115,12 +115,20 @@
         </p>
         <hr class="minor"/>
         <p>
+          <strong>Q: </strong>Are packages that show zero data race compiler diagnostics guaranteed to be safe from data race errors?
+        </p>
+        <p>
+          <strong>A: </strong>No. We gather data on data race safety from Swift compiler diagnostics with “complete” concurrency checks enabled. We can’t tell if the diagnostics produce zero errors due to a genuine lack of data race safety errors or whether errors have been suppressed using techniques like 
+          <code>@unchecked Sendable</code>.
+        </p>
+        <hr class="minor"/>
+        <p>
           <strong>Q: </strong>Why use 
           <code>-strict-concurrency=complete</code> instead of 
           <code>-swift-version 6</code>?
         </p>
         <p>
-          <strong>A: </strong>Data-race safety diagnostics are determined in different stages of the compiler. For example, type checking produces some data-race safety errors, and others are diagnosed during control-flow analysis after code generation. If type checking produces errors, the compiler will not proceed to code generation, so testing with 
+          <strong>A: </strong>Data race safety diagnostics are determined in different stages of the compiler. For example, type checking produces some data race safety errors, and others are diagnosed during control-flow analysis after code generation. If type checking produces errors, the compiler will not proceed to code generation, so testing with 
           <code>-swift-version 6</code> would show fewer errors than really exist across the package ecosystem.
         </p>
         <hr class="minor"/>


### PR DESCRIPTION
After some good external feedback, I want to soften the wording we use around data race safety. It's great to be able to say "Safe from data race errors", but it's not necessarily true as package authors can suppress the errors with things like `@unchecked Sendable` annotations.

This PR has an additional FAQ question on the RfS6 page, more information on the builds FAQ, and changes to the package page wording to say "Zero data race errors" rather than "Safe from data races".

![Screenshot 2024-08-06 at 15 37 23@2x](https://github.com/user-attachments/assets/b5fe4410-21e1-47a6-bd39-5d3efd64705c)
