### PR TITLE
Readme alert styling

### DIFF
--- a/FrontEnd/styles/readme.scss
+++ b/FrontEnd/styles/readme.scss
@@ -91,6 +91,25 @@
         margin: 20px 0;
     }
 
+    .markdown-alert {
+        padding-left: 15px;
+        fill: currentColor;
+        border-left: solid;
+    }
+
+    .markdown-alert-title {
+        font-weight: 500;
+    }
+
+    .markdown-alert p:nth-child(2) {
+        color: black;
+    }
+
+    .markdown-alert-title svg {
+        margin-right: 10px;
+        transform: translateY(3px);
+    }
+
     .markdown-alert-note {
         color: var(--mid-blue);
     }
@@ -109,25 +128,6 @@
 
     .markdown-alert-caution {
         color: var(--mid-red);
-    }
-
-    .markdown-alert {
-        padding-left: 15px;
-        fill: currentColor;
-        border-left: solid currentColor;
-    }
-
-    .markdown-alert-title {
-        font-weight: 500;
-    }
-
-    .markdown-alert p:nth-child(2) {
-        color: black;
-    }
-
-    .markdown-alert-title svg {
-        margin-right: 10px;
-        transform: translateY(3px);
     }
 }
 

--- a/FrontEnd/styles/readme.scss
+++ b/FrontEnd/styles/readme.scss
@@ -92,18 +92,17 @@
     }
 
     .markdown-alert {
-        padding-left: 10px;
+        padding-left: 15px;
         border-left: solid black;
     }
 
     .markdown-alert-title {
-        display: block;
-        margin-top: 20px;
         font-weight: 500;
     }
 
     .markdown-alert-title svg {
         margin-right: 10px;
+        transform: translateY(3px);
     }
 }
 

--- a/FrontEnd/styles/readme.scss
+++ b/FrontEnd/styles/readme.scss
@@ -91,13 +91,38 @@
         margin: 20px 0;
     }
 
+    .markdown-alert-note {
+        color: var(--mid-blue);
+    }
+
+    .markdown-alert-tip {
+        color: var(--dark-green);
+    }
+
+    .markdown-alert-important {
+        color: var(--mid-purple);
+    }
+
+    .markdown-alert-warning {
+        color: var(--yellow);
+    }
+
+    .markdown-alert-caution {
+        color: var(--mid-red);
+    }
+
     .markdown-alert {
         padding-left: 15px;
-        border-left: solid black;
+        fill: currentColor;
+        border-left: solid currentColor;
     }
 
     .markdown-alert-title {
         font-weight: 500;
+    }
+
+    .markdown-alert p:nth-child(2) {
+        color: black;
     }
 
     .markdown-alert-title svg {

--- a/FrontEnd/styles/readme.scss
+++ b/FrontEnd/styles/readme.scss
@@ -94,7 +94,7 @@
     .markdown-alert {
         padding-left: 15px;
         fill: currentColor;
-        border-left: solid;
+        border-left: solid 3px;
     }
 
     .markdown-alert-title {

--- a/FrontEnd/styles/readme.scss
+++ b/FrontEnd/styles/readme.scss
@@ -90,6 +90,21 @@
     details {
         margin: 20px 0;
     }
+
+    .markdown-alert {
+        padding-left: 10px;
+        border-left: solid black;
+    }
+
+    .markdown-alert-title {
+        display: block;
+        margin-top: 20px;
+        font-weight: 500;
+    }
+
+    .markdown-alert-title svg {
+        margin-right: 10px;
+    }
 }
 
 g-emoji {


### PR DESCRIPTION
Update styling for [alerts](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts) to fix #3253 

Before: 
<img width="858" alt="before-styling-note" src="https://github.com/user-attachments/assets/010b67d7-a10e-49d8-9578-a08243a72253">
<img width="867" alt="before-styling-important" src="https://github.com/user-attachments/assets/6179a0b4-b1ef-4149-8fec-3ca9d64b1ba8">

After: 
<img width="904" alt="after-styling-note" src="https://github.com/user-attachments/assets/913fddf0-f89a-46c5-a237-417f9d5bb3cf">
<img width="880" alt="after-styling-important" src="https://github.com/user-attachments/assets/597db190-4da8-4edd-8526-4b51e8fc5c16">

Github's styling:
<img width="860" alt="github-styling-note" src="https://github.com/user-attachments/assets/554d60cf-2c0f-410d-a6b2-872f0ce73aa0">
<img width="848" alt="github-styling-important" src="https://github.com/user-attachments/assets/5f7ee547-c238-402d-841b-bed16bfe506d">