### PR TITLE
Change release desc

### DIFF
--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -351,9 +351,9 @@ extension API.PackageController.GetRoute.Model {
         }
     }
 
-    func stableReleaseMetadata() -> Node<HTML.ListContext> {
+    func latestReleaseMetadata() -> Node<HTML.ListContext> {
         guard let dateLink = releases.stable else { return .empty }
-        return releaseMetadata(dateLink, title: "Latest Stable Release", cssClass: "stable")
+        return releaseMetadata(dateLink, title: "Latest Release", cssClass: "stable")
     }
 
     func betaReleaseMetadata() -> Node<HTML.ListContext> {

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -301,7 +301,7 @@ extension PackageShow {
                 .class("sidebar-versions"),
                 .ariaLabel("Versions"),
                 .ul(
-                    model.stableReleaseMetadata(),
+                    model.latestReleaseMetadata(),
                     model.betaReleaseMetadata(),
                     model.defaultBranchMetadata()
                 )

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -328,7 +328,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -328,7 +328,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -332,7 +332,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
@@ -325,7 +325,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -325,7 +325,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -356,7 +356,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -531,7 +531,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -320,7 +320,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -208,7 +208,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -328,7 +328,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -327,7 +327,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -328,7 +328,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -261,7 +261,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_withPackageFundingLinks.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_withPackageFundingLinks.1.html
@@ -333,7 +333,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -328,7 +328,7 @@
                   <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
                     <span class="stable">5.2.0</span>
                   </a>
-                  <strong>Latest Stable Release</strong>
+                  <strong>Latest Release</strong>
                   <small>Released 12 days ago</small>
                 </li>
                 <li class="beta">


### PR DESCRIPTION
Change description from "Latest Stable Release" to "Latest Release" to resolve #3261  
Before: 
<img width="252" alt="pre-change" src="https://github.com/user-attachments/assets/48eda76c-e47d-454a-8923-ef8e8b36ddc6">
Now: 
<img width="291" alt="post-change" src="https://github.com/user-attachments/assets/422b3cb4-cd62-49f7-baca-6006c355b1c9">
