### PR TITLE
Convert joined query builder to async await

### DIFF
--- a/Sources/App/Core/Query+Support/JoinedQueryBuilder.swift
+++ b/Sources/App/Core/Query+Support/JoinedQueryBuilder.swift
@@ -134,11 +134,6 @@ struct JoinedQueryBuilder<J: ModelInitializable> {
             .map(J.init(model:))
     }
 
-    func all() -> EventLoopFuture<[J]> {
-        queryBuilder.all()
-            .mapEach(J.init(model:))
-    }
-
     func first() async throws -> J? {
         try await queryBuilder.first()
             .map(J.init(model:))

--- a/Sources/App/Core/Query+Support/JoinedQueryBuilder.swift
+++ b/Sources/App/Core/Query+Support/JoinedQueryBuilder.swift
@@ -139,11 +139,6 @@ struct JoinedQueryBuilder<J: ModelInitializable> {
             .map(J.init(model:))
     }
 
-    func first() -> EventLoopFuture<J?> {
-        queryBuilder.first()
-            .optionalMap(J.init(model:))
-    }
-
     func page(_ page: Int, size pageSize: Int) async throws -> Page<J> {
         let page = try await queryBuilder.page(page, size: pageSize)
         return .init(results: page.results.map(J.init(model:)),

--- a/Tests/AppTests/BuildMonitorIndexModelTests.swift
+++ b/Tests/AppTests/BuildMonitorIndexModelTests.swift
@@ -19,25 +19,25 @@ import XCTVapor
 
 class BuildMonitorIndexModelTests: AppTestCase {
 
-    func test_init_from_Build() throws {
+    func test_init_from_Build() async throws {
         do {
             let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package,
                                       latest: .defaultBranch,
                                       packageName: "LeftPad from Version.packageName",
                                       reference: .branch("main"))
-            try version.save(on: app.db).wait()
-            try Build(id: .id0,
-                      version: version,
-                      platform: .macosXcodebuild,
-                      status: .ok,
-                      swiftVersion: .init(5, 6, 0)).save(on: app.db).wait()
-            try Repository(package: package,
-                           ownerName: "Dave Verwer from Repository.ownerName").save(on: app.db).wait()
+            try await version.save(on: app.db)
+            try await Build(id: .id0,
+                            version: version,
+                            platform: .macosXcodebuild,
+                            status: .ok,
+                            swiftVersion: .init(5, 6, 0)).save(on: app.db)
+            try await Repository(package: package,
+                                 ownerName: "Dave Verwer from Repository.ownerName").save(on: app.db)
         }
 
         // Query results back through the Joined4
-        let buildResult = try BuildResult.query(on: app.db).first().wait().unwrap()
+        let buildResult = try await BuildResult.query(on: app.db).first().unwrap()
 
         // MUT
         let model = try XCTUnwrap(BuildMonitorIndex.Model(buildResult: buildResult))
@@ -52,22 +52,22 @@ class BuildMonitorIndexModelTests: AppTestCase {
         XCTAssertEqual(model.status, .ok)
     }
 
-    func test_init_from_Build_without_repository_name() throws {
+    func test_init_from_Build_without_repository_name() async throws {
         do {
             let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package,
                                       packageName: nil) // Deliberately missing a `packageName`
-            try version.save(on: app.db).wait()
-            try Build(version: version,
-                      platform: .macosXcodebuild,
-                      status: .ok,
-                      swiftVersion: .init(5, 6, 0)).save(on: app.db).wait()
-            try Repository(package: package,
-                           name: "LeftPad from Repository.name").save(on: app.db).wait()
+            try await version.save(on: app.db)
+            try await Build(version: version,
+                            platform: .macosXcodebuild,
+                            status: .ok,
+                            swiftVersion: .init(5, 6, 0)).save(on: app.db)
+            try await Repository(package: package,
+                                 name: "LeftPad from Repository.name").save(on: app.db)
         }
 
         // Query results back through the Joined4
-        let buildResult = try BuildResult.query(on: app.db).first().wait().unwrap()
+        let buildResult = try await BuildResult.query(on: app.db).first().unwrap()
 
         // MUT
         let model = try XCTUnwrap(BuildMonitorIndex.Model(buildResult: buildResult))
@@ -75,23 +75,23 @@ class BuildMonitorIndexModelTests: AppTestCase {
         XCTAssertEqual(model.packageName, "LeftPad from Repository.name")
     }
 
-    func test_init_from_Build_with_no_package_name() throws {
+    func test_init_from_Build_with_no_package_name() async throws {
         do {
             let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package,
                                       packageName: nil) // Deliberately missing a `packageName`
-            try version.save(on: app.db).wait()
-            try Build(version: version,
-                      platform: .macosXcodebuild,
-                      status: .ok,
-                      swiftVersion: .init(5, 6, 0)).save(on: app.db).wait()
-            try Repository(package: package,
-                           name: nil) // Deliberately missing a `name`
-                .save(on: app.db).wait()
+            try await version.save(on: app.db)
+            try await Build(version: version,
+                            platform: .macosXcodebuild,
+                            status: .ok,
+                            swiftVersion: .init(5, 6, 0)).save(on: app.db)
+            try await Repository(package: package,
+                                 name: nil) // Deliberately missing a `name`
+            .save(on: app.db)
         }
 
         // Query results back through the Joined4
-        let buildResult = try BuildResult.query(on: app.db).first().wait().unwrap()
+        let buildResult = try await BuildResult.query(on: app.db).first().unwrap()
 
         // MUT
         let model = try XCTUnwrap(BuildMonitorIndex.Model(buildResult: buildResult))
@@ -99,23 +99,23 @@ class BuildMonitorIndexModelTests: AppTestCase {
         XCTAssertEqual(model.packageName, "Unknown Package")
     }
 
-    func test_init_from_Build_without_ownerName() throws {
+    func test_init_from_Build_without_ownerName() async throws {
         do {
             let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package)
-            try version.save(on: app.db).wait()
-            try Build(version: version,
-                      platform: .macosXcodebuild,
-                      status: .ok,
-                      swiftVersion: .init(5, 6, 0)).save(on: app.db).wait()
-            try Repository(package: package,
-                           owner: "daveverwer from Repository.owner",
-                           ownerName: nil) // Deliberately missing an `ownerName`
-                .save(on: app.db).wait()
+            try await version.save(on: app.db)
+            try await Build(version: version,
+                            platform: .macosXcodebuild,
+                            status: .ok,
+                            swiftVersion: .init(5, 6, 0)).save(on: app.db)
+            try await Repository(package: package,
+                                 owner: "daveverwer from Repository.owner",
+                                 ownerName: nil) // Deliberately missing an `ownerName`
+            .save(on: app.db)
         }
 
         // Query results back through the Joined4
-        let buildResult = try BuildResult.query(on: app.db).first().wait().unwrap()
+        let buildResult = try await BuildResult.query(on: app.db).first().unwrap()
 
         // MUT
         let model = try XCTUnwrap(BuildMonitorIndex.Model(buildResult: buildResult))

--- a/Tests/AppTests/Joined3Tests.swift
+++ b/Tests/AppTests/Joined3Tests.swift
@@ -19,84 +19,81 @@ import XCTest
 
 class Joined3Tests: AppTestCase {
 
-    func test_query_no_version() throws {
+    func test_query_no_version() async throws {
         // setup
         let p = try savePackage(on: app.db, "1")
-        try Repository(package: p).save(on: app.db).wait()
+        try await Repository(package: p).save(on: app.db)
 
         // MUT
-        let res = try Joined3<Package, Repository, Version>.query(on: app.db)
-            .all()
-            .wait()
+        let res = try await Joined3<Package, Repository, Version>.query(on: app.db).all()
 
         // validate
         XCTAssertEqual(res.map(\.model.id), [])
     }
 
-    func test_query_multiple_versions() throws {
+    func test_query_multiple_versions() async throws {
         // Ensure multiple versions don't multiply the package selection
         // setup
         let p = try savePackage(on: app.db, "1")
-        try Repository(package: p).save(on: app.db).wait()
-        try Version(package: p, latest: .defaultBranch).save(on: app.db).wait()
-        try Version(package: p, latest: .release).save(on: app.db).wait()
+        try await Repository(package: p).save(on: app.db)
+        try await Version(package: p, latest: .defaultBranch).save(on: app.db)
+        try await Version(package: p, latest: .release).save(on: app.db)
 
         // MUT
-        let res = try Joined3<Package, Repository, Version>
+        let res = try await Joined3<Package, Repository, Version>
             .query(on: app.db, version: .defaultBranch)
             .all()
-            .wait()
 
         // validate
         XCTAssertEqual(res.map(\.model.id), [p.id])
     }
 
 
-    func test_query_relationship_properties() throws {
+    func test_query_relationship_properties() async throws {
         // Ensure relationship properties are populated by query
         // setup
         let p = try savePackage(on: app.db, "1")
-        try Repository(package: p, owner: "owner").save(on: app.db).wait()
-        try Version(package: p,
+        try await Repository(package: p, owner: "owner").save(on: app.db)
+        try await Version(package: p,
                     latest: .defaultBranch,
-                    packageName: "package name").save(on: app.db).wait()
+                    packageName: "package name").save(on: app.db)
 
         // MUT
-        let res = try Joined3<Package, Repository, Version>
+        let res = try await Joined3<Package, Repository, Version>
             .query(on: app.db, version: .defaultBranch)
-            .all().wait()
+            .all()
 
         // validate
         XCTAssertEqual(res.map { $0.repository.owner }, ["owner"])
         XCTAssertEqual(res.map { $0.version.packageName }, ["package name"])
     }
 
-    func test_query_missing_relations() throws {
+    func test_query_missing_relations() async throws {
         // Neither should be possible in practice, this is just ensuring we cannot
         // force unwrap the `repository` or `version` properties in the pathological
         // event, because there are no results to access the properties on.
         do {  // no repository
             let p = try savePackage(on: app.db, "1")
-            try Version(package: p,
+            try await Version(package: p,
                         latest: .defaultBranch,
-                        packageName: "package name").save(on: app.db).wait()
+                        packageName: "package name").save(on: app.db)
 
             // MUT
-            let res = try Joined3<Package, Repository, Version>
+            let res = try await Joined3<Package, Repository, Version>
                 .query(on: app.db, version: .defaultBranch)
-                .all().wait()
+                .all()
 
             // validate - result is empty, `res[0].repository` cannot be called
             XCTAssertTrue(res.isEmpty)
         }
         do {  // no version
             let p = try savePackage(on: app.db, "2")
-            try Repository(package: p, owner: "owner").save(on: app.db).wait()
+            try await Repository(package: p, owner: "owner").save(on: app.db)
 
             // MUT
-            let res = try Joined3<Package, Repository, Version>
+            let res = try await Joined3<Package, Repository, Version>
                 .query(on: app.db, version: .defaultBranch)
-                .all().wait()
+                .all()
 
             // validate - result is empty, `res[0].repository` cannot be called
             XCTAssertTrue(res.isEmpty)

--- a/Tests/AppTests/JoinedQueryBuilderTests.swift
+++ b/Tests/AppTests/JoinedQueryBuilderTests.swift
@@ -24,7 +24,7 @@ import XCTest
 /// and essentially compiler checked.
 class JoinedQueryBuilderTests: AppTestCase {
 
-    func test_sort() throws {
+    func test_sort() async throws {
         // setup
         try (0..<3).shuffled().forEach { idx in
             try Package(url: "\(idx)".url).save(on: app.db).wait()
@@ -38,9 +38,9 @@ class JoinedQueryBuilderTests: AppTestCase {
 
         do {  // test sort(_ sort: DatabaseQuery.Sort)
             // MUT
-            let res = try query()
+            let res = try await query()
                 .sort(DatabaseQuery.Sort.sort(.sql(unsafeRaw: "url"), .descending))
-                .all().wait()
+                .all()
 
             // validate
             XCTAssertEqual(res.map(\.url), ["2", "1", "0"])
@@ -48,9 +48,9 @@ class JoinedQueryBuilderTests: AppTestCase {
 
         do {  // test sort<Field>(_ field: KeyPath<...>, _ direction:)
             // MUT
-            let res = try query()
+            let res = try await query()
                 .sort(\.$url, .descending)
-                .all().wait()
+                .all()
 
             // validate
             XCTAssertEqual(res.map(\.url), ["2", "1", "0"])
@@ -58,9 +58,9 @@ class JoinedQueryBuilderTests: AppTestCase {
 
         do {  // test sort(_ field: DatabaseQuery.Field, _ direction:)
             // MUT
-            let res = try query()
+            let res = try await query()
                 .sort(DatabaseQuery.Field.sql(unsafeRaw: "url"), .descending)
-                .all().wait()
+                .all()
 
             // validate
             XCTAssertEqual(res.map(\.url), ["2", "1", "0"])

--- a/Tests/AppTests/PackageInfoTests.swift
+++ b/Tests/AppTests/PackageInfoTests.swift
@@ -19,18 +19,17 @@ import XCTest
 
 class PackageInfoTests: AppTestCase {
 
-    func test_title_package_name() throws {
+    func test_title_package_name() async throws {
         // Ensure title is populated from package.name()
         // setup
         let p = try savePackage(on: app.db, "1")
-        try Repository(package: p, name: "repo name", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: p, latest: .defaultBranch, packageName: "package name")
-            .save(on: app.db).wait()
-        let joined = try XCTUnwrap(Joined3<Package, Repository, Version>
-                                    .query(on: app.db, version: .defaultBranch)
-                                    .first()
-                                    .wait())
+        try await Repository(package: p, name: "repo name", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: p, latest: .defaultBranch, packageName: "package name")
+            .save(on: app.db)
+        let joined = try await XCTUnwrapAsync(try await Joined3<Package, Repository, Version>
+            .query(on: app.db, version: .defaultBranch)
+            .first())
 
         // MUT
         let pkgInfo = PackageInfo(package: joined)
@@ -39,18 +38,17 @@ class PackageInfoTests: AppTestCase {
         XCTAssertEqual(pkgInfo?.title, "package name")
     }
 
-    func test_title_repo_name() throws {
+    func test_title_repo_name() async throws {
         // Ensure title is populated from repoName if package.name() is nil
         // setup
         let p = try savePackage(on: app.db, "1")
-        try Repository(package: p, name: "repo name", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: p, latest: .defaultBranch, packageName: nil)
-            .save(on: app.db).wait()
-        let joined = try XCTUnwrap(Joined3<Package, Repository, Version>
-                                    .query(on: app.db, version: .defaultBranch)
-                                    .first()
-                                    .wait())
+        try await Repository(package: p, name: "repo name", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: p, latest: .defaultBranch, packageName: nil)
+            .save(on: app.db)
+        let joined = try await XCTUnwrapAsync(try await Joined3<Package, Repository, Version>
+            .query(on: app.db, version: .defaultBranch)
+            .first())
 
         // MUT
         let pkgInfo = PackageInfo(package: joined)


### PR DESCRIPTION
This eliminates the remaining references of `EventLoopFuture`.

What's left are only two protocol conformances which we have to keep, because they're conformances to Vapor protocols (`Client` and `Database`). We can drop these only when Vapor updates these protocols and drops them.

What's left to do in order to fully move off of ELFs is to eliminate our use of `.wait()` calls in sync tests of our test suite. These need to be converted into proper `async throws` tests. There are currently 192 `.wait()` calls across 18 files.