### PR TITLE
Roll back to Soto 6.x until the Soto Cognito libraries support 7.x

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "be2441293ba73b4860ddd36ee48561798ff51a3b9497b64983ee1c24a12af89d",
+  "originHash" : "6ae7335a682b3be27994b6ef856d2a166455a5b43a582f9c17da2f694763ca42",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "e048c8ee94967e8d8a1c2ec0e1156d6f7fa34d31",
         "version" : "1.20.0"
+      }
+    },
+    {
+      "identity" : "big-num",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/adam-fowler/big-num.git",
+      "state" : {
+        "revision" : "5c5511ad06aeb2b97d0868f7394e14a624bfb1c7",
+        "version" : "2.0.2"
       }
     },
     {
@@ -175,7 +184,7 @@
     {
       "identity" : "shellquote",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/SwiftPackageIndex/ShellQuote.git",
+      "location" : "https://github.com/SwiftPackageIndex/ShellQuote",
       "state" : {
         "revision" : "5f555550c30ef43d64b36b40c2c291a95d62580c",
         "version" : "1.0.2"
@@ -186,8 +195,26 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto.git",
       "state" : {
-        "revision" : "7f1225d1992debad64d6f0adec4dfc2c15a49367",
-        "version" : "7.0.0"
+        "revision" : "c28c3efa72e6beceae6f38f8c8fe18e7c57e3418",
+        "version" : "6.8.0"
+      }
+    },
+    {
+      "identity" : "soto-cognito-authentication",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor-community/soto-cognito-authentication.git",
+      "state" : {
+        "revision" : "6c4740e61e121a9c299d7d0e5c41df008d41f48a",
+        "version" : "4.0.0"
+      }
+    },
+    {
+      "identity" : "soto-cognito-authentication-kit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/soto-project/soto-cognito-authentication-kit.git",
+      "state" : {
+        "revision" : "a505426e32dad89755b4b3334409f288c4f9aa04",
+        "version" : "4.2.0"
       }
     },
     {
@@ -195,8 +222,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/soto-project/soto-core.git",
       "state" : {
-        "revision" : "86145a0e6a5091bf124fc18aa029698c4c419b1a",
-        "version" : "7.0.0"
+        "revision" : "3ed66ec536bc372360d7e3ec39a5e8b1870747ea",
+        "version" : "6.5.2"
       }
     },
     {
@@ -204,8 +231,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftPackageIndex/SPIManifest.git",
       "state" : {
-        "revision" : "218e4390e6062d5887810e3f178d6fd103eb8b6f",
-        "version" : "1.5.1"
+        "revision" : "dad0c2f1c386816b4c39c09e75be552ca8d5a798",
+        "version" : "1.6.0"
       }
     },
     {
@@ -305,15 +332,6 @@
       "state" : {
         "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
         "version" : "1.3.3"
-      }
-    },
-    {
-      "identity" : "swift-distributed-tracing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-distributed-tracing.git",
-      "state" : {
-        "revision" : "11c756c5c4d7de0eeed8595695cadd7fa107aa19",
-        "version" : "1.1.1"
       }
     },
     {
@@ -431,15 +449,6 @@
       "state" : {
         "revision" : "a0e7d73f462c1c38c59dc40a3969ac40cea42950",
         "version" : "0.13.0"
-      }
-    },
-    {
-      "identity" : "swift-service-context",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-service-context.git",
-      "state" : {
-        "revision" : "0c62c5b4601d6c125050b5c3a97f20cce881d32b",
-        "version" : "1.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -42,7 +42,8 @@ let package = Package(
         .package(url: "https://github.com/pointfreeco/swift-parsing.git", from: "0.12.0"),
         .package(url: "https://github.com/pointfreeco/swift-snapshot-testing.git", from: "1.11.1"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.3.2"),
-        .package(url: "https://github.com/soto-project/soto.git", from: "7.0.0"),
+        .package(url: "https://github.com/soto-project/soto.git", from: "6.0.0"),
+        .package(url: "https://github.com/vapor-community/soto-cognito-authentication.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.0.0"),
         .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.13.0"),
@@ -72,6 +73,7 @@ let package = Package(
                     .product(name: "SwiftPMPackageCollections", package: "swift-package-manager"),
                     .product(name: "Vapor", package: "vapor"),
                     .product(name: "VaporToOpenAPI", package: "VaporToOpenAPI"),
+                    .product(name: "SotoCognitoAuthentication", package: "soto-cognito-authentication")
                 ],
                 swiftSettings: swiftSettings,
                 linkerSettings: [.unsafeFlags(["-Xlinker", "-interposable"],

--- a/Sources/S3Store/S3Store.swift
+++ b/Sources/S3Store/S3Store.swift
@@ -31,12 +31,13 @@ public struct S3Store {
     }
 
     public func save(payload: Data, to key: Key) async throws {
-        let client = AWSClient(credentialProvider: .static(accessKeyId: credentials.keyId, secretAccessKey: credentials.secret))
+        let client = AWSClient(credentialProvider: .static(accessKeyId: credentials.keyId, secretAccessKey: credentials.secret),
+                               httpClientProvider: .createNew)
         do {
             let s3 = S3(client: client, region: Self.region)
             let req = S3.PutObjectRequest(
                 acl: .publicRead,  // requires "Block all public access" to be "off"
-                body: .init(buffer: .init(data: payload)),
+                body: .data(payload),
                 bucket: key.bucket,
                 key: key.path
             )


### PR DESCRIPTION
Putting this in as a PR now, ahead of the work that @rahafjrw is doing on #3384. Mainly because there may be some discussion about rolling back the Soto change which I’d like to get out of the way before the first of the auth PRs land.

This rolls Soto back to 6.x due to the dependency in https://swiftpackageindex.com/soto-project/soto-cognito-authentication-kit 4.x. It undoes the change made in https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/3207/files#diff-5d2ca8674645a1e92a14b68d5cc308c427c2d58120392a0df74d6a4f5fc97440.

There is a beta version of soto-cognito-authentication-kit in development, but it is not yet released. I chatted with @adam-fowler this afternoon and apparently the hold up on that beta is the dependency on the beta version of jwt-kit which is currently in RC.

It’s unlikely all of these will shake out before the authentication feature is finalised, but they also should not hold us on 6.x for very long since all of the dependencies have a RC status at the moment.