### PR TITLE
Fix GitHub local-document anchors

### DIFF
--- a/FrontEnd/scripts/controllers/readme_controller.js
+++ b/FrontEnd/scripts/controllers/readme_controller.js
@@ -15,20 +15,6 @@
 import { Controller } from '@hotwired/stimulus'
 
 export class ReadmeController extends Controller {
-    fixReadmeAnchors() {
-        const linkElements = this.element.querySelectorAll('a')
-        linkElements.forEach((linkElement) => {
-            // Remove turbo from *all* links inside the README.
-            linkElement.setAttribute('data-turbo', 'false')
-
-            const linkTarget = linkElement.getAttribute('href')
-            if (linkTarget?.[0] === '#') {
-                // Fix up anchor URLs with the GitHub specific anchor name
-                linkElement.setAttribute('href', `#user-content-${linkTarget.substring(1)}`)
-            }
-        })
-    }
-
     navigateToAnchorFromLocation() {
         // If the browser has an anchor in the URL that may be inside the README then
         // we should attempt to scroll it into view once the README is loaded.

--- a/FrontEnd/styles/readme.scss
+++ b/FrontEnd/styles/readme.scss
@@ -69,9 +69,18 @@
         display: none;
     }
 
-    .anchor {
-        position: absolute;
-        visibility: hidden;
+    .markdown-heading {
+        position: relative;
+
+        > a {
+            position: absolute;
+            top: 0;
+            left: 0;
+
+            svg {
+                visibility: hidden;
+            }
+        }
     }
 
     .contains-task-list {

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -342,10 +342,7 @@ extension PackageShow {
                                         .value(model.repositoryName),
                                         .readme).relativeURL(),
                 .data(named: "controller", value: "readme"),
-                .data(named: "action", value: """
-                        turbo:frame-load->readme#fixReadmeAnchors \
-                        turbo:frame-load->readme#navigateToAnchorFromLocation
-                        """),
+                .data(named: "action", value: "turbo:frame-load->readme#navigateToAnchorFromLocation"),
                 .div(.spinner())
             )
         }

--- a/Tests/AppTests/PackageReadmeModelTests.swift
+++ b/Tests/AppTests/PackageReadmeModelTests.swift
@@ -65,7 +65,6 @@ class PackageReadmeModelTests: SnapshotTestCase {
 
         // validate
         let html = try XCTUnwrap(try element?.html())
-        // This assert is a snapshot, because Xcode strips trailing whitespace and the html has blank spaces at the end of each line, breaking the assert.
         assertSnapshot(of: html, as: .lines)
     }
 
@@ -91,7 +90,6 @@ class PackageReadmeModelTests: SnapshotTestCase {
 
         // validate
         let html = try XCTUnwrap(try element?.html())
-        // This assert is a snapshot, because Xcode strips trailing whitespace and the html has blank spaces at the end of each line, breaking the assert.
         assertSnapshot(of: html, as: .lines)
     }
 
@@ -108,5 +106,49 @@ class PackageReadmeModelTests: SnapshotTestCase {
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "https://full.host/and/path")).absoluteString, "https://full.host/and/path")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "https://full.host/encoded%20spaces")).absoluteString, "https://full.host/encoded%20spaces")
         XCTAssertEqual(try XCTUnwrap(URL(withPotentiallyUnencodedPath: "https://full.host/unencoded spaces")).absoluteString, "https://full.host/unencoded%20spaces")
+    }
+
+    func test_Element_fixInlineAnchors() throws {
+        // setup
+        let element = Element.extractReadme("""
+            <div id="readme">
+                <article>
+                    <p>README content.</p>
+                    <a href="https://example.com/url">Standard link.</a>
+                    <a href="#anchor">Lower case anchor link.</a>
+                    <a href="#Anchor">Upper case anchor link.</a>
+                    <a>Invalid link.</a>
+                </article>
+            </div>
+            """)
+
+        // MUT
+        element?.fixInlineAnchors()
+
+        // validate
+        let html = try XCTUnwrap(try element?.html())
+        assertSnapshot(of: html, as: .lines)
+    }
+
+    func test_Element_disableTurboOnLinks() throws {
+        // setup
+        let element = Element.extractReadme("""
+            <div id="readme">
+                <article>
+                    <p>README content.</p>
+                    <a href="https://example.com/url">Absolute link.</a>
+                    <a href="/url">Relative link.</a>
+                    <a href="#anchor">Lower case anchor link.</a>
+                    <a>Invalid link.</a>
+                </article>
+            </div>
+            """)
+
+        // MUT
+        element?.disableTurboOnLinks()
+
+        // validate
+        let html = try XCTUnwrap(try element?.html())
+        assertSnapshot(of: html, as: .lines)
     }
 }

--- a/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_Element_disableTurboOnLinks.1.txt
+++ b/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_Element_disableTurboOnLinks.1.txt
@@ -1,0 +1,5 @@
+<p>README content.</p> 
+<a href="https://example.com/url" data-turbo="false">Absolute link.</a> 
+<a href="/url" data-turbo="false">Relative link.</a> 
+<a href="#anchor" data-turbo="false">Lower case anchor link.</a> 
+<a data-turbo="false">Invalid link.</a>

--- a/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_Element_fixInlineAnchors.1.txt
+++ b/Tests/AppTests/__Snapshots__/PackageReadmeModelTests/test_Element_fixInlineAnchors.1.txt
@@ -1,0 +1,5 @@
+<p>README content.</p> 
+<a href="https://example.com/url">Standard link.</a> 
+<a href="#user-content-anchor">Lower case anchor link.</a> 
+<a href="#user-content-anchor">Upper case anchor link.</a> 
+<a>Invalid link.</a>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -364,7 +364,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -364,7 +364,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -368,7 +368,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
@@ -361,7 +361,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/owner/repo/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/owner/repo/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -361,7 +361,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -392,7 +392,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -567,7 +567,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -356,7 +356,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -244,7 +244,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -364,7 +364,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -363,7 +363,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -364,7 +364,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -297,7 +297,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_withPackageFundingLinks.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_withPackageFundingLinks.1.html
@@ -369,7 +369,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -364,7 +364,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#fixReadmeAnchors turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>


### PR DESCRIPTION
Fixes #3300

This did turn out to be caused by GitHub changing their markup. They add `user-content-` to every local anchor destination so that it doesn't clash with anything on their page, but they do not fix up the source anchors in their API call, only in their own web version. We were processing these already, but it looks like GitHub is no longer correcting the case, so we now need to do that as well. This fixes that.

Also, We were doing this README pre-processing in JavaScript and other pre-processing in Swift, so I've moved it all to Swift. We do still need one bit of JavaScript for it to work, but we're much more consistent with where we deal with these issues now.