### PR TITLE
Fix s6 warnings

### DIFF
--- a/Sources/App/Controllers/API/API+BuildController.swift
+++ b/Sources/App/Controllers/API/API+BuildController.swift
@@ -20,6 +20,7 @@ import Vapor
 extension API {
 
     enum BuildController {
+        @Sendable
         static func buildReport(req: Request) async throws -> HTTPStatus {
             let dto = try req.content.decode(PostBuildReportDTO.self, using: buildReportDecoder)
             let version = try await App.Version
@@ -100,6 +101,7 @@ extension API {
             return decoder
         }
 
+        @Sendable
         static func docReport(req: Request) async throws -> HTTPStatus {
             let dto = try req.content.decode(PostDocReportDTO.self)
             let buildId = try req.parameters.get("id")

--- a/Sources/App/Controllers/API/API+DependencyController.swift
+++ b/Sources/App/Controllers/API/API+DependencyController.swift
@@ -27,6 +27,7 @@ extension API {
             var resolvedDependencies: [CanonicalPackageURL]?
         }
 
+        @Sendable
         static func get(req: Request) async throws -> [PackageRecord] {
             try await query(on: req.db)
         }

--- a/Sources/App/Controllers/API/API+PackageCollectionController.swift
+++ b/Sources/App/Controllers/API/API+PackageCollectionController.swift
@@ -22,6 +22,7 @@ extension API {
 
     enum PackageCollectionController {
 
+        @Sendable
         static func generate(req: Request) throws -> EventLoopFuture<SignedCollection> {
             AppMetrics.apiPackageCollectionGetTotal?.inc()
 

--- a/Sources/App/Controllers/API/API+PackageController.swift
+++ b/Sources/App/Controllers/API/API+PackageController.swift
@@ -20,6 +20,7 @@ extension API {
 
     enum PackageController {
 
+        @Sendable
         static func get(req: Request) async throws -> GetRoute.Model {
             guard
                 let owner = req.parameters.get("owner"),
@@ -35,6 +36,7 @@ extension API {
             var type: BadgeType
         }
 
+        @Sendable
         static func badge(req: Request) async throws -> Badge {
             guard
                 let owner = req.parameters.get("owner"),

--- a/Sources/App/Controllers/API/API+SearchController.swift
+++ b/Sources/App/Controllers/API/API+SearchController.swift
@@ -47,6 +47,7 @@ extension API {
             }
         }
 
+        @Sendable
         static func get(req: Request) async throws -> Search.Response {
             let query = try req.query.decode(Query.self)
             AppMetrics.apiSearchGetTotal?.inc()

--- a/Sources/App/Controllers/AuthorController.swift
+++ b/Sources/App/Controllers/AuthorController.swift
@@ -33,6 +33,7 @@ enum AuthorController {
             }
     }
 
+    @Sendable
     static func show(req: Request) throws -> EventLoopFuture<HTML> {
         guard let owner = req.parameters.get("owner") else {
             return req.eventLoop.future(error: Abort(.notFound))

--- a/Sources/App/Controllers/BlogController.swift
+++ b/Sources/App/Controllers/BlogController.swift
@@ -17,10 +17,12 @@ import Plot
 
 enum BlogController {
 
+    @Sendable
     static func index(req: Request) async throws -> HTML {
         BlogActions.Index.View(path: req.url.path, model: try BlogActions.Model()).document()
     }
 
+    @Sendable
     static func indexFeed(req: Request) async throws -> RSS {
         let model = try BlogActions.Model()
         let items = model.summaries.map { summary -> Node <RSS.ChannelContext> in
@@ -54,6 +56,7 @@ enum BlogController {
                        items: items).rss
     }
 
+    @Sendable
     static func show(req: Request) async throws -> HTML {
         guard let slug = req.parameters.get("slug")
         else { throw Abort(.notFound) }

--- a/Sources/App/Controllers/BuildController.swift
+++ b/Sources/App/Controllers/BuildController.swift
@@ -18,6 +18,7 @@ import Vapor
 
 
 enum BuildController {
+    @Sendable
     static func show(req: Request) throws -> EventLoopFuture<HTML> {
         guard let id = req.parameters.get("id"),
               let buildId = UUID.init(uuidString: id)
@@ -28,7 +29,7 @@ enum BuildController {
                 Build.fetchLogs(client: req.client, logUrl: result.build.logUrl)
                     .map { (result, $0) }
             }
-            .map(BuildShow.Model.init(result:logs:))
+            .map { BuildShow.Model.init(result: $0, logs: $1) }
             .unwrap(or: Abort(.notFound))
             .map {
                 BuildShow.View(path: req.url.path, model: $0).document()

--- a/Sources/App/Controllers/BuildMonitorController.swift
+++ b/Sources/App/Controllers/BuildMonitorController.swift
@@ -17,6 +17,7 @@ import Plot
 import Vapor
 
 enum BuildMonitorController {
+    @Sendable
     static func index(req: Request) async throws -> HTML {
         let builds = try await BuildResult.query(on: req.db)
             .field(Build.self, \.$id)

--- a/Sources/App/Controllers/KeywordController.swift
+++ b/Sources/App/Controllers/KeywordController.swift
@@ -47,6 +47,7 @@ enum KeywordController {
         }
     }
 
+    @Sendable
     static func show(req: Request) async throws -> HTML {
         guard let keyword = req.parameters.get("keyword") else {
             throw Abort(.notFound)

--- a/Sources/App/Controllers/PackageCollectionController.swift
+++ b/Sources/App/Controllers/PackageCollectionController.swift
@@ -16,6 +16,7 @@ import Vapor
 
 
 enum PackageCollectionController {
+    @Sendable
     static func generate(req: Request) throws -> EventLoopFuture<SignedCollection> {
         AppMetrics.packageCollectionGetTotal?.inc()
 

--- a/Sources/App/Controllers/PackageController+routes.swift
+++ b/Sources/App/Controllers/PackageController+routes.swift
@@ -20,6 +20,7 @@ import SemanticVersion
 
 enum PackageController {
 
+    @Sendable
     static func show(req: Request) async throws -> Response {
         guard
             let owner = req.parameters.get("owner"),
@@ -178,6 +179,7 @@ enum PackageController {
         return response
     }
 
+    @Sendable
     static func siteMap(req: Request) async throws -> SiteMap {
         guard
             let owner = req.parameters.get("owner"),
@@ -289,6 +291,7 @@ enum PackageController {
         }
     }
 
+    @Sendable
     static func readme(req: Request) async throws -> Node<HTML.BodyContext> {
         guard
             let owner = req.parameters.get("owner"),
@@ -324,6 +327,7 @@ enum PackageController {
         }
     }
 
+    @Sendable
     static func releases(req: Request) throws -> EventLoopFuture<Node<HTML.BodyContext>> {
         guard
             let owner = req.parameters.get("owner"),
@@ -334,10 +338,11 @@ enum PackageController {
 
         return Joined<Package, Repository>
             .query(on: req.db, owner: owner, repository: repository)
-            .map(PackageReleases.Model.init(package:))
+            .map { PackageReleases.Model.init(package: $0) }
             .map { PackageReleases.View(model: $0).document() }
     }
 
+    @Sendable
     static func builds(req: Request) async throws -> HTML {
         guard
             let owner = req.parameters.get("owner"),
@@ -356,6 +361,7 @@ enum PackageController {
         return BuildIndex.View(path: req.url.path, model: model).document()
     }
 
+    @Sendable
     static func maintainerInfo(req: Request) async throws -> HTML {
         guard
             let owner = req.parameters.get("owner"),

--- a/Sources/App/Controllers/ReadyForSwift6Controller.swift
+++ b/Sources/App/Controllers/ReadyForSwift6Controller.swift
@@ -16,7 +16,7 @@ import Vapor
 import Plot
 
 enum ReadyForSwift6Controller {
-
+    @Sendable
     static func show(req: Request) async throws -> HTML {
         let model = ReadyForSwift6Show.Model()
         return ReadyForSwift6Show.View(path: req.url.string, model: model).document()

--- a/Sources/App/Controllers/SearchController.swift
+++ b/Sources/App/Controllers/SearchController.swift
@@ -19,6 +19,7 @@ import Vapor
 
 enum SearchController {
 
+    @Sendable
     static func show(req: Request) async throws -> HTML {
         let query = try req.query.decode(API.SearchController.Query.self)
 

--- a/Sources/App/Controllers/SiteMapController.swift
+++ b/Sources/App/Controllers/SiteMapController.swift
@@ -44,6 +44,7 @@ enum SiteMapController {
     /// Generate a sitemap index page for a given request
     /// - Parameter req: `Request`
     /// - Returns: `SiteMapIndex`
+    @Sendable
     static func index(req: Request) async throws -> SiteMapIndex {
         guard let db = req.db as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
@@ -119,6 +120,7 @@ enum SiteMapController {
         )
     }
 
+    @Sendable
     static func staticPages(req: Request) async throws -> SiteMap {
         SiteMap(
             .group(

--- a/Sources/App/Controllers/SupportersController.swift
+++ b/Sources/App/Controllers/SupportersController.swift
@@ -18,6 +18,7 @@ import Vapor
 
 enum SupportersController {
 
+    @Sendable
     static func show(req: Request) async throws -> HTML {
         let model = SupportersShow.Model()
         return SupportersShow.View(path: req.url.string, model: model).document()

--- a/Sources/App/Controllers/ValidateSPIManifestController.swift
+++ b/Sources/App/Controllers/ValidateSPIManifestController.swift
@@ -19,11 +19,13 @@ import SPIManifest
 
 enum ValidateSPIManifestController {
 
+    @Sendable
     static func show(req: Request) async throws -> HTML {
         let model = ValidateSPIManifest.Model()
         return ValidateSPIManifest.View(path: req.url.path, model: model).document()
     }
 
+    @Sendable
     static func validate(req: Request) async throws -> HTML {
         struct FormData: Content {
             var manifest: String

--- a/Sources/App/Core/RSS.swift
+++ b/Sources/App/Core/RSS.swift
@@ -39,6 +39,7 @@ struct RSSFeed: Sendable {
         )
     }
 
+    @Sendable
     static func showPackages(req: Request) async throws -> RSS {
         try await RSSFeed.recentPackages(on: req.db, limit: Constants.rssFeedMaxItemCount).rss
     }
@@ -60,6 +61,7 @@ struct RSSFeed: Sendable {
         }
     }
 
+    @Sendable
     static func showReleases(req: Request) async throws -> RSS {
         let filter = try req.query.decode(Query.self).filter
         return try await RSSFeed.recentReleases(on: req.db,

--- a/Tests/AppTests/Helpers/CapturingLogger.swift
+++ b/Tests/AppTests/Helpers/CapturingLogger.swift
@@ -23,7 +23,7 @@ struct CapturingLogger: LogHandler {
 
     var logs = QueueIsolated<[LogEntry]>([])
 
-    func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
+    func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
         logs.withValue { logs in
             logs.append(.init(level: level, message: "\(message)"))
         }


### PR DESCRIPTION
This fixes all remaining Swift6 warnings (and one deprecation warning related to LogHandler).

The warnings were of the kind `Converting non-sendable function value` and raised for our request handers:

```swift
        app.get(SiteURL.package(.key, .key, .none).pathComponents,
                use: PackageController.show).excludeFromOpenAPI()
```

A known fix for this was to write

```swift
        app.get(SiteURL.package(.key, .key, .none).pathComponents,
                use: { try await PackageController.show(req: $0) }).excludeFromOpenAPI()
```

which is quite a bit of extra noise. We were hoping the compiler should infer `@Sendable` automatically to make this change unnecessary.

However, a simpler fix is to annotate the request handlers as `@Sendable`. See also https://forums.swift.org/t/vapor-and-sendable-route-handlers/71613/3

This clears all the noise now and should get us warning free.