### PR TITLE
Add `forked_from` as a pointer either to an existing package or as a reference to a URL

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -191,7 +191,7 @@ func updateRepository(on database: Database,
     do {
         if let parentUrl = metadata.repository?.normalizedParentUrl {
             if let packageId = try await Package.query(on: database)
-                .filter(\.$url == parentUrl)
+                .filter(\.$url, .custom("ilike"), parentUrl)
                 .first()?.id {
                 fork = .parentId(packageId)
             } else {

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -244,7 +244,7 @@ private extension Github.Metadata.Repository {
 private extension Github.Metadata.Repository {
     // Returns a normalized version of the URL. Adding a `.git` if not present.
     var normalizedParentUrl: String? {
-        guard let url = parent.url else { return nil }
+        guard let url = parent?.url else { return nil }
         guard !url.hasSuffix(".git") else { return url }
         let normalizedUrl = url + ".git"
         return normalizedUrl

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -124,14 +124,13 @@ func ingest(client: Client,
                         Current.logger().warning("storeS3Readme failed")
                         s3Readme = .error("\(error)")
                     }
-                    
+
                     try await updateRepository(on: database,
                                                for: repo,
                                                metadata: metadata,
                                                licenseInfo: license,
                                                readmeInfo: readme,
                                                s3Readme: s3Readme)
-                        
                     return pkg
                 }
 

--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -125,7 +125,7 @@ func ingest(client: Client,
                         s3Readme = .error("\(error)")
                     }
                     
-                    let fork: Fork? = try? await getFork(on: database, parent: metadata.repository?.parent)
+                    let fork = await getFork(on: database, parent: metadata.repository?.parent)
 
                     try await updateRepository(on: database,
                                                for: repo,

--- a/Sources/App/Core/Extensions/URL+ext.swift
+++ b/Sources/App/Core/Extensions/URL+ext.swift
@@ -1,0 +1,24 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Foundation
+
+extension URL {
+    var normalized: Self? {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else { return nil }
+        if components.scheme == "http" { components.scheme = "https" }
+        if !components.path.hasSuffix(".git") { components.path = components.path + ".git" }
+        return components.url!
+    }
+}

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -284,6 +284,9 @@ extension Github {
                     homepageUrl
                     isArchived
                     isFork
+                    parent {
+                        url
+                    }
                     isInOrganization
                     licenseInfo {
                       name
@@ -348,6 +351,7 @@ extension Github {
             var isArchived: Bool
             // periphery:ignore
             var isFork: Bool
+            var parent: Parent
             var isInOrganization: Bool
             var licenseInfo: LicenseInfo?
             var mergedPullRequests: IssueNodes
@@ -458,6 +462,10 @@ extension Github {
                     var name: String
                 }
             }
+        }
+        
+        struct Parent: Decodable, Equatable {
+            var url: String?
         }
     }
 

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -351,7 +351,7 @@ extension Github {
             var isArchived: Bool
             // periphery:ignore
             var isFork: Bool
-            var parent: Parent
+            var parent: Parent?
             var isInOrganization: Bool
             var licenseInfo: LicenseInfo?
             var mergedPullRequests: IssueNodes

--- a/Sources/App/Migrations/079/UpdateRepositoryAddFork.swift
+++ b/Sources/App/Migrations/079/UpdateRepositoryAddFork.swift
@@ -1,0 +1,35 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+
+struct UpdateRepositoryAddFork: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("repositories")
+            .field("forked_from", .json)
+            // delete old `forked_from_id` field
+            .deleteField("forked_from_id")
+            .update()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("repositories")
+            .deleteField("forked_from")
+            .field("forked_from_id", .uuid,
+                    .references("repositories", "id")).unique(on: "forked_from_id")
+            .update()
+    }
+}

--- a/Sources/App/Migrations/079/UpdateRepositoryAddForkedFrom.swift
+++ b/Sources/App/Migrations/079/UpdateRepositoryAddForkedFrom.swift
@@ -16,7 +16,7 @@ import Fluent
 import SQLKit
 
 
-struct UpdateRepositoryAddFork: AsyncMigration {
+struct UpdateRepositoryAddForkedFrom: AsyncMigration {
     func prepare(on database: Database) async throws {
         try await database.schema("repositories")
             .field("forked_from", .json)

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -50,6 +50,9 @@ final class Repository: @unchecked Sendable, Model, Content {
 
     @Field(key: "first_commit_date")
     var firstCommitDate: Date?
+    
+    @Field(key: "forked_from")
+    var forkedFrom: Fork?
 
     @Field(key: "forks")
     var forks: Int
@@ -119,9 +122,6 @@ final class Repository: @unchecked Sendable, Model, Content {
 
     @Field(key: "summary")
     var summary: String?
-    
-    @Field(key: "forked_from")
-    var forkedFrom: Fork?
 
     // initializers
 

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -34,9 +34,6 @@ final class Repository: @unchecked Sendable, Model, Content {
 
     // reference fields
 
-    @OptionalParent(key: "forked_from_id")  // TODO: remove or implement
-    var forkedFrom: Repository?
-
     @Parent(key: "package_id")
     var package: Package
 
@@ -122,6 +119,9 @@ final class Repository: @unchecked Sendable, Model, Content {
 
     @Field(key: "summary")
     var summary: String?
+    
+    @Field(key: "forked_from")
+    var forkedFrom: Fork?
 
     // initializers
 
@@ -135,7 +135,7 @@ final class Repository: @unchecked Sendable, Model, Content {
          firstCommitDate: Date? = nil,
          forks: Int = 0,
          fundingLinks: [FundingLink] = [],
-         forkedFrom: Repository? = nil,
+         forkedFrom: Fork? = nil,
          homepageUrl: String? = nil,
          isArchived: Bool = false,
          isInOrganization: Bool = false,
@@ -164,9 +164,7 @@ final class Repository: @unchecked Sendable, Model, Content {
         self.commitCount = commitCount
         self.firstCommitDate = firstCommitDate
         self.forks = forks
-        if let forkId = forkedFrom?.id {
-            self.$forkedFrom.id = forkId
-        }
+        self.forkedFrom = forkedFrom
         self.fundingLinks = fundingLinks
         self.homepageUrl = homepageUrl
         self.isArchived = isArchived
@@ -272,4 +270,9 @@ enum S3Readme: Codable, Equatable {
                 return true
         }
     }
+}
+
+enum Fork: Codable, Equatable {
+    case parentId(Package.Id)
+    case parentURL(String)
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -334,6 +334,9 @@ public func configure(_ app: Application) async throws -> String {
     do { // Migration 078 - Add `build_date` and `commit_hash` to `builds`
         app.migrations.add(UpdateBuildAddBuildDateCommitHash())
     }
+    do { // Migration 079 - Add `fork` to `repositories`
+        app.migrations.add(UpdateRepositoryAddFork())
+    }
 
     app.asyncCommands.use(Analyze.Command(), as: "analyze")
     app.asyncCommands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -334,8 +334,8 @@ public func configure(_ app: Application) async throws -> String {
     do { // Migration 078 - Add `build_date` and `commit_hash` to `builds`
         app.migrations.add(UpdateBuildAddBuildDateCommitHash())
     }
-    do { // Migration 079 - Add `fork` to `repositories`
-        app.migrations.add(UpdateRepositoryAddFork())
+    do { // Migration 079 - Add `forked_from` to `repositories`
+        app.migrations.add(UpdateRepositoryAddForkedFrom())
     }
 
     app.asyncCommands.use(Analyze.Command(), as: "analyze")

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -604,31 +604,24 @@ class IngestorTests: AppTestCase {
         try await Package(id: .id0, url: "https://github.com/foo/parent.git".url, processingStage: .analysis).save(on: app.db)
         try await Package(url: "https://github.com/bar/forked.git", processingStage: .analysis).save(on: app.db)
 
-        var parent: Github.Metadata.Parent?
-        
         // test lookup when package is in the index
-        parent = .init(url: "https://github.com/foo/parent.git")
-        let fork = await getFork(on: app.db, parent: parent)
+        let fork = await getFork(on: app.db, parent: .init(url: "https://github.com/foo/parent.git"))
         XCTAssertEqual(fork, .parentId(.id0))
         
         // test lookup when package is in the index but with different case in URL
-        parent = .init(url: "https://github.com/Foo/Parent.git")
-        let fork2 = await getFork(on: app.db, parent: parent)
+        let fork2 = await getFork(on: app.db, parent: .init(url: "https://github.com/Foo/Parent.git"))
         XCTAssertEqual(fork2, .parentId(.id0))
         
         // test whem metadata repo url doesn't have `.git` at end
-        parent = .init(url: "https://github.com/Foo/Parent")
-        let fork3 = await getFork(on: app.db, parent: parent)
+        let fork3 = await getFork(on: app.db, parent: .init(url: "https://github.com/Foo/Parent"))
         XCTAssertEqual(fork3, .parentId(.id0))
         
         // test lookup when package is not in the index
-        parent = .init(url: "https://github.com/some/other.git")
-        let fork4 = await getFork(on: app.db, parent: parent)
+        let fork4 = await getFork(on: app.db, parent: .init(url: "https://github.com/some/other.git"))
         XCTAssertEqual(fork4, .parentURL("https://github.com/some/other.git"))
         
         // test lookup when parent url is nil
-        parent = nil
-        let fork5 = await getFork(on: app.db, parent: parent)
+        let fork5 = await getFork(on: app.db, parent: nil)
         XCTAssertEqual(fork5, nil)
     }
 }

--- a/Tests/AppTests/Mocks/GithubMetadata+mock.swift
+++ b/Tests/AppTests/Mocks/GithubMetadata+mock.swift
@@ -25,6 +25,7 @@ extension Github.Metadata {
                                   issuesClosedAtDates: [],
                                   license: .mit,
                                   openIssues: 3,
+                                  parentUrl: nil, 
                                   openPullRequests: 0,
                                   owner: "packageOwner",
                                   pullRequestsClosedAtDates: [],
@@ -34,7 +35,7 @@ extension Github.Metadata {
                                   stars: 2,
                                   summary: "desc")
 
-    static func mock(owner: String, repository: String) -> Self {
+    static func mock(owner: String, repository: String, parentUrl: String? = nil) -> Self {
         return .init(defaultBranch: "main",
                      forks: owner.count + repository.count,
                      homepageUrl: nil,
@@ -42,6 +43,7 @@ extension Github.Metadata {
                      issuesClosedAtDates: [],
                      license: .mit,
                      openIssues: 3,
+                     parentUrl: parentUrl,
                      openPullRequests: 0,
                      owner: owner,
                      pullRequestsClosedAtDates: [],
@@ -60,6 +62,7 @@ extension Github.Metadata {
          issuesClosedAtDates: [Date],
          license: License,
          openIssues: Int,
+         parentUrl: String?,
          openPullRequests: Int,
          owner: String,
          pullRequestsClosedAtDates: [Date],
@@ -84,7 +87,8 @@ extension Github.Metadata {
                               fundingLinks: fundingLinks,
                               homepageUrl: homepageUrl,
                               isArchived: false,
-                              isFork: false,
+                              isFork: false, 
+                              parent: .init(url: parentUrl),
                               isInOrganization: isInOrganization,
                               licenseInfo: .init(name: license.fullName, key: license.rawValue),
                               mergedPullRequests: .init(closedAtDates: []),

--- a/Tests/AppTests/RepositoryTests.swift
+++ b/Tests/AppTests/RepositoryTests.swift
@@ -178,19 +178,6 @@ final class RepositoryTests: AppTestCase {
         }
     }
 
-    func test_forkedFrom_relationship() async throws {
-        let p1 = Package(url: "p1")
-        try await p1.save(on: app.db)
-        let p2 = Package(url: "p2")
-        try await p2.save(on: app.db)
-
-        // test forked from link
-        let parent = try Repository(package: p1)
-        try await parent.save(on: app.db)
-        let child = try Repository(package: p2, forkedFrom: parent)
-        try await child.save(on: app.db)
-    }
-
     func test_delete_cascade() async throws {
         // delete package must delete repository
         let pkg = Package(id: UUID(), url: "1")


### PR DESCRIPTION
Supercedes #3355 and implements the first part of #551. UI changes still pending.

@supersonicbyte I was seeing test failures in `test_decode_Metadata_null` and `test_fetchMetadata` which I have fixed by making `Parent` optional in the GitHub metadata. I don’t believe that `parent` is a mandatory field supplied by GitHub, so this feels like a reasonable fix to me but could you verify please?

Thanks!