### PR TITLE
Add Forked From

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -191,7 +191,7 @@ func updateRepository(on database: Database,
     do {
         if let parentUrl = metadata.repository?.normalizedParentUrl {
             if let packageId = try await Package.query(on: database)
-                .filter(\.$url == parentUrl)
+                .filter(\.$url, .custom("ilike"), parentUrl)
                 .first()?.id {
                 fork = .parentId(packageId)
             } else {

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -284,6 +284,9 @@ extension Github {
                     homepageUrl
                     isArchived
                     isFork
+                    parent {
+                        url
+                    }
                     isInOrganization
                     licenseInfo {
                       name
@@ -348,6 +351,7 @@ extension Github {
             var isArchived: Bool
             // periphery:ignore
             var isFork: Bool
+            var parent: Parent
             var isInOrganization: Bool
             var licenseInfo: LicenseInfo?
             var mergedPullRequests: IssueNodes
@@ -458,6 +462,10 @@ extension Github {
                     var name: String
                 }
             }
+        }
+        
+        struct Parent: Decodable, Equatable {
+            var url: String?
         }
     }
 

--- a/Sources/App/Migrations/079/UpdateRepositoryAddFork.swift
+++ b/Sources/App/Migrations/079/UpdateRepositoryAddFork.swift
@@ -1,0 +1,35 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+
+struct UpdateRepositoryAddFork: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("repositories")
+            .field("forked_from", .json)
+            // delete old `forked_from_id` field
+            .deleteField("forked_from_id")
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("repositories")
+            .deleteField("forked_from")
+            .field("forked_from_id", .uuid,
+                    .references("repositories", "id")).unique(on: "forked_from_id")
+            .update()
+    }
+}

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -34,9 +34,6 @@ final class Repository: @unchecked Sendable, Model, Content {
 
     // reference fields
 
-    @OptionalParent(key: "forked_from_id")  // TODO: remove or implement
-    var forkedFrom: Repository?
-
     @Parent(key: "package_id")
     var package: Package
 
@@ -122,6 +119,9 @@ final class Repository: @unchecked Sendable, Model, Content {
 
     @Field(key: "summary")
     var summary: String?
+    
+    @Field(key: "forked_from")
+    var forkedFrom: Fork?
 
     // initializers
 
@@ -135,7 +135,7 @@ final class Repository: @unchecked Sendable, Model, Content {
          firstCommitDate: Date? = nil,
          forks: Int = 0,
          fundingLinks: [FundingLink] = [],
-         forkedFrom: Repository? = nil,
+         forkedFrom: Fork? = nil,
          homepageUrl: String? = nil,
          isArchived: Bool = false,
          isInOrganization: Bool = false,
@@ -164,9 +164,7 @@ final class Repository: @unchecked Sendable, Model, Content {
         self.commitCount = commitCount
         self.firstCommitDate = firstCommitDate
         self.forks = forks
-        if let forkId = forkedFrom?.id {
-            self.$forkedFrom.id = forkId
-        }
+        self.forkedFrom = forkedFrom
         self.fundingLinks = fundingLinks
         self.homepageUrl = homepageUrl
         self.isArchived = isArchived
@@ -272,4 +270,9 @@ enum S3Readme: Codable, Equatable {
                 return true
         }
     }
+}
+
+enum Fork: Codable, Equatable {
+    case parentId(Package.Id)
+    case parentURL(String)
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -334,6 +334,9 @@ public func configure(_ app: Application) async throws -> String {
     do { // Migration 078 - Add `build_date` and `commit_hash` to `builds`
         app.migrations.add(UpdateBuildAddBuildDateCommitHash())
     }
+    do { // Migration 079 - Add `fork` to `repositories`
+        app.migrations.add(UpdateRepositoryAddFork())
+    }
 
     app.asyncCommands.use(Analyze.Command(), as: "analyze")
     app.asyncCommands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Tests/AppTests/Mocks/GithubMetadata+mock.swift
+++ b/Tests/AppTests/Mocks/GithubMetadata+mock.swift
@@ -25,6 +25,7 @@ extension Github.Metadata {
                                   issuesClosedAtDates: [],
                                   license: .mit,
                                   openIssues: 3,
+                                  parentUrl: nil, 
                                   openPullRequests: 0,
                                   owner: "packageOwner",
                                   pullRequestsClosedAtDates: [],
@@ -34,7 +35,7 @@ extension Github.Metadata {
                                   stars: 2,
                                   summary: "desc")
 
-    static func mock(owner: String, repository: String) -> Self {
+    static func mock(owner: String, repository: String, parentUrl: String? = nil) -> Self {
         return .init(defaultBranch: "main",
                      forks: owner.count + repository.count,
                      homepageUrl: nil,
@@ -42,6 +43,7 @@ extension Github.Metadata {
                      issuesClosedAtDates: [],
                      license: .mit,
                      openIssues: 3,
+                     parentUrl: parentUrl,
                      openPullRequests: 0,
                      owner: owner,
                      pullRequestsClosedAtDates: [],
@@ -60,6 +62,7 @@ extension Github.Metadata {
          issuesClosedAtDates: [Date],
          license: License,
          openIssues: Int,
+         parentUrl: String?,
          openPullRequests: Int,
          owner: String,
          pullRequestsClosedAtDates: [Date],
@@ -84,7 +87,8 @@ extension Github.Metadata {
                               fundingLinks: fundingLinks,
                               homepageUrl: homepageUrl,
                               isArchived: false,
-                              isFork: false,
+                              isFork: false, 
+                              parent: .init(url: parentUrl),
                               isInOrganization: isInOrganization,
                               licenseInfo: .init(name: license.fullName, key: license.rawValue),
                               mergedPullRequests: .init(closedAtDates: []),

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -178,19 +178,6 @@ final class RepositoryTests: AppTestCase {
         }
     }
 
-    func test_forkedFrom_relationship() async throws {
-        let p1 = Package(url: "p1")
-        try await p1.save(on: app.db)
-        let p2 = Package(url: "p2")
-        try await p2.save(on: app.db)
-
-        // test forked from link
-        let parent = try Repository(package: p1)
-        try await parent.save(on: app.db)
-        let child = try Repository(package: p2, forkedFrom: parent)
-        try await child.save(on: app.db)
-    }
-
     func test_delete_cascade() async throws {
         // delete package must delete repository
         let pkg = Package(id: UUID(), url: "1")


### PR DESCRIPTION
This PR tries to resolve the following issue: https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/551

The `forkedFrom` attribute on the `Repository` will enable us to determine if the package is forked from another repo, and we can reflect it on the UI.