### PR TITLE
Update base image ref

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-docker:
 	@# run tests inside a docker container
 	docker run --rm -v "$(PWD)":/host -w /host \
 	  --add-host=host.docker.internal:host-gateway \
-	  registry.gitlab.com/finestructure/spi-base:64b8a588964762ef9c89ccecd3ea137a734afcbb \
+	  registry.gitlab.com/finestructure/spi-base:1.0.3 \
 	  make test
 
 test-e2e: db-reset reconcile ingest analyze


### PR DESCRIPTION
Looks like I hadn't saved the Makefile when updating to the tagged version.

`spi-base:64b8a588964762ef9c89ccecd3ea137a734afcbb` is the same as `spi-base:1.0.3`, so the effect is purely cosmetic.