### PR TITLE
Disable workflow concurrency on branch basis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ on:
   schedule:
     - cron: "0 8 * * *"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-linux:
     name: Test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,10 @@ on:
     workflow_dispatch:
     push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
     lint-front-end:
         name: Lint Front-End

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -18,6 +18,10 @@ on:
   workflow_dispatch:
   push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-linux:
     name: Query Performance Test

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -22,8 +22,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-#test
-
 jobs:
   snapshots:
     name: Image Snapshots

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -18,6 +18,10 @@ on:
   workflow_dispatch:
   push:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   snapshots:
     name: Image Snapshots

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -22,6 +22,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+#test
+
 jobs:
   snapshots:
     name: Image Snapshots


### PR DESCRIPTION
Disabling concurrency for workflows on a branch can be helpful to reduce redundant jobs executions. For example:
• I made a PR and it triggers the CI workflows
• I notice that I have a typo in the tests and I that it will cause the tests to fail
• I commit the fix
• Workflows for both commits will run concurrently

This PR disables workflow concurrency on branch basis and the previous scenario would be:
• I made a PR and it triggers the CI workflows
• I notice that I have a typo in the tests and I that it will cause the tests to fail
• I commit the fix
• The workflow of the most recent commit will cancel any in progress or pending workflows from the previous commit

Results of this PR is that we don't waste build time on non-latest commits.

More about workflow concurrency can be found [here](https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-using-concurrency-and-the-default-behavior).