### PR TITLE
Add run 11 results

### DIFF
--- a/Resources/ChartData/rfs6-errors.json
+++ b/Resources/ChartData/rfs6-errors.json
@@ -51,6 +51,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 5 (16A5221g)",
         "value" : 58085
+      },
+      {
+        "date" : "2024-08-28",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
+        "value" : 62212
       }
     ]
   },
@@ -106,6 +112,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 5 (16A5221g)",
         "value" : 1448
+      },
+      {
+        "date" : "2024-08-28",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
+        "value" : 1458
       }
     ]
   },
@@ -161,6 +173,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 5 (16A5221g)",
         "value" : 443
+      },
+      {
+        "date" : "2024-08-28",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
+        "value" : 531
       }
     ]
   }

--- a/Resources/ChartData/rfs6-events.json
+++ b/Resources/ChartData/rfs6-events.json
@@ -18,5 +18,9 @@
     {
         "date": "2024-08-06",
         "value": "Xcode 16 beta 5 released"
+    },
+    {
+        "date": "2024-08-20",
+        "value": "Xcode 16 beta 6 released"
     }
 ]

--- a/Resources/ChartData/rfs6-packages.json
+++ b/Resources/ChartData/rfs6-packages.json
@@ -51,6 +51,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 5 (16A5221g)",
         "value" : 1551
+      },
+      {
+        "date" : "2024-08-28",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
+        "value" : 1545
       }
     ]
   },
@@ -106,6 +112,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 5 (16A5221g)",
         "value" : 21
+      },
+      {
+        "date" : "2024-08-28",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
+        "value" : 21
       }
     ]
   },
@@ -160,6 +172,12 @@
         "date" : "2024-08-17",
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 5 (16A5221g)",
+        "value" : 9
+      },
+      {
+        "date" : "2024-08-28",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
         "value" : 9
       }
     ]


### PR DESCRIPTION
We had a good run there for a while...

![CleanShot 2024-08-28 at 10 09 18@2x](https://github.com/user-attachments/assets/51d51350-d264-4dfc-af9e-84849260194f)
