### PR TITLE
Remove wait calls

### DIFF
--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -25,7 +25,7 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
     func test_init_no_packageName() async throws {
         // Tests behaviour when we're lacking data
         // setup package without package name
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg, name: "bar", owner: "foo").save(on: app.db)
         let version = try App.Version(package: pkg,
                                       latest: .defaultBranch,
@@ -50,7 +50,7 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
     }
 
     func test_init_packageIdentity() async throws {
-        let pkg = try savePackage(on: app.db, URL(string: "https://github.com/foo/swift-bar.git")!)
+        let pkg = try await savePackage(on: app.db, URL(string: "https://github.com/foo/swift-bar.git")!)
         try await Repository(package: pkg, name: "bar", owner: "foo").save(on: app.db)
         let version = try App.Version(package: pkg, latest: .defaultBranch, packageName: nil, reference: .branch("main"))
         try await version.save(on: app.db)
@@ -71,7 +71,7 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
     }
 
     func test_init_generated_documentation() async throws {
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg, name: "bar", owner: "foo").save(on: app.db)
         let version = try App.Version(package: pkg, latest: .defaultBranch, packageName: nil, reference: .branch("main"))
         version.docArchives = [.init(name: "archive1", title: "Archive One")]
@@ -93,7 +93,7 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
     }
 
     func test_init_external_documentation() async throws {
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg, name: "bar", owner: "foo").save(on: app.db)
         let version = try App.Version(package: pkg, latest: .defaultBranch, packageName: nil, reference: .branch("main"))
         version.spiManifest = try .init(yml: """
@@ -454,7 +454,7 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
 
     func test_languagePlatformInfo() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg,
                              defaultBranch: "default",
                              name: "bar",

--- a/Tests/AppTests/API+PackageController+GetRouteTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRouteTests.swift
@@ -23,7 +23,7 @@ class API_PackageController_GetRouteTests: AppTestCase {
 
     func test_releaseInfo() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg,
                              defaultBranch: "default",
                              name: "bar",
@@ -69,7 +69,7 @@ class API_PackageController_GetRouteTests: AppTestCase {
     func test_releaseInfo_exclude_non_latest() async throws {
         // Test to ensure that we don't include versions with `latest IS NULL`
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg,
                              defaultBranch: "default",
                              name: "bar",

--- a/Tests/AppTests/API+PackageControllerTests.swift
+++ b/Tests/AppTests/API+PackageControllerTests.swift
@@ -27,7 +27,7 @@ class API_PackageControllerTests: AppTestCase {
         Current.date = {
             Date.init(timeIntervalSince1970: 1608000588)  // Dec 15, 2020
         }
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg,
                              commitCount: 1433,
                              defaultBranch: "default",
@@ -65,7 +65,7 @@ class API_PackageControllerTests: AppTestCase {
         Current.date = {
             Date.init(timeIntervalSince1970: 1608000588)  // Dec 15, 2020
         }
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg,
                              commitCount: 1433,
                              defaultBranch: "default",
@@ -135,7 +135,7 @@ class API_PackageControllerTests: AppTestCase {
 
     func test_ProductCount_query() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg,
                              defaultBranch: "main",
                              name: "bar",
@@ -282,7 +282,7 @@ class API_PackageControllerTests: AppTestCase {
     func test_BuildInfo_query() async throws {
         // setup
         do {
-            let pkg = try savePackage(on: app.db, "1".url)
+            let pkg = try await savePackage(on: app.db, "1".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  name: "bar",
@@ -304,7 +304,7 @@ class API_PackageControllerTests: AppTestCase {
             }
         }
         do { // unrelated package and build
-            let pkg = try savePackage(on: app.db, "2".url)
+            let pkg = try await savePackage(on: app.db, "2".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  name: "bar2",
@@ -348,7 +348,7 @@ class API_PackageControllerTests: AppTestCase {
     func test_GetRoute_query() async throws {
         // ensure GetRoute.query is wired up correctly (detailed tests are elsewhere)
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "bar", owner: "foo")
             .save(on: app.db)
         try await Version(package: pkg, latest: .defaultBranch).save(on: app.db)

--- a/Tests/AppTests/API_DependencyControllerTests.swift
+++ b/Tests/AppTests/API_DependencyControllerTests.swift
@@ -21,7 +21,7 @@ final class API_DependencyControllerTests: AppTestCase {
 
     func test_query() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, id: .id0, "http://github.com/foo/bar")
+        let pkg = try await savePackage(on: app.db, id: .id0, "http://github.com/foo/bar")
         try await Repository(package: pkg,
                              defaultBranch: "default",
                              name: "bar",

--- a/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
+++ b/Tests/AppTests/AnalyzerVersionThrottlingTests.swift
@@ -19,12 +19,12 @@ import XCTest
 
 class AnalyzerVersionThrottlingTests: AppTestCase {
 
-    func test_throttle_keep_old() throws {
+    func test_throttle_keep_old() async throws {
         // Test keeping old when within throttling window
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let old = try makeVersion(pkg, "sha_old", -.hours(23), .branch("main"))
         let new = try makeVersion(pkg, "sha_new", -.hours(1), .branch("main"))
 
@@ -35,12 +35,12 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         XCTAssertEqual(res, [old])
     }
 
-    func test_throttle_take_new() throws {
+    func test_throttle_take_new() async throws {
         // Test picking new version when old one is outside the window
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let old = try makeVersion(pkg, "sha_old", .hours(-26), .branch("main"))
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .branch("main"))
 
@@ -51,12 +51,12 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         XCTAssertEqual(res, [new])
     }
 
-    func test_throttle_ignore_tags() throws {
+    func test_throttle_ignore_tags() async throws {
         // Test to ensure tags are exempt from throttling
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let old = try makeVersion(pkg, "sha_old", .hours(-23), .tag(1, 0, 0))
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .tag(2, 0, 0))
 
@@ -67,12 +67,12 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         XCTAssertEqual(res, [new])
     }
 
-    func test_throttle_new_package() throws {
+    func test_throttle_new_package() async throws {
         // Test picking up a new package's branch
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .branch("main"))
 
         // MUT
@@ -82,14 +82,14 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         XCTAssertEqual(res, [new])
     }
 
-    func test_throttle_branch_ref_change() throws {
+    func test_throttle_branch_ref_change() async throws {
         // Test behaviour when changing default branch names
         // Changed to return [new] to avoid branch renames causing 404s
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2217
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let old = try makeVersion(pkg, "sha_old", .hours(-23), .branch("develop"))
         let new = try makeVersion(pkg, "sha_new", .hours(-1), .branch("main"))
 
@@ -100,14 +100,14 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         XCTAssertEqual(res, [new])
     }
 
-    func test_throttle_rename() throws {
+    func test_throttle_rename() async throws {
         // Ensure incoming branch renames are throttled
         // Changed to return [new] to avoid branch renames causing 404s
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2217
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let old = try makeVersion(pkg, "sha", .hours(-1), .branch("main-old"))
         let new = try makeVersion(pkg, "sha", .hours(-1), .branch("main-new"))
 
@@ -118,14 +118,14 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         XCTAssertEqual(res, [new])
     }
 
-    func test_throttle_multiple_incoming_branches_keep_old() throws {
+    func test_throttle_multiple_incoming_branches_keep_old() async throws {
         // Test behaviour with multiple incoming branch revisions
         // NB: this is a theoretical scenario, in practise there should only
         // ever be one branch revision among the incoming revisions.
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let old = try makeVersion(pkg, "sha_old", .hours(-23), .branch("main"))
         let new0 = try makeVersion(pkg, "sha_new0", .hours(-3), .branch("main"))
         let new1 = try makeVersion(pkg, "sha_new1", .hours(-2), .branch("main"))
@@ -139,14 +139,14 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         XCTAssertEqual(res, [old])
     }
 
-    func test_throttle_multiple_incoming_branches_take_new() throws {
+    func test_throttle_multiple_incoming_branches_take_new() async throws {
         // Test behaviour with multiple incoming branch revisions
         // NB: this is a theoretical scenario, in practise there should only
         // ever be one branch revision among the incoming revisions.
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let old = try makeVersion(pkg, "sha_old", .hours(-26), .branch("main"))
         let new0 = try makeVersion(pkg, "sha_new0", .hours(-3), .branch("main"))
         let new1 = try makeVersion(pkg, "sha_new1", .hours(-2), .branch("main"))
@@ -287,7 +287,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         }
     }
 
-    func test_throttle_force_push() throws {
+    func test_throttle_force_push() async throws {
         // Test the exceptional case where we have a newer branch revision in
         // the db than the incoming version. This could happen for instance
         // if an older branch revision is force pushed, effectively removing
@@ -296,7 +296,7 @@ class AnalyzerVersionThrottlingTests: AppTestCase {
         // setup
         Current.date = { .t0 }
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
 
         do {  // both within window
             let ex = try makeVersion(pkg, "sha-ex", .hours(-1), .branch("main"))

--- a/Tests/AppTests/ArrayVersionExtensionTests.swift
+++ b/Tests/AppTests/ArrayVersionExtensionTests.swift
@@ -22,7 +22,7 @@ import SPIManifest
 class ArrayVersionExtensionTests: AppTestCase {
 
     func test_Array_canonicalDocumentationTarget() async throws {
-        let pkg = try await savePackageAsync(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         let archive = DocArchive(name: "foo", title: "Foo")
 
         do {

--- a/Tests/AppTests/AuthorControllerTests.swift
+++ b/Tests/AppTests/AuthorControllerTests.swift
@@ -21,7 +21,7 @@ class AuthorControllerTests: AppTestCase {
 
     func test_query() async throws {
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p, owner: "owner").save(on: app.db)
         try await Version(package: p, latest: .defaultBranch).save(on: app.db)
 
@@ -34,7 +34,7 @@ class AuthorControllerTests: AppTestCase {
 
     func test_query_no_version() async throws {
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p, owner: "owner").save(on: app.db)
 
         // MUT
@@ -67,7 +67,7 @@ class AuthorControllerTests: AppTestCase {
 
     func test_show_owner() async throws {
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p, owner: "owner").save(on: app.db)
         try await Version(package: p, latest: .defaultBranch).save(on: app.db)
 
@@ -79,7 +79,7 @@ class AuthorControllerTests: AppTestCase {
 
     func test_show_owner_empty() async throws {
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p, owner: "owner").save(on: app.db)
         try await Version(package: p, latest: .defaultBranch).save(on: app.db)
 

--- a/Tests/AppTests/BuildIndexModelTests.swift
+++ b/Tests/AppTests/BuildIndexModelTests.swift
@@ -23,7 +23,7 @@ class BuildIndexModelTests: AppTestCase {
     func test_init_no_name() async throws {
         // Tests behaviour when we're lacking data
         // setup package without package name
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              defaultBranch: "main",
                              forks: 42,

--- a/Tests/AppTests/BuildMonitorControllerTests.swift
+++ b/Tests/AppTests/BuildMonitorControllerTests.swift
@@ -19,20 +19,20 @@ import XCTest
 
 class BuildMonitorControllerTests: AppTestCase {
 
-    func test_show_owner() throws {
+    func test_show_owner() async throws {
         do {
             let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package)
-            try version.save(on: app.db).wait()
-            try Build(version: version,
-                      platform: .macosXcodebuild,
-                      status: .ok,
-                      swiftVersion: .init(5, 6, 0)).save(on: app.db).wait()
-            try Repository(package: package).save(on: app.db).wait()
+            try await version.save(on: app.db)
+            try await Build(version: version,
+                            platform: .macosXcodebuild,
+                            status: .ok,
+                            swiftVersion: .init(5, 6, 0)).save(on: app.db)
+            try await Repository(package: package).save(on: app.db)
         }
 
         // MUT
-        try app.test(.GET, "/build-monitor", afterResponse: { response in
+        try await app.test(.GET, "/build-monitor", afterResponse: { response async in
             XCTAssertEqual(response.status, .ok)
         })
     }

--- a/Tests/AppTests/BuildMonitorControllerTests.swift
+++ b/Tests/AppTests/BuildMonitorControllerTests.swift
@@ -21,7 +21,7 @@ class BuildMonitorControllerTests: AppTestCase {
 
     func test_show_owner() async throws {
         do {
-            let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
+            let package = try await savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package)
             try await version.save(on: app.db)
             try await Build(version: version,

--- a/Tests/AppTests/BuildMonitorIndexModelTests.swift
+++ b/Tests/AppTests/BuildMonitorIndexModelTests.swift
@@ -21,7 +21,7 @@ class BuildMonitorIndexModelTests: AppTestCase {
 
     func test_init_from_Build() async throws {
         do {
-            let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
+            let package = try await savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package,
                                       latest: .defaultBranch,
                                       packageName: "LeftPad from Version.packageName",
@@ -54,7 +54,7 @@ class BuildMonitorIndexModelTests: AppTestCase {
 
     func test_init_from_Build_without_repository_name() async throws {
         do {
-            let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
+            let package = try await savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package,
                                       packageName: nil) // Deliberately missing a `packageName`
             try await version.save(on: app.db)
@@ -77,7 +77,7 @@ class BuildMonitorIndexModelTests: AppTestCase {
 
     func test_init_from_Build_with_no_package_name() async throws {
         do {
-            let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
+            let package = try await savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package,
                                       packageName: nil) // Deliberately missing a `packageName`
             try await version.save(on: app.db)
@@ -101,7 +101,7 @@ class BuildMonitorIndexModelTests: AppTestCase {
 
     func test_init_from_Build_without_ownerName() async throws {
         do {
-            let package = try savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
+            let package = try await savePackage(on: app.db, "https://github.com/daveverwer/LeftPad")
             let version = try Version(package: package)
             try await version.save(on: app.db)
             try await Build(version: version,

--- a/Tests/AppTests/BuildResultTests.swift
+++ b/Tests/AppTests/BuildResultTests.swift
@@ -21,7 +21,7 @@ class BuildResultTests: AppTestCase {
 
     func test_query() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         let repo = try Repository(package: pkg)
         try await repo.save(on: app.db)
         let version = try Version(package: pkg)

--- a/Tests/AppTests/BuildShowModelTests.swift
+++ b/Tests/AppTests/BuildShowModelTests.swift
@@ -31,7 +31,7 @@ class BuildShowModelTests: AppTestCase {
 
     func test_init() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                        defaultBranch: "main",
                        forks: 42,

--- a/Tests/AppTests/BuildTests.swift
+++ b/Tests/AppTests/BuildTests.swift
@@ -24,7 +24,7 @@ class BuildTests: AppTestCase {
 
     func test_save() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let v = try Version(package: pkg)
         try await v.save(on: app.db)
         let b = try Build(version: v,
@@ -53,7 +53,7 @@ class BuildTests: AppTestCase {
     func test_delete_cascade() async throws {
         // Ensure deleting a version also deletes the builds
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let v = try Version(package: pkg)
         try await v.save(on: app.db)
         let b = try Build(version: v,
@@ -79,7 +79,7 @@ class BuildTests: AppTestCase {
     func test_unique_constraint() async throws {
         // Ensure builds are unique over (id, platform, swiftVersion)
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let v1 = try Version(package: pkg)
         try await v1.save(on: app.db)
         let v2 = try Version(package: pkg)
@@ -132,7 +132,7 @@ class BuildTests: AppTestCase {
         Current.gitlabPipelineToken = { "pipeline token" }
         Current.siteURL = { "http://example.com" }
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         let v = try Version(package: p, reference: .branch("main"))
         try await v.save(on: app.db)
         let buildId = UUID()
@@ -197,7 +197,7 @@ class BuildTests: AppTestCase {
         Current.gitlabPipelineToken = { "pipeline token" }
         Current.siteURL = { "http://example.com" }
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         let v = try Version(package: p, reference: .branch("main"))
         try await v.save(on: app.db)
         let buildId = UUID()
@@ -245,7 +245,7 @@ class BuildTests: AppTestCase {
     func test_query() async throws {
         // Test querying by (platform/swiftVersion/versionId)
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let v1 = try Version(package: pkg)
         try await v1.save(on: app.db)
         do { // decoy version and build
@@ -307,7 +307,7 @@ class BuildTests: AppTestCase {
 
     func test_delete_by_versionId() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let vid1 = UUID()
         let v1 = try Version(id: vid1, package: pkg)
         try await v1.save(on: app.db)

--- a/Tests/AppTests/BuildTriggerTests.swift
+++ b/Tests/AppTests/BuildTriggerTests.swift
@@ -42,36 +42,36 @@ class BuildTriggerTests: AppTestCase {
                                 latest: .defaultBranch,
                                 reference: .branch("main"))
             try await v.save(on: app.db)
-            try BuildPair.all.forEach { pair in
-                try Build(id: UUID(),
-                          version: v,
-                          platform: pair.platform,
-                          status: .ok,
-                          swiftVersion: pair.swiftVersion)
-                    .save(on: app.db).wait()
+            for pair in BuildPair.all {
+                try await Build(id: UUID(),
+                                version: v,
+                                platform: pair.platform,
+                                status: .ok,
+                                swiftVersion: pair.swiftVersion)
+                .save(on: app.db)
             }
         }
         // save two packages with partially completed builds
-        try [pkgIdIncomplete1, pkgIdIncomplete2].forEach { id in
+        for id in [pkgIdIncomplete1, pkgIdIncomplete2] {
             let p = Package(id: id, url: id.uuidString.url)
-            try p.save(on: app.db).wait()
-            try [Version.Kind.defaultBranch, .release].forEach { kind in
+            try await p.save(on: app.db)
+            for kind in [Version.Kind.defaultBranch, .release] {
                 let v = try Version(package: p,
                                     latest: kind,
                                     reference: kind == .release
-                                        ? .tag(1, 2, 3)
-                                        : .branch("main"))
-                try v.save(on: app.db).wait()
-                try BuildPair.all
+                                    ? .tag(1, 2, 3)
+                                    : .branch("main"))
+                try await v.save(on: app.db)
+                for pair in BuildPair.all
                     .dropFirst() // skip one platform to create a build gap
-                    .forEach { pair in
-                        try Build(id: UUID(),
-                                  version: v,
-                                  platform: pair.platform,
-                                  status: .ok,
-                                  swiftVersion: pair.swiftVersion)
-                            .save(on: app.db).wait()
-                    }
+                {
+                    try await Build(id: UUID(),
+                                    version: v,
+                                    platform: pair.platform,
+                                    status: .ok,
+                                    swiftVersion: pair.swiftVersion)
+                    .save(on: app.db)
+                }
             }
         }
 
@@ -90,13 +90,13 @@ class BuildTriggerTests: AppTestCase {
         let pkgId = UUID()
         let p = Package(id: pkgId, url: pkgId.uuidString.url)
         try await p.save(on: app.db)
-        try [Version.Kind.defaultBranch, .release].forEach { kind in
+        for kind in [Version.Kind.defaultBranch, .release] {
             let v = try Version(package: p,
                                 latest: kind,
                                 reference: kind == .release
-                                    ? .tag(1, 2, 3)
-                                    : .branch("main"))
-            try v.save(on: app.db).wait()
+                                ? .tag(1, 2, 3)
+                                : .branch("main"))
+            try await v.save(on: app.db)
         }
 
         // MUT
@@ -157,26 +157,26 @@ class BuildTriggerTests: AppTestCase {
         let pkgIdIncomplete2 = UUID()
         Current.buildTriggerAllowList = { [pkgIdIncomplete2] }
         // save two packages with partially completed builds
-        try [pkgIdIncomplete1, pkgIdIncomplete2].forEach { id in
+        for id in [pkgIdIncomplete1, pkgIdIncomplete2] {
             let p = Package(id: id, url: id.uuidString.url)
-            try p.save(on: app.db).wait()
-            try [Version.Kind.defaultBranch, .release].forEach { kind in
+            try await p.save(on: app.db)
+            for kind in [Version.Kind.defaultBranch, .release] {
                 let v = try Version(package: p,
                                     latest: kind,
                                     reference: kind == .release
                                         ? .tag(1, 2, 3)
                                         : .branch("main"))
-                try v.save(on: app.db).wait()
-                try BuildPair.all
+                try await v.save(on: app.db)
+                for pair in BuildPair.all
                     .dropFirst() // skip one platform to create a build gap
-                    .forEach { pair in
-                        try Build(id: UUID(),
-                                  version: v,
-                                  platform: pair.platform,
-                                  status: .ok,
-                                  swiftVersion: pair.swiftVersion)
-                            .save(on: app.db).wait()
-                    }
+                {
+                    try await Build(id: UUID(),
+                                    version: v,
+                                    platform: pair.platform,
+                                    status: .ok,
+                                    swiftVersion: pair.swiftVersion)
+                    .save(on: app.db)
+                }
             }
         }
 
@@ -213,16 +213,16 @@ class BuildTriggerTests: AppTestCase {
                                 latest: .release,
                                 reference: .tag(1, 2, 3))
             try await v.save(on: app.db)
-            try Build.Platform.allActive
-                .filter { $0 != droppedPlatform } // skip one platform to create a build gap
-                .forEach { platform in
-                try SwiftVersion.allActive.forEach { swiftVersion in
-                    try Build(id: UUID(),
-                              version: v,
-                              platform: platform,
-                              status: .ok,
-                              swiftVersion: swiftVersion)
-                        .save(on: app.db).wait()
+            for platform in Build.Platform.allActive
+                .filter({ $0 != droppedPlatform }) // skip one platform to create a build gap
+            {
+                for swiftVersion in SwiftVersion.allActive {
+                    try await Build(id: UUID(),
+                                    version: v,
+                                    platform: platform,
+                                    status: .ok,
+                                    swiftVersion: swiftVersion)
+                    .save(on: app.db)
                 }
             }
         }
@@ -303,16 +303,16 @@ class BuildTriggerTests: AppTestCase {
                                   - documentation_targets: [t0]
                                 """))
             try await v.save(on: app.db)
-            try Build.Platform.allActive
-                .filter { $0 != .macosSpm } // skip macosSpm platform to create a build gap
-                .forEach { platform in
-                try SwiftVersion.allActive.forEach { swiftVersion in
-                    try Build(id: UUID(),
-                              version: v,
-                              platform: platform,
-                              status: .ok,
-                              swiftVersion: swiftVersion)
-                        .save(on: app.db).wait()
+            for platform in Build.Platform.allActive
+                .filter({ $0 != .macosSpm }) // skip macosSpm platform to create a build gap
+            {
+                for swiftVersion in SwiftVersion.allActive {
+                    try await Build(id: UUID(),
+                                    version: v,
+                                    platform: platform,
+                                    status: .ok,
+                                    swiftVersion: swiftVersion)
+                    .save(on: app.db)
                 }
             }
         }
@@ -671,11 +671,11 @@ class BuildTriggerTests: AppTestCase {
         Current.getStatusCount = { c, _ in 299 + triggerCount.withLockedValue { $0 } }
 
         let pkgIds = [UUID(), UUID()]
-        try pkgIds.forEach { id in
+        for id in pkgIds {
             let p = Package(id: id, url: id.uuidString.url)
-            try p.save(on: app.db).wait()
-            try Version(id: UUID(), package: p, latest: .defaultBranch, reference: .branch("main"))
-                .save(on: app.db).wait()
+            try await p.save(on: app.db)
+            try await Version(id: UUID(), package: p, latest: .defaultBranch, reference: .branch("main"))
+                .save(on: app.db)
         }
 
         // MUT
@@ -705,7 +705,8 @@ class BuildTriggerTests: AppTestCase {
             .save(on: app.db)
         // shift createdAt back to make build eligible from trimming
         try await updateBuildCreatedAt(id: .id2, addTimeInterval: -.hours(5), on: app.db)
-        XCTAssertEqual(try Build.query(on: app.db).count().wait(), 1)
+        let db = app.db
+        try await XCTAssertEqualAsync(try await Build.query(on: db).count(), 1)
 
         // MUT
         try await triggerBuilds(on: app.db,
@@ -1019,7 +1020,8 @@ class BuildTriggerTests: AppTestCase {
             try await updateBuildCreatedAt(id: .id2, addTimeInterval: -.hours(5), on: app.db)
         }
 
-        XCTAssertEqual(try Build.query(on: app.db).count().wait(), 3)
+        let db = app.db
+        try await XCTAssertEqualAsync(try await Build.query(on: db).count(), 3)
 
         // MUT
         let deleteCount = try await trimBuilds(on: app.db)
@@ -1055,7 +1057,8 @@ class BuildTriggerTests: AppTestCase {
             try await updateBuildCreatedAt(id: .id2, addTimeInterval: -.hours(5), on: app.db)
         }
 
-        XCTAssertEqual(try Build.query(on: app.db).count().wait(), 3)
+        let db = app.db
+        try await XCTAssertEqualAsync(try await Build.query(on: db).count(), 3)
 
         // MUT
         let deleteCount = try await trimBuilds(on: app.db)
@@ -1111,7 +1114,8 @@ class BuildTriggerTests: AppTestCase {
             }
         }
 
-        XCTAssertEqual(try Build.query(on: app.db).count().wait(), 8)
+        let db = app.db
+        try await XCTAssertEqualAsync(try await Build.query(on: db).count(), 8)
 
         // MUT
         let deleteCount = try await trimBuilds(on: app.db)
@@ -1167,7 +1171,8 @@ class BuildTriggerTests: AppTestCase {
 
         // validate
         XCTAssertEqual(deleteCount, 0)
-        XCTAssertEqual(try Build.query(on: app.db).count().wait(), 1)
+        let db = app.db
+        try await XCTAssertEqualAsync(try await Build.query(on: db).count(), 1)
 
         // make build "old" by resetting "created_at"
         try await updateBuildCreatedAt(id: buildId, addTimeInterval: -.hours(4), on: app.db)
@@ -1202,7 +1207,8 @@ class BuildTriggerTests: AppTestCase {
 
         // validate
         XCTAssertEqual(deleteCount, 0)
-        XCTAssertEqual(try Build.query(on: app.db).count().wait(), 1)
+        let db = app.db
+        try await XCTAssertEqualAsync(try await Build.query(on: db).count(), 1)
 
         // make build "old" by resetting "created_at"
         try await updateBuildCreatedAt(id: buildId, addTimeInterval: -.hours(5), on: app.db)

--- a/Tests/AppTests/DocUploadTests.swift
+++ b/Tests/AppTests/DocUploadTests.swift
@@ -22,7 +22,7 @@ final class DocUploadTests: AppTestCase {
 
     func test_attach() async throws {
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let versionId = UUID()
         let buildId = UUID()
         let docUploadId = UUID()
@@ -57,7 +57,7 @@ final class DocUploadTests: AppTestCase {
     func test_detachAndDelete() async throws {
         // Ensure deleting doc_uploads doesn't cascade into builds
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let v = try Version(id: UUID(), package: pkg)
         try await v.save(on: app.db)
         let buildId = UUID()
@@ -89,7 +89,7 @@ final class DocUploadTests: AppTestCase {
 
     func test_delete_cascade_build() async throws {
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let buildId = UUID()
         let v = try Version(id: UUID(), package: pkg)
         try await v.save(on: app.db)
@@ -115,7 +115,7 @@ final class DocUploadTests: AppTestCase {
 
     func test_delete_cascade_version() async throws {
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let versionId = UUID()
         let v = try Version(id: versionId, package: pkg)
         try await v.save(on: app.db)
@@ -142,7 +142,7 @@ final class DocUploadTests: AppTestCase {
     func test_unique_constraint_doc_uploads_build_id() async throws {
         // Ensure different doc_uploads cannot be attached to the same build
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let v = try Version(id: UUID(), package: pkg)
         try await v.save(on: app.db)
         let b = try Build(version: v, platform: .iOS, status: .ok, swiftVersion: .v3)
@@ -167,7 +167,7 @@ final class DocUploadTests: AppTestCase {
     func test_unique_constraint_builds_doc_upload_id_1() async throws {
         // Ensure doc_upload cannot be attached to two different versions (via builds from two different versions)
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let v1 = try Version(id: UUID(), package: pkg)
         try await v1.save(on: app.db)
         let v2 = try Version(id: UUID(), package: pkg)
@@ -195,7 +195,7 @@ final class DocUploadTests: AppTestCase {
     func test_unique_constraint_builds_doc_upload_id_2() async throws {
         // Ensure doc_upload cannot be attached to same version more than once (via two builds from same version)
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let v = try Version(id: UUID(), package: pkg)
         try await v.save(on: app.db)
         let b1 = try Build(id: UUID(), version: v, platform: .linux, status: .ok, swiftVersion: .v3)
@@ -221,7 +221,7 @@ final class DocUploadTests: AppTestCase {
     func test_unique_constraint_builds_version_id_partial() async throws {
         // Ensure no single version can reference two doc_uploads
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let v = try Version(id: UUID(), package: pkg)
         try await v.save(on: app.db)
         let b1 = try Build(id: UUID(), version: v, platform: .linux, status: .ok, swiftVersion: .v3)

--- a/Tests/AppTests/DocumentationTargetTests.swift
+++ b/Tests/AppTests/DocumentationTargetTests.swift
@@ -22,7 +22,7 @@ final class DocumentationTargetTests: AppTestCase {
     func test_external() async throws {
         // Test external doc url lookup
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              name: "bar",
                              owner: "foo").save(on: app.db)
@@ -50,7 +50,7 @@ final class DocumentationTargetTests: AppTestCase {
     func test_external_override() async throws {
         // Test external doc url lookup overriding internal doc archives
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              name: "bar",
                              owner: "foo").save(on: app.db)
@@ -80,7 +80,7 @@ final class DocumentationTargetTests: AppTestCase {
 
     func test_internal_defaultBranch() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              name: "bar",
                              owner: "foo").save(on: app.db)
@@ -104,7 +104,7 @@ final class DocumentationTargetTests: AppTestCase {
 
     func test_internal_stableBranch() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              name: "bar",
                              owner: "foo").save(on: app.db)

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -25,7 +25,7 @@ class ErrorReportingTests: AppTestCase {
                               error: AppError.cacheDirectoryDoesNotExist(pkg.id, "path"),
                               stage: .ingestion)
         do {
-            let pkg = try fetch(id: pkg.id, on: app.db)
+            let pkg = try await XCTUnwrapAsync(try await Package.find(pkg.id, on: app.db))
             XCTAssertEqual(pkg.status, .cacheDirectoryDoesNotExist)
             XCTAssertEqual(pkg.processingStage, .ingestion)
         }

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -20,7 +20,7 @@ import XCTVapor
 class ErrorReportingTests: AppTestCase {
 
     func test_recordError() async throws {
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await recordError(database: app.db,
                               error: AppError.cacheDirectoryDoesNotExist(pkg.id, "path"),
                               stage: .ingestion)
@@ -73,7 +73,7 @@ class ErrorReportingTests: AppTestCase {
 
     func test_invalidPackageCachePath() async throws {
         // setup
-        try await savePackagesAsync(on: app.db, ["1", "2"], processingStage: .ingestion)
+        try await savePackages(on: app.db, ["1", "2"], processingStage: .ingestion)
 
         // MUT
         try await Analyze.analyze(client: app.client,

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -64,8 +64,8 @@ class IngestorTests: AppTestCase {
             case badRequest
         }
 
-        let packages = try await savePackagesAsync(on: app.db, ["https://github.com/foo/1",
-                                                                "https://github.com/foo/2"])
+        let packages = try await savePackages(on: app.db, ["https://github.com/foo/1",
+                                                           "https://github.com/foo/2"])
             .map(Joined<Package, Repository>.init(model:))
         Current.fetchMetadata = { _, owner, repository in
             if owner == "foo" && repository == "1" {
@@ -87,7 +87,7 @@ class IngestorTests: AppTestCase {
     }
 
     func test_updateRepository_insert() async throws {
-        let pkg = try await savePackageAsync(on: app.db, "https://github.com/foo/bar")
+        let pkg = try await savePackage(on: app.db, "https://github.com/foo/bar")
         let repo = Repository(packageId: try pkg.requireID())
 
         // MUT
@@ -108,7 +108,7 @@ class IngestorTests: AppTestCase {
     }
 
     func test_updateRepository_update() async throws {
-        let pkg = try await savePackageAsync(on: app.db, "https://github.com/foo/bar")
+        let pkg = try await savePackage(on: app.db, "https://github.com/foo/bar")
         let repo = Repository(packageId: try pkg.requireID())
         let md: Github.Metadata = .init(defaultBranch: "main",
                                         forks: 1,
@@ -199,7 +199,7 @@ class IngestorTests: AppTestCase {
 
     func test_homePageEmptyString() async throws {
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "2")
+        let pkg = try await savePackage(on: app.db, "2")
         let repo = Repository(packageId: try pkg.requireID())
         let md: Github.Metadata = .init(defaultBranch: "main",
                                         forks: 1,
@@ -236,8 +236,8 @@ class IngestorTests: AppTestCase {
 
     func test_updatePackage() async throws {
         // setup
-        let pkgs = try await savePackagesAsync(on: app.db, ["https://github.com/foo/1",
-                                                            "https://github.com/foo/2"])
+        let pkgs = try await savePackages(on: app.db, ["https://github.com/foo/1",
+                                                       "https://github.com/foo/2"])
             .map(Joined<Package, Repository>.init(model:))
         let results: [Result<Joined<Package, Repository>, Error>] = [
             .failure(AppError.genericError(try pkgs[0].model.requireID(), "error 1")),
@@ -304,8 +304,8 @@ class IngestorTests: AppTestCase {
         let urls = ["https://github.com/foo/1",
                     "https://github.com/foo/2",
                     "https://github.com/foo/3"]
-        let packages = try await savePackagesAsync(on: app.db, urls.asURLs,
-                                                   processingStage: .reconciliation)
+        let packages = try await savePackages(on: app.db, urls.asURLs,
+                                              processingStage: .reconciliation)
         Current.fetchMetadata = { _, owner, repository in
             if owner == "foo" && repository == "2" {
                 throw AppError.genericError(packages[1].id, "error 2")

--- a/Tests/AppTests/Joined3Tests.swift
+++ b/Tests/AppTests/Joined3Tests.swift
@@ -21,7 +21,7 @@ class Joined3Tests: AppTestCase {
 
     func test_query_no_version() async throws {
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p).save(on: app.db)
 
         // MUT
@@ -34,7 +34,7 @@ class Joined3Tests: AppTestCase {
     func test_query_multiple_versions() async throws {
         // Ensure multiple versions don't multiply the package selection
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p).save(on: app.db)
         try await Version(package: p, latest: .defaultBranch).save(on: app.db)
         try await Version(package: p, latest: .release).save(on: app.db)
@@ -52,7 +52,7 @@ class Joined3Tests: AppTestCase {
     func test_query_relationship_properties() async throws {
         // Ensure relationship properties are populated by query
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p, owner: "owner").save(on: app.db)
         try await Version(package: p,
                     latest: .defaultBranch,
@@ -73,7 +73,7 @@ class Joined3Tests: AppTestCase {
         // force unwrap the `repository` or `version` properties in the pathological
         // event, because there are no results to access the properties on.
         do {  // no repository
-            let p = try savePackage(on: app.db, "1")
+            let p = try await savePackage(on: app.db, "1")
             try await Version(package: p,
                         latest: .defaultBranch,
                         packageName: "package name").save(on: app.db)
@@ -87,7 +87,7 @@ class Joined3Tests: AppTestCase {
             XCTAssertTrue(res.isEmpty)
         }
         do {  // no version
-            let p = try savePackage(on: app.db, "2")
+            let p = try await savePackage(on: app.db, "2")
             try await Repository(package: p, owner: "owner").save(on: app.db)
 
             // MUT

--- a/Tests/AppTests/JoinedQueryBuilderTests.swift
+++ b/Tests/AppTests/JoinedQueryBuilderTests.swift
@@ -26,8 +26,8 @@ class JoinedQueryBuilderTests: AppTestCase {
 
     func test_sort() async throws {
         // setup
-        try (0..<3).shuffled().forEach { idx in
-            try Package(url: "\(idx)".url).save(on: app.db).wait()
+        for idx in (0..<3).shuffled() {
+            try await Package(url: "\(idx)".url).save(on: app.db)
         }
         // query helper
         func query() -> JoinedQueryBuilder<Package> {

--- a/Tests/AppTests/JoinedTests.swift
+++ b/Tests/AppTests/JoinedTests.swift
@@ -44,7 +44,7 @@ class JoinedTests: AppTestCase {
     func test_repository_access() async throws {
         // Test accessing repository through the join vs through the package relation
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p).save(on: app.db)
 
         // MUT
@@ -65,7 +65,7 @@ class JoinedTests: AppTestCase {
     func test_repository_update() async throws {
         // Test updating the repository through the join
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p).save(on: app.db)
 
         let jpr = try await XCTUnwrapAsync(try await JPR.query(on: app.db).first())

--- a/Tests/AppTests/KeywordControllerTests.swift
+++ b/Tests/AppTests/KeywordControllerTests.swift
@@ -22,7 +22,7 @@ class KeywordControllerTests: AppTestCase {
     func test_query() async throws {
         // setup
         do {
-            let p = try savePackage(on: app.db, "0")
+            let p = try await savePackage(on: app.db, "0")
             try await Repository(package: p,
                                  keywords: ["bar"],
                                  name: "0",
@@ -31,7 +31,7 @@ class KeywordControllerTests: AppTestCase {
             try await Version(package: p, latest: .defaultBranch).save(on: app.db)
         }
         do {
-            let p = try savePackage(on: app.db, "1")
+            let p = try await savePackage(on: app.db, "1")
             try await Repository(package: p,
                                  keywords: ["foo"],
                                  name: "1",
@@ -40,7 +40,7 @@ class KeywordControllerTests: AppTestCase {
             try await Version(package: p, latest: .defaultBranch).save(on: app.db)
         }
         do {
-            let p = try savePackage(on: app.db, "2")
+            let p = try await savePackage(on: app.db, "2")
             try await Repository(package: p,
                                  name: "2",
                                  owner: "owner")
@@ -104,7 +104,7 @@ class KeywordControllerTests: AppTestCase {
     func test_show_keyword() async throws {
         // setup
         do {
-            let p = try savePackage(on: app.db, "1")
+            let p = try await savePackage(on: app.db, "1")
             try await Repository(package: p,
                                  keywords: ["foo"],
                                  name: "1",

--- a/Tests/AppTests/MetricsTests.swift
+++ b/Tests/AppTests/MetricsTests.swift
@@ -62,7 +62,7 @@ class MetricsTests: AppTestCase {
         let initialDeletedTag = try XCTUnwrap(
             AppMetrics.analyzeVersionsDeletedCount?.get(.versionLabels(kind: .tag))
         )
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let new = [
             try Version(package: pkg, reference: .branch("main")),
             try Version(package: pkg, reference: .tag(1, 2, 3)),
@@ -110,7 +110,7 @@ class MetricsTests: AppTestCase {
 
     func test_ingestDurationSeconds() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
 
         // MUT
         try await ingest(client: app.client, database: app.db, mode: .id(pkg.id!))
@@ -121,7 +121,7 @@ class MetricsTests: AppTestCase {
 
     func test_analyzeDurationSeconds() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
 
         // MUT
         try await Analyze.analyze(client: app.client, database: app.db, mode: .id(pkg.id!))
@@ -132,7 +132,7 @@ class MetricsTests: AppTestCase {
 
     func test_triggerBuildsDurationSeconds() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
 
         // MUT
         try await triggerBuilds(on: app.db, client: app.client, mode: .packageId(pkg.id!, force: true))

--- a/Tests/AppTests/PackageCollectionTests.swift
+++ b/Tests/AppTests/PackageCollectionTests.swift
@@ -37,7 +37,7 @@ class PackageCollectionTests: AppTestCase {
         // Tests PackageResult.query with the url filter option
         // setup
         for index in (0..<3) {
-            let pkg = try savePackage(on: app.db, "url-\(index)".url)
+            let pkg = try await savePackage(on: app.db, "url-\(index)".url)
             do {
                 let v = try Version(package: pkg,
                                     latest: .release,
@@ -84,7 +84,7 @@ class PackageCollectionTests: AppTestCase {
         // Tests PackageResult.query without results has safe relationship accessors
         // setup
         for index in (0..<3) {
-            let pkg = try savePackage(on: app.db, "url-\(index)".url)
+            let pkg = try await savePackage(on: app.db, "url-\(index)".url)
             do {
                 let v = try Version(package: pkg,
                                     latest: .release,
@@ -131,7 +131,7 @@ class PackageCollectionTests: AppTestCase {
         // first package
         let owners = ["foo", "foo", "someone else"]
         for index in (0..<3) {
-            let pkg = try savePackage(on: app.db, "url-\(index)".url)
+            let pkg = try await savePackage(on: app.db, "url-\(index)".url)
             do {
                 let v = try Version(package: pkg,
                                     latest: .release,
@@ -346,7 +346,7 @@ class PackageCollectionTests: AppTestCase {
     func test_generate_from_urls() async throws {
         // setup
         Current.date = { Date(timeIntervalSince1970: 1610112345) }
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         do {
             let v = try Version(package: pkg,
                                 latest: .release,
@@ -395,7 +395,7 @@ class PackageCollectionTests: AppTestCase {
         // setup
         Current.date = { Date(timeIntervalSince1970: 1610112345) }
         // first package
-        let p1 = try savePackage(on: app.db, "https://github.com/foo/1")
+        let p1 = try await savePackage(on: app.db, "https://github.com/foo/1")
         do {
             let v = try Version(id: UUID(),
                                 package: p1,
@@ -423,7 +423,7 @@ class PackageCollectionTests: AppTestCase {
             try await Target(version: v, name: "t1").save(on: app.db)
         }
         // second package
-        let p2 = try savePackage(on: app.db, "https://github.com/foo/2")
+        let p2 = try await savePackage(on: app.db, "https://github.com/foo/2")
         do {
             let v = try Version(id: UUID(),
                                 package: p2,
@@ -447,7 +447,7 @@ class PackageCollectionTests: AppTestCase {
             try await Target(version: v, name: "t2").save(on: app.db)
         }
         // unrelated package
-        _ = try savePackage(on: app.db, "https://github.com/bar/1")
+        _ = try await savePackage(on: app.db, "https://github.com/bar/1")
         try await Repository(package: p1,
                              defaultBranch: "main",
                              license: .mit,
@@ -491,7 +491,7 @@ class PackageCollectionTests: AppTestCase {
         // Ensure we only export significant versions
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1147
         // setup
-        let p = try savePackage(on: app.db, "https://github.com/foo/1")
+        let p = try await savePackage(on: app.db, "https://github.com/foo/1")
         try await Repository(package: p,
                              defaultBranch: "main",
                              license: .mit,
@@ -631,7 +631,7 @@ class PackageCollectionTests: AppTestCase {
 
     func test_case_insensitive_owner_matching() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "https://github.com/foo/1")
+        let pkg = try await savePackage(on: app.db, "https://github.com/foo/1")
         do {
             let v = try Version(id: UUID(),
                                 package: pkg,
@@ -665,7 +665,7 @@ class PackageCollectionTests: AppTestCase {
         // Ensure ownerName is used in collectionName and overview
         // setup
         // first package
-        let p1 = try savePackage(on: app.db, "https://github.com/foo/1")
+        let p1 = try await savePackage(on: app.db, "https://github.com/foo/1")
         do {
             let v = try Version(id: UUID(),
                                 package: p1,

--- a/Tests/AppTests/PackageContributorsTests.swift
+++ b/Tests/AppTests/PackageContributorsTests.swift
@@ -65,7 +65,7 @@ class PackageContributorsTests : AppTestCase {
 
     func test_PackageContributors_extract() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1".asGithubUrl.url)
+        let pkg = try await savePackage(on: app.db, "1".asGithubUrl.url)
         Current.fileManager.fileExists = { @Sendable _ in true }
         Current.git.shortlog = { @Sendable _ in
             """

--- a/Tests/AppTests/PackageController+BuildsRouteTests.swift
+++ b/Tests/AppTests/PackageController+BuildsRouteTests.swift
@@ -24,7 +24,7 @@ class PackageController_BuildsRouteTests: AppTestCase {
     func test_BuildInfo_query() async throws {
         // setup
         do {
-            let pkg = try savePackage(on: app.db, "1".url)
+            let pkg = try await savePackage(on: app.db, "1".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  name: "bar",
@@ -50,7 +50,7 @@ class PackageController_BuildsRouteTests: AppTestCase {
             }
         }
         do { // unrelated package and build
-            let pkg = try savePackage(on: app.db, "2".url)
+            let pkg = try await savePackage(on: app.db, "2".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  name: "bar2",
@@ -86,7 +86,7 @@ class PackageController_BuildsRouteTests: AppTestCase {
 
     func test_query() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              defaultBranch: "main",
                              forks: 42,
@@ -120,7 +120,7 @@ class PackageController_BuildsRouteTests: AppTestCase {
 
     func test_query_no_builds() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              defaultBranch: "main",
                              forks: 42,

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -23,16 +23,16 @@ import Vapor
 
 class PackageController_routesTests: SnapshotTestCase {
 
-    func test_show() throws {
+    func test_show() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "package", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg, latest: .defaultBranch).save(on: app.db).wait()
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg, latest: .defaultBranch).save(on: app.db)
 
         // MUT
-        try app.test(.GET, "/owner/package") {
-            XCTAssertEqual($0.status, .ok)
+        try await app.test(.GET, "/owner/package") { res async in
+            XCTAssertEqual(res.status, .ok)
         }
     }
 
@@ -67,7 +67,7 @@ class PackageController_routesTests: SnapshotTestCase {
 
     func test_ShowModel_packageAvailable() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg, latest: .defaultBranch).save(on: app.db)
@@ -136,7 +136,7 @@ class PackageController_routesTests: SnapshotTestCase {
     func test_readme_route() async throws {
         // Test that readme route is set up
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg, latest: .defaultBranch).save(on: app.db)
@@ -150,7 +150,7 @@ class PackageController_routesTests: SnapshotTestCase {
     func test_readme_basic() async throws {
         // Test readme fragment happy path
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, defaultBranch: "main", name: "package", owner: "owner", readmeHtmlUrl: "html url")
             .save(on: app.db)
         try await Version(package: pkg, latest: .defaultBranch).save(on: app.db)
@@ -172,7 +172,7 @@ class PackageController_routesTests: SnapshotTestCase {
     func test_readme_no_readmeHtmlUrl() async throws {
         // Test readme fragment when there's no readme html url
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner", readmeHtmlUrl: nil)
             .save(on: app.db)
         try await Version(package: pkg, latest: .defaultBranch).save(on: app.db)
@@ -201,7 +201,7 @@ class PackageController_routesTests: SnapshotTestCase {
         // setup
         struct Error: Swift.Error { }
         Current.fetchS3Readme = { _, _, _ in throw Error() }
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg,
                              name: "package",
                              owner: "owner",
@@ -231,58 +231,58 @@ class PackageController_routesTests: SnapshotTestCase {
         XCTAssert(s3Readme.isError)
     }
 
-    func test_releases() throws {
+    func test_releases() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "package", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg, latest: .defaultBranch).save(on: app.db).wait()
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg, latest: .defaultBranch).save(on: app.db)
 
         // MUT
-        try app.test(.GET, "/owner/package/releases") {
-            XCTAssertEqual($0.status, .ok)
+        try await app.test(.GET, "/owner/package/releases") { res async in
+            XCTAssertEqual(res.status, .ok)
         }
     }
 
-    func test_builds() throws {
+    func test_builds() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "package", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg, latest: .defaultBranch).save(on: app.db).wait()
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg, latest: .defaultBranch).save(on: app.db)
 
         // MUT
-        try app.test(.GET, "/owner/package/builds") {
-            XCTAssertEqual($0.status, .ok)
+        try await app.test(.GET, "/owner/package/builds") { res async in
+            XCTAssertEqual(res.status, .ok)
         }
     }
 
-    func test_maintainerInfo() throws {
+    func test_maintainerInfo() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "package", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg, latest: .defaultBranch, packageName: "pkg")
-            .save(on: app.db).wait()
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg, latest: .defaultBranch, packageName: "pkg")
+            .save(on: app.db)
 
         // MUT
-        try app.test(.GET, "/owner/package/information-for-package-maintainers") {
-            XCTAssertEqual($0.status, .ok)
+        try await app.test(.GET, "/owner/package/information-for-package-maintainers") { res async in
+            XCTAssertEqual(res.status, .ok)
         }
     }
 
-    func test_maintainerInfo_no_packageName() throws {
+    func test_maintainerInfo_no_packageName() async throws {
         // Ensure we display the page even if packageName is not set
         // setup
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "package", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg, latest: .defaultBranch, packageName: nil)
-            .save(on: app.db).wait()
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg, latest: .defaultBranch, packageName: nil)
+            .save(on: app.db)
 
         // MUT
-        try app.test(.GET, "/owner/package/information-for-package-maintainers") {
-            XCTAssertEqual($0.status, .ok)
+        try await app.test(.GET, "/owner/package/information-for-package-maintainers") { res async in
+            XCTAssertEqual(res.status, .ok)
         }
     }
 
@@ -431,7 +431,7 @@ class PackageController_routesTests: SnapshotTestCase {
         // Test the redirect documentation routes without any reference:
         //   /owner/package/documentation + various path elements
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -487,7 +487,7 @@ class PackageController_routesTests: SnapshotTestCase {
         // Test the current (~) documentation routes:
         //   /owner/package/documentation/~ + various path elements
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -565,7 +565,7 @@ class PackageController_routesTests: SnapshotTestCase {
         // Test the current (~) documentation routes with baseURL rewriting:
         //   /owner/package/documentation/~ + various path elements
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -635,7 +635,7 @@ class PackageController_routesTests: SnapshotTestCase {
         // Test the documentation routes with a reference:
         //   /owner/package/documentation/{reference} + various path elements
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -710,7 +710,7 @@ class PackageController_routesTests: SnapshotTestCase {
     func test_documentation_routes_no_archive() async throws {
         // Test documentation routes when no archive is in the path
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -746,85 +746,85 @@ class PackageController_routesTests: SnapshotTestCase {
         }
     }
 
-    func test_documentationRoot_notFound() throws {
+    func test_documentationRoot_notFound() async throws {
         // setup
         Current.fetchDocumentation = { _, _ in .init(status: .notFound) }
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "package", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg,
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg,
                     commit: "0123456789",
                     commitDate: .t0,
                     docArchives: [], // No docArchives!
                     latest: .defaultBranch,
                     packageName: "pkg",
                     reference: .branch("main"))
-        .save(on: app.db).wait()
-        try Version(package: pkg,
+        .save(on: app.db)
+        try await Version(package: pkg,
                     commit: "9876543210",
                     commitDate: .t0,
                     docArchives: [], // No docArchives!
                     latest: .release,
                     packageName: "pkg",
                     reference: .tag(1, 0, 0))
-        .save(on: app.db).wait()
+        .save(on: app.db)
 
         // MUT
-        try app.test(.GET, "/owner/package/main/documentation") {
-            XCTAssertEqual($0.status, .notFound)
+        try await app.test(.GET, "/owner/package/main/documentation") { res async in
+            XCTAssertEqual(res.status, .notFound)
         }
-        try app.test(.GET, "/owner/package/1.0.0/documentation") {
-            XCTAssertEqual($0.status, .notFound)
+        try await app.test(.GET, "/owner/package/1.0.0/documentation") { res async in
+            XCTAssertEqual(res.status, .notFound)
         }
     }
 
-    func test_documentation_404() throws {
+    func test_documentation_404() async throws {
         // Test conversion of any doc fetching errors into 404s.
         // setup
         Current.fetchDocumentation = { _, uri in .init(status: .badRequest) }
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "package", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg, latest: .defaultBranch, packageName: "pkg")
-            .save(on: app.db).wait()
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg, latest: .defaultBranch, packageName: "pkg")
+            .save(on: app.db)
 
         // MUT
         // test base url
-        try app.test(.GET, "/owner/package/1.2.3/documentation") {
-            XCTAssertEqual($0.status, .notFound)
+        try await app.test(.GET, "/owner/package/1.2.3/documentation") { res async in
+            XCTAssertEqual(res.status, .notFound)
         }
 
         // test path a/b
-        try app.test(.GET, "/owner/package/1.2.3/documentation/a/b") {
-            XCTAssertEqual($0.status, .notFound)
+        try await app.test(.GET, "/owner/package/1.2.3/documentation/a/b") { res async in
+            XCTAssertEqual(res.status, .notFound)
         }
     }
 
-    func test_documentation_error() throws {
+    func test_documentation_error() async throws {
         // Test behaviour when fetchDocumentation throws
         struct SomeError: Error { }
         Current.fetchDocumentation = { _, _ in throw SomeError() }
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "package", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg,
-                    commit: "123",
-                    commitDate: .t0,
-                    docArchives: [.init(name: "foo", title: "Foo")],
-                    latest: .defaultBranch,
-                    packageName: "pkg",
-                    reference: .tag(1, 2, 3))
-            .save(on: app.db).wait()
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg,
+                          commit: "123",
+                          commitDate: .t0,
+                          docArchives: [.init(name: "foo", title: "Foo")],
+                          latest: .defaultBranch,
+                          packageName: "pkg",
+                          reference: .tag(1, 2, 3))
+        .save(on: app.db)
 
         // MUT
-        try app.test(.GET, "/owner/package/1.2.3/documentation") {
-            XCTAssertEqual($0.status, .seeOther)
-            XCTAssertEqual($0.headers.location, "/owner/package/1.2.3/documentation/foo")
+        try await app.test(.GET, "/owner/package/1.2.3/documentation") { res async in
+            XCTAssertEqual(res.status, .seeOther)
+            XCTAssertEqual(res.headers.location, "/owner/package/1.2.3/documentation/foo")
         }
-        try app.test(.GET, "/owner/package/1.2.3/documentation/foo") {
+        try await app.test(.GET, "/owner/package/1.2.3/documentation/foo") { res async in
             // hits Current.fetchDocumentation which throws, converted to notFound
             // Regression test for https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2015
-            XCTAssertEqual($0.status, .notFound)
+            XCTAssertEqual(res.status, .notFound)
         }
     }
 
@@ -834,7 +834,7 @@ class PackageController_routesTests: SnapshotTestCase {
             // embed uri.path in the body as a simple way to test the requested url
             .init(status: .ok, body: .init(string: uri.path))
         }
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -888,7 +888,7 @@ class PackageController_routesTests: SnapshotTestCase {
             // embed uri.path in the body as a simple way to test the requested url
             .init(status: .ok, body: .init(string: uri.path))
         }
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -942,7 +942,7 @@ class PackageController_routesTests: SnapshotTestCase {
             // embed uri.path in the body as a simple way to test the requested url
             .init(status: .ok, body: .init(string: uri.path))
         }
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -1008,7 +1008,7 @@ class PackageController_routesTests: SnapshotTestCase {
         }
     }
 
-    func test_documentation_canonicalCapitalisation() throws {
+    func test_documentation_canonicalCapitalisation() async throws {
         // setup
         Current.fetchDocumentation = { _, uri in
             // embed uri.path in the body as a simple way to test the requested url
@@ -1017,20 +1017,20 @@ class PackageController_routesTests: SnapshotTestCase {
         
         // The `packageName` property on the `Version` has been set to the lower-cased version so
         // we can be sure the canonical URL is built from the properties on the `Repository` model.
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "Package", owner: "Owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg,
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "Package", owner: "Owner")
+            .save(on: app.db)
+        try await Version(package: pkg,
                     commit: "0123456789",
                     commitDate: .t0,
                     docArchives: [.init(name: "docs", title: "Docs")],
                     latest: .defaultBranch,
                     packageName: "package",
                     reference: .tag(1, 2, 3))
-            .save(on: app.db).wait()
+            .save(on: app.db)
 
-        try app.test(.GET, "/owner/package/1.2.3/documentation/a/b") { response in
-            let document = try SwiftSoup.parse(response.body.string)
+        try await app.test(.GET, "/owner/package/1.2.3/documentation/a/b") { res async throws in
+            let document = try SwiftSoup.parse(res.body.string)
             let linkElements = try document.select("link[rel='canonical']")
             XCTAssertEqual(linkElements.count, 1)
 
@@ -1043,7 +1043,7 @@ class PackageController_routesTests: SnapshotTestCase {
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2287
         // Ensure references are path encoded
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -1102,7 +1102,7 @@ class PackageController_routesTests: SnapshotTestCase {
 
     func test_documentation_routes_tutorials() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, name: "package", owner: "owner")
             .save(on: app.db)
         try await Version(package: pkg,
@@ -1201,41 +1201,41 @@ class PackageController_routesTests: SnapshotTestCase {
         }
     }
 
-    func test_tutorial() throws {
+    func test_tutorial() async throws {
         // setup
         Current.fetchDocumentation = { _, uri in
             // embed uri.path in the body as a simple way to test the requested url
             .init(status: .ok, body: .init(string: "<p>\(uri.path)</p>"))
         }
-        let pkg = try savePackage(on: app.db, "1")
-        try Repository(package: pkg, name: "package", owner: "owner")
-            .save(on: app.db).wait()
-        try Version(package: pkg,
+        let pkg = try await savePackage(on: app.db, "1")
+        try await Repository(package: pkg, name: "package", owner: "owner")
+            .save(on: app.db)
+        try await Version(package: pkg,
                     commit: "0123456789",
                     commitDate: Date(timeIntervalSince1970: 0),
                     docArchives: [.init(name: "docs", title: "Docs")],
                     latest: .defaultBranch,
                     packageName: "pkg",
                     reference: .tag(.init(1, 2, 3)))
-            .save(on: app.db).wait()
+            .save(on: app.db)
 
         // MUT
         // test path a/b
-        try app.test(.GET, "/owner/package/1.2.3/tutorials/a/b") {
-            XCTAssertEqual($0.status, .ok)
-            XCTAssertEqual($0.content.contentType?.description, "text/html; charset=utf-8")
+        try await app.test(.GET, "/owner/package/1.2.3/tutorials/a/b") { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.content.contentType?.description, "text/html; charset=utf-8")
             XCTAssertTrue(
-                $0.body.asString().contains("<p>/owner/package/1.2.3/tutorials/a/b</p>"),
-                "was: \($0.body.asString())"
+                res.body.asString().contains("<p>/owner/package/1.2.3/tutorials/a/b</p>"),
+                "was: \(res.body.asString())"
             )
             // Assert body includes the docc.css stylesheet link (as a test that our proxy header injection works)
-            XCTAssertTrue($0.body.asString().contains(#"<link rel="stylesheet" href="/docc.css?test" />"#),
-                          "was: \($0.body.asString())")
+            XCTAssertTrue(res.body.asString().contains(#"<link rel="stylesheet" href="/docc.css?test" />"#),
+                          "was: \(res.body.asString())")
         }
 
         // Test case insensitive path.
-        try app.test(.GET, "/Owner/Package/1.2.3/tutorials/a/b") {
-            XCTAssertEqual($0.status, .ok)
+        try await app.test(.GET, "/Owner/Package/1.2.3/tutorials/a/b") { res async in
+            XCTAssertEqual(res.status, .ok)
         }
     }
 
@@ -1350,7 +1350,7 @@ class PackageController_routesTests: SnapshotTestCase {
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/2288
 
         // setup
-        let pkg = try savePackage(on: app.db, "https://github.com/foo/bar".url, processingStage: .ingestion)
+        let pkg = try await savePackage(on: app.db, "https://github.com/foo/bar".url, processingStage: .ingestion)
         try await Repository(package: pkg, defaultBranch: "main", name: "bar", owner: "foo")
             .save(on: app.db)
         try await Version(package: pkg,

--- a/Tests/AppTests/PackageInfoTests.swift
+++ b/Tests/AppTests/PackageInfoTests.swift
@@ -22,7 +22,7 @@ class PackageInfoTests: AppTestCase {
     func test_title_package_name() async throws {
         // Ensure title is populated from package.name()
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p, name: "repo name", owner: "owner")
             .save(on: app.db)
         try await Version(package: p, latest: .defaultBranch, packageName: "package name")
@@ -41,7 +41,7 @@ class PackageInfoTests: AppTestCase {
     func test_title_repo_name() async throws {
         // Ensure title is populated from repoName if package.name() is nil
         // setup
-        let p = try savePackage(on: app.db, "1")
+        let p = try await savePackage(on: app.db, "1")
         try await Repository(package: p, name: "repo name", owner: "owner")
             .save(on: app.db)
         try await Version(package: p, latest: .defaultBranch, packageName: nil)

--- a/Tests/AppTests/PackageResultTests.swift
+++ b/Tests/AppTests/PackageResultTests.swift
@@ -23,7 +23,7 @@ class PackageResultTests: AppTestCase {
     typealias PackageResult = PackageController.PackageResult
 
     func test_joined5() async throws {
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              defaultBranch: "main",
                              forks: 42,
@@ -56,7 +56,7 @@ class PackageResultTests: AppTestCase {
 
     func test_joined5_no_preRelease() async throws {
         do {
-            let pkg = try savePackage(on: app.db, "1".url)
+            let pkg = try await savePackage(on: app.db, "1".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  forks: 42,
@@ -74,7 +74,7 @@ class PackageResultTests: AppTestCase {
         }
         do {
             // unrelated package to test join behaviour
-            let pkg = try savePackage(on: app.db, "2".url)
+            let pkg = try await savePackage(on: app.db, "2".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  forks: 42,
@@ -104,7 +104,7 @@ class PackageResultTests: AppTestCase {
 
     func test_joined5_defaultBranch_only() async throws {
         do {
-            let pkg = try savePackage(on: app.db, "1".url)
+            let pkg = try await savePackage(on: app.db, "1".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  forks: 42,
@@ -119,7 +119,7 @@ class PackageResultTests: AppTestCase {
         }
         do {
             // unrelated package to test join behaviour
-            let pkg = try savePackage(on: app.db, "2".url)
+            let pkg = try await savePackage(on: app.db, "2".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  forks: 42,
@@ -148,7 +148,7 @@ class PackageResultTests: AppTestCase {
 
     func test_query_owner_repository() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              defaultBranch: "main",
                              forks: 42,
@@ -173,7 +173,7 @@ class PackageResultTests: AppTestCase {
 
     func test_query_owner_repository_case_insensitivity() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "1".url)
+        let pkg = try await savePackage(on: app.db, "1".url)
         try await Repository(package: pkg,
                              defaultBranch: "main",
                              forks: 42,
@@ -197,7 +197,7 @@ class PackageResultTests: AppTestCase {
 
     func test_activity() async throws {
         // setup
-        let pkg = try savePackage(on: app.db, "https://github.com/Alamofire/Alamofire")
+        let pkg = try await savePackage(on: app.db, "https://github.com/Alamofire/Alamofire")
         try await Repository(package: pkg,
                              lastIssueClosedAt: .t0,
                              lastPullRequestClosedAt: .t1,
@@ -225,7 +225,7 @@ class PackageResultTests: AppTestCase {
         // setup
         do {
             // first package has docs
-            let pkg = try savePackage(on: app.db, "1".url)
+            let pkg = try await savePackage(on: app.db, "1".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  forks: 42,
@@ -253,7 +253,7 @@ class PackageResultTests: AppTestCase {
         }
         do {
             // second package doesn't have docs
-            let pkg = try savePackage(on: app.db, "2".url)
+            let pkg = try await savePackage(on: app.db, "2".url)
             try await Repository(package: pkg,
                                  defaultBranch: "main",
                                  forks: 42,

--- a/Tests/AppTests/ReAnalyzeVersionsTests.swift
+++ b/Tests/AppTests/ReAnalyzeVersionsTests.swift
@@ -31,9 +31,9 @@ class ReAnalyzeVersionsTests: AppTestCase {
         // - then change input data in fields that are affecting existing versions (which `analysis` is "blind" to)
         // - run analysis again to confirm "blindness"
         // - run re-analysis and confirm changes are now reflected
-        let pkg = try savePackage(on: app.db,
-                                  "https://github.com/foo/1".url,
-                                  processingStage: .ingestion)
+        let pkg = try await savePackage(on: app.db,
+                                        "https://github.com/foo/1".url,
+                                        processingStage: .ingestion)
         let repoId = UUID()
         try await Repository(id: repoId,
                              package: pkg,
@@ -179,9 +179,9 @@ class ReAnalyzeVersionsTests: AppTestCase {
         // churn over and over on failing versions.
         let cutoff = Date.t1
         Current.date = { .t2 }
-        let pkg = try savePackage(on: app.db,
-                                  "https://github.com/foo/1".url,
-                                  processingStage: .ingestion)
+        let pkg = try await savePackage(on: app.db,
+                                        "https://github.com/foo/1".url,
+                                        processingStage: .ingestion)
         try await Repository(package: pkg,
                              defaultBranch: "main").save(on: app.db)
         Current.git.commitCount = { @Sendable _ in 12 }

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -221,7 +221,7 @@ final class RepositoryTests: AppTestCase {
         do {
             // MUT - identical
             try await Repository(id: UUID(), package: p2, name: "bar", owner: "foo").save(on: app.db)
-            XCTFail("Expcted error")
+            XCTFail("Expected error")
         } catch {
             XCTAssert(String(reflecting: error).contains(
                 #"duplicate key value violates unique constraint "idx_repositories_owner_name""#),
@@ -233,6 +233,7 @@ final class RepositoryTests: AppTestCase {
         do {
             // MUT - diffrent case repository
             try await Repository(id: UUID(), package: p2, name: "Bar", owner: "foo").save(on: app.db)
+            XCTFail("Expected error")
         } catch {
             XCTAssert(String(reflecting: error).contains(
                 #"duplicate key value violates unique constraint "idx_repositories_owner_name""#),
@@ -244,6 +245,7 @@ final class RepositoryTests: AppTestCase {
         do {
             // MUT - diffrent case owner
             try await Repository(id: UUID(), package: p2, name: "bar", owner: "Foo").save(on: app.db)
+            XCTFail("Expected error")
         } catch {
             XCTAssert(String(reflecting: error).contains(
                 #"duplicate key value violates unique constraint "idx_repositories_owner_name""#),

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -20,9 +20,9 @@ import XCTVapor
 
 final class RepositoryTests: AppTestCase {
 
-    func test_save() throws {
+    func test_save() async throws {
         let pkg = Package(id: UUID(), url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let repo = try Repository(id: UUID(),
                                   package: pkg,
                                   authors: PackageAuthors(authors: [
@@ -54,10 +54,10 @@ final class RepositoryTests: AppTestCase {
                                   stars: 42,
                                   summary: "desc")
 
-        try repo.save(on: app.db).wait()
+        try await repo.save(on: app.db)
 
         do {
-            let r = try XCTUnwrap(Repository.find(repo.id, on: app.db).wait())
+            let r = try await XCTUnwrapAsync(try await Repository.find(repo.id, on: app.db))
             XCTAssertEqual(r.$package.id, pkg.id)
             XCTAssertEqual(r.authors,
                            PackageAuthors(authors: [ .init(name: "Foo"), .init(name: "Bar")],
@@ -90,9 +90,9 @@ final class RepositoryTests: AppTestCase {
         }
     }
 
-    func test_generated_lastActivityAt_lastCommitDate() throws {
+    func test_generated_lastActivityAt_lastCommitDate() async throws {
         let pkg = Package(url: "p1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
 
         let oldestDate = Date(timeIntervalSinceReferenceDate: 0)
         let moreRecentDate = Date(timeIntervalSinceReferenceDate: 100)
@@ -101,15 +101,15 @@ final class RepositoryTests: AppTestCase {
         repo.lastCommitDate = moreRecentDate
         repo.lastIssueClosedAt = oldestDate
         repo.lastPullRequestClosedAt = oldestDate
-        try repo.save(on: app.db).wait()
+        try await repo.save(on: app.db)
 
-        let fetchedRepo = try XCTUnwrap(Repository.find(repo.id, on: app.db).wait())
+        let fetchedRepo = try await XCTUnwrapAsync(try await Repository.find(repo.id, on: app.db))
         XCTAssertEqual(fetchedRepo.lastActivityAt, moreRecentDate)
     }
 
-    func test_generated_lastActivityAt_lastIssueClosedAt() throws {
+    func test_generated_lastActivityAt_lastIssueClosedAt() async throws {
         let pkg = Package(url: "p1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
 
         let oldestDate = Date(timeIntervalSinceReferenceDate: 0)
         let moreRecentDate = Date(timeIntervalSinceReferenceDate: 100)
@@ -118,15 +118,15 @@ final class RepositoryTests: AppTestCase {
         repo.lastCommitDate = oldestDate
         repo.lastIssueClosedAt = moreRecentDate
         repo.lastPullRequestClosedAt = oldestDate
-        try repo.save(on: app.db).wait()
+        try await repo.save(on: app.db)
 
-        let fetchedRepo = try XCTUnwrap(Repository.find(repo.id, on: app.db).wait())
+        let fetchedRepo = try await XCTUnwrapAsync(try await Repository.find(repo.id, on: app.db))
         XCTAssertEqual(fetchedRepo.lastActivityAt, moreRecentDate)
     }
 
-    func test_generated_lastActivityAt_lastPullRequestClosedAt() throws {
+    func test_generated_lastActivityAt_lastPullRequestClosedAt() async throws {
         let pkg = Package(url: "p1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
 
         let oldestDate = Date(timeIntervalSinceReferenceDate: 0)
         let moreRecentDate = Date(timeIntervalSinceReferenceDate: 100)
@@ -135,15 +135,15 @@ final class RepositoryTests: AppTestCase {
         repo.lastCommitDate = oldestDate
         repo.lastIssueClosedAt = oldestDate
         repo.lastPullRequestClosedAt = moreRecentDate
-        try repo.save(on: app.db).wait()
+        try await repo.save(on: app.db)
 
-        let fetchedRepo = try XCTUnwrap(Repository.find(repo.id, on: app.db).wait())
+        let fetchedRepo = try await XCTUnwrapAsync(try await Repository.find(repo.id, on: app.db))
         XCTAssertEqual(fetchedRepo.lastActivityAt, moreRecentDate)
     }
 
-    func test_generated_lastActivityAt_nullValues() throws {
+    func test_generated_lastActivityAt_nullValues() async throws {
         let pkg = Package(url: "p1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
 
         let date = Date(timeIntervalSinceReferenceDate: 0)
 
@@ -151,111 +151,116 @@ final class RepositoryTests: AppTestCase {
         repo.lastCommitDate = date
         repo.lastIssueClosedAt = nil
         repo.lastPullRequestClosedAt = nil
-        try repo.save(on: app.db).wait()
+        try await repo.save(on: app.db)
 
-        let fetchedRepo = try XCTUnwrap(Repository.find(repo.id, on: app.db).wait())
+        let fetchedRepo = try await XCTUnwrapAsync(try await Repository.find(repo.id, on: app.db))
         XCTAssertEqual(fetchedRepo.lastActivityAt, date)
     }
 
-    func test_package_relationship() throws {
+    func test_package_relationship() async throws {
         let pkg = Package(url: "p1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let repo = try Repository(package: pkg)
-        try repo.save(on: app.db).wait()
+        try await repo.save(on: app.db)
         // test some ways to resolve the relationship
         XCTAssertEqual(repo.$package.id, pkg.id)
-        XCTAssertEqual(try repo.$package.get(on: app.db).wait().url, "p1")
+        let db = app.db
+        try await XCTAssertEqualAsync(try await repo.$package.get(on: db).url, "p1")
 
         // ensure one-to-one is in place
         do {
             let repo = try Repository(package: pkg)
-            XCTAssertThrowsError(try repo.save(on: app.db).wait())
-            XCTAssertEqual(try Repository.query(on: app.db).all().wait().count, 1)
+            do {
+                try await repo.save(on: app.db)
+                XCTFail("Expected error")
+            } catch { }
+            try await XCTAssertEqualAsync(try await Repository.query(on: db).all().count, 1)
         }
     }
 
-    func test_forkedFrom_relationship() throws {
+    func test_forkedFrom_relationship() async throws {
         let p1 = Package(url: "p1")
-        try p1.save(on: app.db).wait()
+        try await p1.save(on: app.db)
         let p2 = Package(url: "p2")
-        try p2.save(on: app.db).wait()
+        try await p2.save(on: app.db)
 
         // test forked from link
         let parent = try Repository(package: p1)
-        try parent.save(on: app.db).wait()
+        try await parent.save(on: app.db)
         let child = try Repository(package: p2, forkedFrom: parent)
-        try child.save(on: app.db).wait()
+        try await child.save(on: app.db)
     }
 
-    func test_delete_cascade() throws {
+    func test_delete_cascade() async throws {
         // delete package must delete repository
         let pkg = Package(id: UUID(), url: "1")
         let repo = try Repository(id: UUID(), package: pkg)
-        try pkg.save(on: app.db).wait()
-        try repo.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
+        try await repo.save(on: app.db)
 
-        XCTAssertEqual(try Package.query(on: app.db).count().wait(), 1)
-        XCTAssertEqual(try Repository.query(on: app.db).count().wait(), 1)
+        let db = app.db
+        try await XCTAssertEqualAsync(try await Package.query(on: db).count(), 1)
+        try await XCTAssertEqualAsync(try await Repository.query(on: db).count(), 1)
 
         // MUT
-        try pkg.delete(on: app.db).wait()
+        try await pkg.delete(on: app.db)
 
         // version and product should be deleted
-        XCTAssertEqual(try Package.query(on: app.db).count().wait(), 0)
-        XCTAssertEqual(try Repository.query(on: app.db).count().wait(), 0)
+        try await XCTAssertEqualAsync(try await Package.query(on: db).count(), 0)
+        try await XCTAssertEqualAsync(try await Repository.query(on: db).count(), 0)
     }
 
-    func test_uniqueOwnerRepository() throws {
+    func test_uniqueOwnerRepository() async throws {
         // Ensure owner/repository is unique, testing various combinations with
         // matching/non-matching case
-        let p1 = try savePackage(on: app.db, "1")
-        try Repository(id: UUID(), package: p1, name: "bar", owner: "foo").save(on: app.db).wait()
-        let p2 = try savePackage(on: app.db, "2")
+        let p1 = try await savePackage(on: app.db, "1")
+        try await Repository(id: UUID(), package: p1, name: "bar", owner: "foo").save(on: app.db)
+        let p2 = try await savePackage(on: app.db, "2")
+        let db = app.db
 
-        XCTAssertThrowsError(
+        do {
             // MUT - identical
-            try Repository(id: UUID(), package: p2, name: "bar", owner: "foo").save(on: app.db).wait()
-        ) {
-            XCTAssert(String(reflecting: $0).contains(
+            try await Repository(id: UUID(), package: p2, name: "bar", owner: "foo").save(on: app.db)
+            XCTFail("Expcted error")
+        } catch {
+            XCTAssert(String(reflecting: error).contains(
                 #"duplicate key value violates unique constraint "idx_repositories_owner_name""#),
-                      "was: \($0.localizedDescription)"
+                      "was: \(error.localizedDescription)"
             )
-            XCTAssertEqual(try! Repository.query(on: app.db).all().wait().count, 1)
+            try await XCTAssertEqualAsync(try await Repository.query(on: db).all().count, 1)
         }
 
-        XCTAssertThrowsError(
+        do {
             // MUT - diffrent case repository
-            try Repository(id: UUID(), package: p2, name: "Bar", owner: "foo").save(on: app.db).wait()
-        ) {
-            XCTAssert(String(reflecting: $0).contains(
+            try await Repository(id: UUID(), package: p2, name: "Bar", owner: "foo").save(on: app.db)
+        } catch {
+            XCTAssert(String(reflecting: error).contains(
                 #"duplicate key value violates unique constraint "idx_repositories_owner_name""#),
-                      "was: \($0.localizedDescription)"
+                      "was: \(error.localizedDescription)"
             )
-            XCTAssertEqual(try! Repository.query(on: app.db).all().wait().count, 1)
+            try await XCTAssertEqualAsync(try await Repository.query(on: db).all().count, 1)
         }
 
-        XCTAssertThrowsError(
+        do {
             // MUT - diffrent case owner
-            try Repository(id: UUID(), package: p2, name: "bar", owner: "Foo").save(on: app.db).wait()
-        ) {
-            XCTAssert(String(reflecting: $0).contains(
+            try await Repository(id: UUID(), package: p2, name: "bar", owner: "Foo").save(on: app.db)
+        } catch {
+            XCTAssert(String(reflecting: error).contains(
                 #"duplicate key value violates unique constraint "idx_repositories_owner_name""#),
-                      "was: \($0.localizedDescription)"
+                      "was: \(error.localizedDescription)"
             )
-            XCTAssertEqual(try! Repository.query(on: app.db).all().wait().count, 1)
+            try await XCTAssertEqualAsync(try await Repository.query(on: db).all().count, 1)
         }
     }
 
-    func test_name_index() throws {
+    func test_name_index() async throws {
         let db = try XCTUnwrap(app.db as? SQLDatabase)
         // Quick way to check index exists - this will throw
         //   "server: index "idx_repositories_name" does not exist (DropErrorMsgNonExistent)"
         // if it doesn't
-        XCTAssertNoThrow(try db.raw("DROP INDEX idx_repositories_name").run().wait())
+        try await db.raw("DROP INDEX idx_repositories_name").run()
         // Recreate index or else the revert in the next tests setUp is going to fail
-        try db.raw(
-            "CREATE INDEX idx_repositories_name ON repositories USING gin (name gin_trgm_ops)"
-        ).run().wait()
+        try await db.raw("CREATE INDEX idx_repositories_name ON repositories USING gin (name gin_trgm_ops)").run()
     }
     
     func test_S3Readme_needsUpdate() {

--- a/Tests/AppTests/ScoreTests.swift
+++ b/Tests/AppTests/ScoreTests.swift
@@ -240,9 +240,8 @@ class ScoreTests: AppTestCase {
                           reference: .branch("default"),
                           resolvedDependencies: [],
                           swiftVersions: ["5"].asSwiftVersions).save(on: app.db)
-        try (0..<20).forEach {
-            try Version(package: pkg, reference: .tag(.init($0, 0, 0)))
-                .save(on: app.db).wait()
+        for idx in (0..<20) {
+            try await Version(package: pkg, reference: .tag(.init(idx, 0, 0))).save(on: app.db)
         }
         let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
         // update versions
@@ -273,9 +272,8 @@ class ScoreTests: AppTestCase {
                           reference: .branch("default"),
                           resolvedDependencies: nil,
                           swiftVersions: ["5"].asSwiftVersions).save(on: app.db)
-        try (0..<20).forEach {
-            try Version(package: pkg, reference: .tag(.init($0, 0, 0)))
-                .save(on: app.db).wait()
+        for idx in (0..<20) {
+            try await Version(package: pkg, reference: .tag(.init(idx, 0, 0))).save(on: app.db)
         }
         let jpr = try await Package.fetchCandidate(app.db, id: pkg.id!)
         // update versions

--- a/Tests/AppTests/ScoreTests.swift
+++ b/Tests/AppTests/ScoreTests.swift
@@ -233,7 +233,7 @@ class ScoreTests: AppTestCase {
 
     func test_computeDetails() async throws {
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, defaultBranch: "default", stars: 10_000).save(on: app.db)
         try await Version(package: pkg,
                           docArchives: [.init(name: "archive1", title: "Archive One")],
@@ -265,7 +265,7 @@ class ScoreTests: AppTestCase {
 
     func test_computeDetails_unknown_resolvedDependencies() async throws {
         // setup
-        let pkg = try await savePackageAsync(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         try await Repository(package: pkg, defaultBranch: "default", stars: 10_000).save(on: app.db)
         try await Version(package: pkg,
                           docArchives: [.init(name: "archive1", title: "Archive One")],

--- a/Tests/AppTests/SearchTests.swift
+++ b/Tests/AppTests/SearchTests.swift
@@ -188,8 +188,8 @@ class SearchTests: AppTestCase {
     func test_fetch_single() async throws {
         // Test search with a single term
         // setup
-        let p1 = try savePackage(on: app.db, "1")
-        let p2 = try savePackage(on: app.db, "2")
+        let p1 = try await savePackage(on: app.db, "1")
+        let p2 = try await savePackage(on: app.db, "2")
         try await Repository(package: p1,
                              defaultBranch: "main",
                              summary: "some package").save(on: app.db)
@@ -232,8 +232,8 @@ class SearchTests: AppTestCase {
     func test_fetch_multiple() async throws {
         // Test search with multiple terms ("and")
         // setup
-        let p1 = try savePackage(on: app.db, "1")
-        let p2 = try savePackage(on: app.db, "2")
+        let p1 = try await savePackage(on: app.db, "1")
+        let p2 = try await savePackage(on: app.db, "2")
         try await Repository(package: p1,
                        defaultBranch: "main",
                        name: "package 1",
@@ -301,8 +301,8 @@ class SearchTests: AppTestCase {
     func test_quoting() async throws {
         // Test searching for a `'`
         // setup
-        let p1 = try savePackage(on: app.db, "1")
-        let p2 = try savePackage(on: app.db, "2")
+        let p1 = try await savePackage(on: app.db, "1")
+        let p2 = try await savePackage(on: app.db, "2")
         try await Repository(package: p1,
                              defaultBranch: "main",
                              lastCommitDate: .t0,

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -128,11 +128,6 @@ func savePackages(on db: Database, _ urls: [URL],
 }
 
 
-func fetch(id: Package.Id?, on db: Database, file: StaticString = #file, line: UInt = #line) throws -> Package {
-    try XCTUnwrap(try Package.find(id, on: db).wait(), file: (file), line: line)
-}
-
-
 // MARK: - Client mocking
 
 

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -110,27 +110,9 @@ func fixturesDirectory(path: String = #file) -> URL {
 // MARK: - Package db helpers
 
 
-// TODO: deprecate in favour of savePackage[Async](...) async throws
 @discardableResult
 func savePackage(on db: Database, id: Package.Id = UUID(), _ url: URL,
-                 processingStage: Package.ProcessingStage? = nil) throws -> Package {
-    let p = Package(id: id, url: url, processingStage: processingStage)
-    try p.save(on: db).wait()
-    return p
-}
-
-
-// TODO: deprecate in favour of savePackages[Async](...) async throws
-@discardableResult
-func savePackages(on db: Database, _ urls: [URL],
-                  processingStage: Package.ProcessingStage? = nil) throws -> [Package] {
-    try urls.map { try savePackage(on: db, $0, processingStage: processingStage) }
-}
-
-
-@discardableResult
-func savePackageAsync(on db: Database, id: Package.Id = UUID(), _ url: URL,
-                      processingStage: Package.ProcessingStage? = nil) async throws -> Package {
+                 processingStage: Package.ProcessingStage? = nil) async throws -> Package {
     let p = Package(id: id, url: url, processingStage: processingStage)
     try await p.save(on: db)
     return p
@@ -138,10 +120,10 @@ func savePackageAsync(on db: Database, id: Package.Id = UUID(), _ url: URL,
 
 
 @discardableResult
-func savePackagesAsync(on db: Database, _ urls: [URL],
-                       processingStage: Package.ProcessingStage? = nil) async throws -> [Package] {
+func savePackages(on db: Database, _ urls: [URL],
+                  processingStage: Package.ProcessingStage? = nil) async throws -> [Package] {
     try await urls.mapAsync {
-        try await savePackageAsync(on: db, $0, processingStage: processingStage)
+        try await savePackage(on: db, $0, processingStage: processingStage)
     }
 }
 

--- a/Tests/AppTests/VersionDiffTests.swift
+++ b/Tests/AppTests/VersionDiffTests.swift
@@ -147,7 +147,7 @@ class VersionDiffTests: AppTestCase {
     func test_diff_1() async throws {
         // Branch changes commit hash
         // setup
-        let pkg = try savePackage(on: app.db, "1")
+        let pkg = try await savePackage(on: app.db, "1")
         let keptId = UUID()
         let saved: [Version] = [
             try .init(package: pkg, commit: "hash1", reference: .branch("main")),

--- a/Tests/AppTests/ViewUtilsTests.swift
+++ b/Tests/AppTests/ViewUtilsTests.swift
@@ -47,12 +47,12 @@ class ViewUtilsTests: XCTestCase {
 // Test that require DB access
 class ViewUtilsDBTests: AppTestCase {
 
-    func test_makeLink() throws {
+    func test_makeLink() async throws {
         // setup
         let pkg = Package(url: "1")
-        try pkg.save(on: app.db).wait()
+        try await pkg.save(on: app.db)
         let version = try Version(package: pkg)
-        try version.save(on: app.db).wait()
+        try await version.save(on: app.db)
 
         do {  // branch reference
             version.reference = .branch("main")


### PR DESCRIPTION
I didn't want to do this now but once you start pulling a thread...

With this we're clear of all `wait()` calls and should be completely converted over to async/await.