### PR TITLE
Add plausible tracking for maintainerinfo page views

### DIFF
--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -101,7 +101,9 @@ extension AppEnvironment {
             do {
                 try await Current.postPlausibleEvent(Current.httpClient(), event, path, user)
             } catch {
-                Current.logger().warning("Plausible.postEvent failed: \(error)")
+                /// track which client is being used; useful in tests
+                let httpClient = "Current.httpClient() of type \(type(of: Current.httpClient()))"
+                Current.logger().warning("Plausible.postEvent failed where: \(httpClient) with \(error)")
             }
         }
     }

--- a/Sources/App/Core/Plausible.swift
+++ b/Sources/App/Core/Plausible.swift
@@ -37,6 +37,7 @@ enum Plausible {
         case sitemapIndex = "/sitemap-index"
         case sitemapStaticPages = "/sitemap-static"
         case sitemapPackage = "/{owner}/{repository}/sitemap"
+        case maintainerPage = "/{owner}/{repository}/information-for-package-maintainers"
     }
 
     struct Error: Swift.Error {

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -71,7 +71,8 @@ func routes(_ app: Application) throws {
         app.get(SiteURL.package(.key, .key, .builds).pathComponents,
                 use: PackageController.builds).excludeFromOpenAPI()
         app.get(SiteURL.package(.key, .key, .maintainerInfo).pathComponents,
-                use: PackageController.maintainerInfo).excludeFromOpenAPI()
+                use: PackageController.maintainerInfo
+        ).excludeFromOpenAPI()
 
         // Only serve sitemaps in production.
         if Current.environment() == .production {
@@ -271,6 +272,13 @@ func routes(_ app: Application) throws {
                 $0.get(SiteURL.siteMapStaticPages.pathComponents, use: SiteMapController.staticPages)
                     .excludeFromOpenAPI()
             }
+        }
+    }
+
+    do { /// apply BackendReportingMiddleware to track page views for GET req to /:owner/:repository/information-for-package-maintainers
+        app.group(BackendReportingMiddleware(path: .maintainerPage)) {
+            $0.get(SiteURL.package(.key, .key, .maintainerInfo).pathComponents, use: PackageController.maintainerInfo)
+                .excludeFromOpenAPI()
         }
     }
 

--- a/Tests/AppTests/BackendReportingMiddlewareTests.swift
+++ b/Tests/AppTests/BackendReportingMiddlewareTests.swift
@@ -1,0 +1,35 @@
+//
+//  BackendReportingMiddlewareTests.swift
+//  
+//
+//  Created by msuzoagu on 8/25/24.
+//
+
+import XCTest
+
+final class BackendReportingMiddlewareTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Tests/AppTests/BackendReportingMiddlewareTests.swift
+++ b/Tests/AppTests/BackendReportingMiddlewareTests.swift
@@ -1,35 +1,53 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
 //
-//  BackendReportingMiddlewareTests.swift
-//  
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-//  Created by msuzoagu on 8/25/24.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
-import XCTest
+import XCTVapor
+import NIOConcurrencyHelpers
+@testable import App
 
 final class BackendReportingMiddlewareTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
+    func testMaintainerPageViewTriggersPlausibleEvent() async throws {
+        let app = Application(.testing)
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
+        /// Defer to shutdown the app asynchronously after the test completes
+        defer {
+            Task {
+                await app.shutdown()
+            }
         }
-    }
 
+        try await configure(app)
+
+        var intercepted = false
+        let mockClient = MockClient { req, res in
+            intercepted = true
+            res.status = .ok
+        }
+
+        /// Ensure Current is using the MockClient
+        Current.setHTTPClient(mockClient)
+
+        /// Trigger a request
+        try app.test(.GET, "/schwa/Compute/information-for-package-maintainers") { res in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertTrue(res.body.string.contains("Information for Compute Maintainers"))
+        }
+
+        /// Await to give time for async tasks
+        try await Task.sleep(nanoseconds: 5_000_000_000)
+
+        XCTAssertTrue(intercepted, "The request was not intercepted by MockClient")
+    }
 }


### PR DESCRIPTION
This PR introduces changes to ensure that page views for routes matching /:owner/:repository/information-for-package-maintainers are sent to the Plausible event API. The update includes:

1. adding a new route wrapped with BackendReportingMiddleware to trigger Plausible event tracking specifically for the maintainer information page
2. a unit test has been added to verify that the Plausible event is triggered correctly

@finestructure 