### PR TITLE
Update Fork to contain fallback URL

### DIFF
--- a/Sources/App/Commands/Ingest.swift
+++ b/Sources/App/Commands/Ingest.swift
@@ -223,7 +223,7 @@ func getFork(on database: Database, parent: Github.Metadata.Parent?) async -> Fo
     if let packageId = try? await Package.query(on: database)
         .filter(\.$url, .custom("ilike"), parentUrl)
         .first()?.id {
-        return .parentId(packageId)
+        return .parentId(id: packageId, fallbackURL: parentUrl)
     } else {
         return .parentURL(parentUrl)
     }

--- a/Sources/App/Migrations/080/UpdateRepositoryAddForkedFrom2.swift
+++ b/Sources/App/Migrations/080/UpdateRepositoryAddForkedFrom2.swift
@@ -1,0 +1,31 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+
+struct UpdateRepositoryAddForkedFrom2: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        guard let db = database as? SQLDatabase else {
+            fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")
+        }
+
+        try await db.raw(#"UPDATE "repositories" SET forked_from = NULL"#).run()
+    }
+
+    func revert(on database: Database) async throws {
+        // There's nothing we can do to restore the previous state
+    }
+}

--- a/Sources/App/Migrations/080/UpdateRepositoryResetForkedFrom.swift
+++ b/Sources/App/Migrations/080/UpdateRepositoryResetForkedFrom.swift
@@ -16,7 +16,7 @@ import Fluent
 import SQLKit
 
 
-struct UpdateRepositoryAddForkedFrom2: AsyncMigration {
+struct UpdateRepositoryResetForkedFrom: AsyncMigration {
     func prepare(on database: Database) async throws {
         guard let db = database as? SQLDatabase else {
             fatalError("Database must be an SQLDatabase ('as? SQLDatabase' must succeed)")

--- a/Sources/App/Models/Repository.swift
+++ b/Sources/App/Models/Repository.swift
@@ -273,6 +273,6 @@ enum S3Readme: Codable, Equatable {
 }
 
 enum Fork: Codable, Equatable {
-    case parentId(Package.Id)
+    case parentId(id: Package.Id, fallbackURL: String)
     case parentURL(String)
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -337,6 +337,9 @@ public func configure(_ app: Application) async throws -> String {
     do { // Migration 079 - Add `forked_from` to `repositories`
         app.migrations.add(UpdateRepositoryAddForkedFrom())
     }
+    do { // Migration 080 - Set`forkded_from` to NULL because of Fork model change in Repository
+        app.migrations.add(UpdateRepositoryAddForkedFrom2())
+    }
 
     app.asyncCommands.use(Analyze.Command(), as: "analyze")
     app.asyncCommands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -337,8 +337,8 @@ public func configure(_ app: Application) async throws -> String {
     do { // Migration 079 - Add `forked_from` to `repositories`
         app.migrations.add(UpdateRepositoryAddForkedFrom())
     }
-    do { // Migration 080 - Set`forkded_from` to NULL because of Fork model change in Repository
-        app.migrations.add(UpdateRepositoryAddForkedFrom2())
+    do { // Migration 080 - Set`forked_from` to NULL because of Fork model change in Repository
+        app.migrations.add(UpdateRepositoryResetForkedFrom())
     }
 
     app.asyncCommands.use(Analyze.Command(), as: "analyze")

--- a/Tests/AppTests/IngestorTests.swift
+++ b/Tests/AppTests/IngestorTests.swift
@@ -606,16 +606,16 @@ class IngestorTests: AppTestCase {
 
         // test lookup when package is in the index
         let fork = await getFork(on: app.db, parent: .init(url: "https://github.com/foo/parent.git"))
-        XCTAssertEqual(fork, .parentId(.id0))
-        
+        XCTAssertEqual(fork, .parentId(id: .id0, fallbackURL: "https://github.com/foo/parent.git"))
+
         // test lookup when package is in the index but with different case in URL
         let fork2 = await getFork(on: app.db, parent: .init(url: "https://github.com/Foo/Parent.git"))
-        XCTAssertEqual(fork2, .parentId(.id0))
-        
+        XCTAssertEqual(fork2, .parentId(id: .id0, fallbackURL: "https://github.com/Foo/Parent.git"))
+
         // test whem metadata repo url doesn't have `.git` at end
         let fork3 = await getFork(on: app.db, parent: .init(url: "https://github.com/Foo/Parent"))
-        XCTAssertEqual(fork3, .parentId(.id0))
-        
+        XCTAssertEqual(fork3, .parentId(id: .id0, fallbackURL: "https://github.com/Foo/Parent.git"))
+
         // test lookup when package is not in the index
         let fork4 = await getFork(on: app.db, parent: .init(url: "https://github.com/some/other.git"))
         XCTAssertEqual(fork4, .parentURL("https://github.com/some/other.git"))


### PR DESCRIPTION
This PR updates the `Fork` enum to contain a fallback URL which we can resort to in cases where the `Package` we are referencing is deleted. More detailed information can be found in this [PR](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/3371).