### PR TITLE
Ensure neither an empty nor a whitespace only string can trigger the interstitial page

### DIFF
--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -195,7 +195,9 @@ extension AppEnvironment {
             Environment.get("HIDE_STAGING_BANNER").flatMap(\.asBool)
                 ?? Constants.defaultHideStagingBanner
         },
-        homepageInterstitial: { Environment.get("HOMEPAGE_INTERSTITIAL") },
+        homepageInterstitial: {
+            Environment.get("HOMEPAGE_INTERSTITIAL").flatMap(\.trimmed)
+        },
         httpClient: { httpClient },
         loadSPIManifest: { path in SPIManifest.Manifest.load(in: path) },
         logger: { logger },

--- a/Sources/App/Core/Extensions/String+ext.swift
+++ b/Sources/App/Core/Extensions/String+ext.swift
@@ -45,7 +45,7 @@ extension String {
     }
 
     var trimmed: String? {
-        let trimmedString = trimmingCharacters(in: .whitespaces)
+        let trimmedString = trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmedString.isEmpty { return nil }
         return trimmedString
     }

--- a/Tests/AppTests/AppEnvironmentTests.swift
+++ b/Tests/AppTests/AppEnvironmentTests.swift
@@ -29,4 +29,29 @@ class AppEnvironmentTests: XCTestCase {
         XCTAssertEqual(Current.fileManager.checkoutsDirectory(), "/tmp/foo")
     }
 
+    func test_homepageInterstitial() throws {
+        defer { unsetenv("HOMEPAGE_INTERSTITIAL") }
+        Current.homepageInterstitial = AppEnvironment.live.homepageInterstitial
+        do {
+            unsetenv("HOMEPAGE_INTERSTITIAL")
+            XCTAssertEqual(Current.homepageInterstitial(), nil)
+        }
+        do {
+            setenv("HOMEPAGE_INTERSTITIAL", "foo", 1)
+            XCTAssertEqual(Current.homepageInterstitial(), "foo")
+        }
+        do {
+            setenv("HOMEPAGE_INTERSTITIAL", "", 1)
+            XCTAssertEqual(Current.homepageInterstitial(), nil)
+        }
+        do {
+            setenv("HOMEPAGE_INTERSTITIAL", " ", 1)
+            XCTAssertEqual(Current.homepageInterstitial(), nil)
+        }
+        do {
+            setenv("HOMEPAGE_INTERSTITIAL", " \t\n ", 1)
+            XCTAssertEqual(Current.homepageInterstitial(), nil)
+        }
+    }
+
 }


### PR DESCRIPTION
I couldn't reproduce the issue locally and I suspect the problem was that this line in `app.yml`

```
    HOMEPAGE_INTERSTITIAL: ${HOMEPAGE_INTERSTITIAL}
```

actually sets the env variable to `""` in the container. I've ad hoc deployed this change to dev (where before the problem was apparent, just like in prod) and it's fixed now.