### PR TITLE
Add run 12 results

### DIFF
--- a/Resources/ChartData/rfs6-errors.json
+++ b/Resources/ChartData/rfs6-errors.json
@@ -57,6 +57,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
         "value" : 62212
+      },
+      {
+        "date" : "2024-09-17",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 RC (16A242)",
+        "value" : 57164
       }
     ]
   },
@@ -118,6 +124,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
         "value" : 1458
+      },
+      {
+        "date" : "2024-09-17",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 RC (16A242)",
+        "value" : 1502
       }
     ]
   },
@@ -179,6 +191,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
         "value" : 531
+      },
+      {
+        "date" : "2024-09-17",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 RC (16A242)",
+        "value" : 452
       }
     ]
   }

--- a/Resources/ChartData/rfs6-events.json
+++ b/Resources/ChartData/rfs6-events.json
@@ -22,5 +22,9 @@
     {
         "date": "2024-08-20",
         "value": "Xcode 16 beta 6 released"
+    },
+    {
+        "date": "2024-09-09",
+        "value": "Xcode 16 RC released"
     }
 ]

--- a/Resources/ChartData/rfs6-packages.json
+++ b/Resources/ChartData/rfs6-packages.json
@@ -57,6 +57,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
         "value" : 1545
+      },
+      {
+        "date" : "2024-09-17",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 RC (16A242)",
+        "value" : 1556
       }
     ]
   },
@@ -118,6 +124,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
         "value" : 21
+      },
+      {
+        "date" : "2024-09-17",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 RC (16A242)",
+        "value" : 22
       }
     ]
   },
@@ -179,6 +191,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.0 beta 6 (16A5230g)",
         "value" : 9
+      },
+      {
+        "date" : "2024-09-17",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.0 Xcode 16.0 RC (16A242)",
+        "value" : 10
       }
     ]
   }


### PR DESCRIPTION
Good news, the error counts are coming back down:

![CleanShot 2024-09-17 at 15 53 14@2x](https://github.com/user-attachments/assets/84a6ec6e-01c4-4d0a-8575-c54ecdf68cc2)
