### PR TITLE
change alert text color based on light/dark mode

### DIFF
--- a/FrontEnd/styles/readme.scss
+++ b/FrontEnd/styles/readme.scss
@@ -111,7 +111,7 @@
     }
 
     .markdown-alert p:nth-child(2) {
-        color: black;
+        color: var(--page-text);
     }
 
     .markdown-alert-title svg {


### PR DESCRIPTION
Fix alert text to be white if in dark mode and black if in light mode
Before:
<img width="840" alt="before-darkmode" src="https://github.com/user-attachments/assets/0f6736af-0da8-44ae-bc93-1be14819ad78">
After:
<img width="858" alt="after-darkmode" src="https://github.com/user-attachments/assets/191d320c-1c99-466b-87d9-cfda71d17587">
