### PR TITLE
Show correct code snippet for products type of plugin

### DIFF
--- a/FrontEnd/scripts/controllers/use_this_package_panel_controller.js
+++ b/FrontEnd/scripts/controllers/use_this_package_panel_controller.js
@@ -26,6 +26,7 @@ export class UseThisPackagePanelController extends Controller {
         const optionElement = selectElement.options[selectElement.selectedIndex]
         const packageName = optionElement.dataset.package
         const productName = optionElement.dataset.product
+        const type = optionElement.dataset.type
         const prefix = type == "plugin" ? ".plugin" : ".product"
         this.snippetTarget.value = `${prefix}(name: "${productName}", package: "${packageName}")`
     }

--- a/FrontEnd/scripts/controllers/use_this_package_panel_controller.js
+++ b/FrontEnd/scripts/controllers/use_this_package_panel_controller.js
@@ -26,6 +26,7 @@ export class UseThisPackagePanelController extends Controller {
         const optionElement = selectElement.options[selectElement.selectedIndex]
         const packageName = optionElement.dataset.package
         const productName = optionElement.dataset.product
-        this.snippetTarget.value = `.product(name: "${productName}", package: "${packageName}")`
+        const prefix = type == "plugin" ? ".plugin" : ".product"
+        this.snippetTarget.value = `${prefix}(name: "${productName}", package: "${packageName}")`
     }
 }

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
@@ -235,6 +235,17 @@ extension API.PackageController.GetRoute.Model {
             case executable
             case plugin
             
+            var stringValue: String {
+                switch self {
+                case .library:
+                    return "library"
+                case .executable:
+                    return "executable"
+                case .plugin:
+                    return "plugin"
+                }
+            }
+            
             init?(_ productType: App.ProductType) {
                 switch productType {
                     case .executable:

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
@@ -230,21 +230,10 @@ extension API.PackageController.GetRoute.Model {
             self.type = type
         }
 
-        enum ProductType: Codable, Equatable {
+        enum ProductType: String, Codable, Equatable {
             case library
             case executable
             case plugin
-            
-            var stringValue: String {
-                switch self {
-                case .library:
-                    return "library"
-                case .executable:
-                    return "executable"
-                case .plugin:
-                    return "plugin"
-                }
-            }
             
             init?(_ productType: App.ProductType) {
                 switch productType {

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -415,10 +415,12 @@ extension API.PackageController.GetRoute.Model {
                     .data(named: "action", value: "input->use-this-package-panel#updateProductSnippet"),
                     .attribute(named: "name", value: "products"),
                     .id("products"),
-                    .forEach(products, { product in
+                    // Filter out products of type `executable` until we add support for them.
+                    .forEach(products.filter({ $0.type != .executable }), { product in
                             .option(
                                 .data(named: "package", value: package),
                                 .data(named: "product", value: product.name),
+                                .data(named: "type", value: product.type.stringValue),
                                 .value(product.name),
                                 .label(product.name)
                             )

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -420,7 +420,7 @@ extension API.PackageController.GetRoute.Model {
                             .option(
                                 .data(named: "package", value: package),
                                 .data(named: "product", value: product.name),
-                                .data(named: "type", value: product.type.stringValue),
+                                .data(named: "type", value: product.type.rawValue),
                                 .value(product.name),
                                 .label(product.name)
                             )


### PR DESCRIPTION
Fixes #3297

This PR addresse this issue: https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3297

Wrong code snippet shown for non-library products. Additionally, executable products are filtered out and will be addressed in a different PR.