### PR TITLE
Custom package collections

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -66,6 +66,7 @@ let package = Package(
                     .product(name: "CanonicalPackageURL", package: "CanonicalPackageURL"),
                     .product(name: "CustomDump", package: "swift-custom-dump"),
                     .product(name: "Dependencies", package: "swift-dependencies"),
+                    .product(name: "DependenciesMacros", package: "swift-dependencies"),
                     .product(name: "DependencyResolution", package: "DependencyResolution"),
                     .product(name: "Fluent", package: "fluent"),
                     .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),

--- a/Sources/App/Commands/Reconcile.swift
+++ b/Sources/App/Commands/Reconcile.swift
@@ -167,7 +167,7 @@ func reconcileCustomCollection(client: Client, database: Database, fullPackageLi
     // Limit incoming URLs to 50 since this is input outside of our control
     @Dependency(\.packageListRepository) var packageListRepository
     let incomingURLs = try await packageListRepository.fetchCustomCollection(client: client, url: collection.url)
-        .prefix(50)
+        .prefix(Constants.maxCustomPackageCollectionSize)
 
     try await collection.reconcile(on: database, packageURLs: incomingURLs)
 }

--- a/Sources/App/Commands/Reconcile.swift
+++ b/Sources/App/Commands/Reconcile.swift
@@ -25,7 +25,7 @@ struct ReconcileCommand: AsyncCommand {
     func run(using context: CommandContext, signature: Signature) async throws {
         Current.setLogger(Logger(component: "reconcile"))
 
-        Current.logger().info("Reconciling ...")
+        Current.logger().info("Reconciling...")
 
         do {
             try await reconcile(client: context.application.client,
@@ -51,12 +51,15 @@ func reconcile(client: Client, database: Database) async throws {
     defer { AppMetrics.reconcileDurationSeconds?.time(since: start) }
 
     // reconcile main package list
+    Current.logger().info("Reconciling main list...")
     let fullPackageList = try await reconcileMainPackageList(client: client, database: database)
 
     do { // reconcile custom package collections
+        Current.logger().info("Reconciling custom collections...")
         @Dependency(\.packageListRepository) var packageListRepository
         let collections = try await packageListRepository.fetchCustomCollections(client: client)
         for collection in collections {
+            Current.logger().info("Reconciling '\(collection.name)' collection...")
             try await reconcileCustomCollection(client: client, database: database, fullPackageList: fullPackageList, collection)
         }
     }

--- a/Sources/App/Commands/Reconcile.swift
+++ b/Sources/App/Commands/Reconcile.swift
@@ -31,7 +31,7 @@ struct ReconcileCommand: AsyncCommand {
             try await reconcile(client: context.application.client,
                                 database: context.application.db)
         } catch {
-            Current.logger().error("\(error.localizedDescription)")
+            Current.logger().error("\(error)")
         }
 
         Current.logger().info("done.")
@@ -40,7 +40,7 @@ struct ReconcileCommand: AsyncCommand {
             try await AppMetrics.push(client: context.application.client,
                                       jobName: "reconcile")
         } catch {
-            Current.logger().warning("\(error.localizedDescription)")
+            Current.logger().warning("\(error)")
         }
     }
 }

--- a/Sources/App/Core/Constants.swift
+++ b/Sources/App/Core/Constants.swift
@@ -26,6 +26,7 @@ enum Constants {
 
     static let packageListUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json")
     static let packageDenyListUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/denylist.json")
+    static let customCollectionsUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/custom-package-collections.json.json")
 
     // NB: the underlying materialised views also have a limit, this is just an additional
     // limit to ensure we don't spill too many rows onto the home page

--- a/Sources/App/Core/Constants.swift
+++ b/Sources/App/Core/Constants.swift
@@ -28,6 +28,8 @@ enum Constants {
     static let packageDenyListUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/denylist.json")
     static let customCollectionsUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/custom-package-collections.json.json")
 
+    static let maxCustomPackageCollectionSize = 50
+
     // NB: the underlying materialised views also have a limit, this is just an additional
     // limit to ensure we don't spill too many rows onto the home page
     static let recentPackagesLimit = 7

--- a/Sources/App/Core/Constants.swift
+++ b/Sources/App/Core/Constants.swift
@@ -26,7 +26,7 @@ enum Constants {
 
     static let packageListUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/packages.json")
     static let packageDenyListUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/denylist.json")
-    static let customCollectionsUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/custom-package-collections.json.json")
+    static let customCollectionsUri = URI(string: "https://raw.githubusercontent.com/SwiftPackageIndex/PackageList/main/custom-package-collections.json")
 
     static let maxCustomPackageCollectionSize = 50
 

--- a/Sources/App/Core/Dependencies/PackageListRepositoryClient.swift
+++ b/Sources/App/Core/Dependencies/PackageListRepositoryClient.swift
@@ -25,6 +25,26 @@ struct PackageListRepositoryClient {
 }
 
 
+extension PackageListRepositoryClient: DependencyKey {
+    static var liveValue: PackageListRepositoryClient {
+        .init(
+            fetchCustomCollection: { client, url in
+                try await client
+                    .get(URI(string: url.absoluteString))
+                    .content
+                    .decode([URL].self, using: JSONDecoder())
+            },
+            fetchCustomCollections: { client in
+                try await client
+                    .get(Constants.customCollectionsUri)
+                    .content
+                    .decode([CustomCollection.DTO].self, using: JSONDecoder())
+            }
+        )
+    }
+}
+
+
 extension PackageListRepositoryClient: Sendable, TestDependencyKey {
     static var testValue: Self { Self() }
 }

--- a/Sources/App/Core/Dependencies/PackageListRepositoryClient.swift
+++ b/Sources/App/Core/Dependencies/PackageListRepositoryClient.swift
@@ -20,6 +20,7 @@ import Vapor
 @DependencyClient
 struct PackageListRepositoryClient {
     var fetchCustomCollection: @Sendable (_ client: Client, _ url: URL) async throws -> [URL]
+    var fetchCustomCollections: @Sendable (_ client: Client) async throws -> [CustomCollection.DTO]
     // TODO: move other package list dependencies here
 }
 

--- a/Sources/App/Core/Dependencies/PackageListRepositoryClient.swift
+++ b/Sources/App/Core/Dependencies/PackageListRepositoryClient.swift
@@ -1,0 +1,38 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Dependencies
+import DependenciesMacros
+import Vapor
+
+
+@DependencyClient
+struct PackageListRepositoryClient {
+    var fetchCustomCollection: @Sendable (_ client: Client, _ url: URL) async throws -> [URL]
+    // TODO: move other package list dependencies here
+}
+
+
+extension PackageListRepositoryClient: Sendable, TestDependencyKey {
+    static var testValue: Self { Self() }
+}
+
+
+extension DependencyValues {
+    var packageListRepository: PackageListRepositoryClient {
+        get { self[PackageListRepositoryClient.self] }
+        set { self[PackageListRepositoryClient.self] = newValue }
+    }
+}
+

--- a/Sources/App/Migrations/081/CreateCustomCollection.swift
+++ b/Sources/App/Migrations/081/CreateCustomCollection.swift
@@ -1,0 +1,44 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+
+struct CreateCustomCollection: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("custom_collections")
+
+        // managed fields
+            .id()
+            .field("created_at", .datetime)
+            .field("updated_at", .datetime)
+
+        // data fields
+            .field("name", .string, .required)
+            .field("description", .string)
+            .field("badge", .string)
+            .field("url", .string, .required)
+
+        // constraints
+            .unique(on: "name")
+            .unique(on: "url")
+
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("custom_collections").delete()
+    }
+}

--- a/Sources/App/Migrations/081/CreateCustomCollectionPackage.swift
+++ b/Sources/App/Migrations/081/CreateCustomCollectionPackage.swift
@@ -1,0 +1,43 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import SQLKit
+
+
+struct CreateCustomCollectionPackage: AsyncMigration {
+    func prepare(on database: Database) async throws {
+        try await database.schema("custom_collections+packages")
+
+        // managed fields
+            .id()
+            .field("created_at", .datetime)
+            .field("updated_at", .datetime)
+
+        // reference fields
+            .field("custom_collection_id", .uuid,
+                   .references("custom_collections", "id", onDelete: .cascade), .required)
+            .field("package_id", .uuid,
+                   .references("packages", "id", onDelete: .cascade), .required)
+
+        // constraints
+            .unique(on: "custom_collection_id", "package_id")
+
+            .create()
+    }
+
+    func revert(on database: Database) async throws {
+        try await database.schema("custom_collections+packages").delete()
+    }
+}

--- a/Sources/App/Models/CustomCollection.swift
+++ b/Sources/App/Models/CustomCollection.swift
@@ -45,23 +45,13 @@ final class CustomCollection: @unchecked Sendable, Model, Content {
     var badge: String?
 
     @Field(key: "url")
-    var url: String
+    var url: URL
 
     // reference fields
     @Siblings(through: CustomCollectionPackage.self, from: \.$customCollection, to: \.$package)
     var packages: [Package]
 
     init() { }
-
-    init(id: Id? = nil, createdAt: Date? = nil, updatedAt: Date? = nil, name: String, description: String? = nil, badge: String? = nil, url: String) {
-        self.id = id
-        self.createdAt = createdAt
-        self.updatedAt = updatedAt
-        self.name = name
-        self.description = description
-        self.badge = badge
-        self.url = url
-    }
 
     init(id: Id? = nil, createdAt: Date? = nil, updatedAt: Date? = nil, _ dto: DTO) {
         self.id = id
@@ -80,7 +70,7 @@ extension CustomCollection {
         var name: String
         var description: String?
         var badge: String?
-        var url: String
+        var url: URL
     }
 
     static func findOrCreate(on database: Database, _ dto: DTO) async throws -> CustomCollection {

--- a/Sources/App/Models/CustomCollection.swift
+++ b/Sources/App/Models/CustomCollection.swift
@@ -1,0 +1,62 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import Vapor
+
+
+final class CustomCollection: @unchecked Sendable, Model, Content {
+    static let schema = "custom_collections"
+
+    typealias Id = UUID
+
+    // managed fields
+
+    @ID(key: .id)
+    var id: Id?
+
+    @Timestamp(key: "created_at", on: .create)
+    var createdAt: Date?
+
+    // periphery:ignore
+    @Timestamp(key: "updated_at", on: .update)
+    var updatedAt: Date?
+
+    // data fields
+
+    @Field(key: "name")
+    var name: String
+
+    @Field(key: "description")
+    var description: String?
+
+    @Field(key: "badge")
+    var badge: String?
+
+    @Field(key: "url")
+    var url: String
+
+    init() { }
+
+    init(id: Id? = nil, createdAt: Date? = nil, updatedAt: Date? = nil, name: String, description: String? = nil, badge: String? = nil, url: String) {
+        self.id = id
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.name = name
+        self.description = description
+        self.badge = badge
+        self.url = url
+    }
+
+}

--- a/Sources/App/Models/CustomCollectionPackage.swift
+++ b/Sources/App/Models/CustomCollectionPackage.swift
@@ -16,8 +16,8 @@ import Fluent
 import Vapor
 
 
-final class CustomCollection: @unchecked Sendable, Model, Content {
-    static let schema = "custom_collections"
+final class CustomCollectionPackage: @unchecked Sendable, Model, Content {
+    static let schema = "custom_collections+packages"
 
     typealias Id = UUID
 
@@ -33,34 +33,21 @@ final class CustomCollection: @unchecked Sendable, Model, Content {
     @Timestamp(key: "updated_at", on: .update)
     var updatedAt: Date?
 
-    // data fields
-
-    @Field(key: "name")
-    var name: String
-
-    @Field(key: "description")
-    var description: String?
-
-    @Field(key: "badge")
-    var badge: String?
-
-    @Field(key: "url")
-    var url: String
-
     // reference fields
-    @Siblings(through: CustomCollectionPackage.self, from: \.$customCollection, to: \.$package)
-    var packages: [Package]
+
+    @Parent(key: "custom_collection_id")
+    var customCollection: CustomCollection
+
+    @Parent(key: "package_id")
+    var package: Package
 
     init() { }
 
-    init(id: Id? = nil, createdAt: Date? = nil, updatedAt: Date? = nil, name: String, description: String? = nil, badge: String? = nil, url: String) {
+    init(id: Id? = nil, createdAt: Date? = nil, updatedAt: Date? = nil, customCollection: CustomCollection, package: Package) {
         self.id = id
         self.createdAt = createdAt
         self.updatedAt = updatedAt
-        self.name = name
-        self.description = description
-        self.badge = badge
-        self.url = url
+        self.customCollection = customCollection
+        self.package = package
     }
-
 }

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -271,6 +271,10 @@ extension QueryBuilder where Model == Package {
     func filter(by url: URL) -> Self {
         filter(\.$url == url.absoluteString)
     }
+
+    func filter(by urls: some Collection<URL>) -> Self {
+        filter(\.$url ~~ urls.map(\.absoluteString))
+    }
 }
 
 

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -273,6 +273,7 @@ extension QueryBuilder where Model == Package {
     }
 
     func filter(by urls: some Collection<URL>) -> Self {
+        // TODO: make case-insensitive and canonicalise incoming URLs
         filter(\.$url ~~ urls.map(\.absoluteString))
     }
 }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -340,6 +340,9 @@ public func configure(_ app: Application) async throws -> String {
     do { // Migration 080 - Set`forked_from` to NULL because of Fork model change in Repository
         app.migrations.add(UpdateRepositoryResetForkedFrom())
     }
+    do { // Migration 081 - Create `custom_collections`
+        app.migrations.add(CreateCustomCollection())
+    }
 
     app.asyncCommands.use(Analyze.Command(), as: "analyze")
     app.asyncCommands.use(CreateRestfileCommand(), as: "create-restfile")

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -342,6 +342,7 @@ public func configure(_ app: Application) async throws -> String {
     }
     do { // Migration 081 - Create `custom_collections`
         app.migrations.add(CreateCustomCollection())
+        app.migrations.add(CreateCustomCollectionPackage())
     }
 
     app.asyncCommands.use(Analyze.Command(), as: "analyze")

--- a/Tests/AppTests/CustomCollectionTests.swift
+++ b/Tests/AppTests/CustomCollectionTests.swift
@@ -84,4 +84,26 @@ class CustomCollectionTests: AppTestCase {
         }
     }
 
+    func test_CustomCollectionPackage_detach() async throws {
+        // setup
+        let pkg = Package(id: .id0, url: "1".asGithubUrl.url)
+        try await pkg.save(on: app.db)
+        let collection = CustomCollection(id: .id1, name: "List", url: "https://github.com/foo/bar/list.json")
+        try await collection.save(on: app.db)
+        try await collection.$packages.attach(pkg, on: app.db)
+
+        // MUT
+        try await collection.$packages.detach(pkg, on: app.db)
+
+        do { // validate
+            let count = try await CustomCollectionPackage.query(on: app.db).count()
+            XCTAssertEqual(count, 0)
+        }
+
+        do { // ensure packag and collection are untouched
+            _ = try await Package.find(.id0, on: app.db).unwrap()
+            _ = try await CustomCollection.find(.id1, on: app.db).unwrap()
+        }
+    }
+
 }

--- a/Tests/AppTests/CustomCollectionTests.swift
+++ b/Tests/AppTests/CustomCollectionTests.swift
@@ -23,7 +23,7 @@ class CustomCollectionTests: AppTestCase {
 
     func test_CustomCollection_save() async throws {
         // MUT
-        try await CustomCollection(id: .id0, name: "List", url: "https://github.com/foo/bar/list.json")
+        try await CustomCollection(id: .id0, .init(name: "List", url: "https://github.com/foo/bar/list.json"))
             .save(on: app.db)
 
         do { // validate
@@ -33,7 +33,7 @@ class CustomCollectionTests: AppTestCase {
         }
 
         do { // ensure name is unique
-            try await CustomCollection(name: "List", url: "https://github.com/foo/bar/other-list.json")
+            try await CustomCollection(.init(name: "List", url: "https://github.com/foo/bar/other-list.json"))
                 .save(on: app.db)
             XCTFail("Expected failure")
         } catch {
@@ -43,7 +43,7 @@ class CustomCollectionTests: AppTestCase {
         }
 
         do { // ensure url is unique
-            try await CustomCollection(name: "List 2", url: "https://github.com/foo/bar/list.json")
+            try await CustomCollection(.init(name: "List 2", url: "https://github.com/foo/bar/list.json"))
                 .save(on: app.db)
             XCTFail("Expected failure")
         } catch {
@@ -87,7 +87,7 @@ class CustomCollectionTests: AppTestCase {
         // setup
         let pkg = Package(id: .id0, url: "1".asGithubUrl.url)
         try await pkg.save(on: app.db)
-        let collection = CustomCollection(id: .id1, name: "List", url: "https://github.com/foo/bar/list.json")
+        let collection = CustomCollection(id: .id1, .init(name: "List", url: "https://github.com/foo/bar/list.json"))
         try await collection.save(on: app.db)
 
         // MUT
@@ -118,7 +118,7 @@ class CustomCollectionTests: AppTestCase {
         // setup
         let pkg = Package(id: .id0, url: "1".asGithubUrl.url)
         try await pkg.save(on: app.db)
-        let collection = CustomCollection(id: .id1, name: "List", url: "https://github.com/foo/bar/list.json")
+        let collection = CustomCollection(id: .id1, .init(name: "List", url: "https://github.com/foo/bar/list.json"))
         try await collection.save(on: app.db)
         try await collection.$packages.attach(pkg, on: app.db)
 
@@ -142,7 +142,7 @@ class CustomCollectionTests: AppTestCase {
         try await p1.save(on: app.db)
         let p2 = Package(id: .id1, url: "2".asGithubUrl.url)
         try await p2.save(on: app.db)
-        let collection = CustomCollection(id: .id2, name: "List", url: "https://github.com/foo/bar/list.json")
+        let collection = CustomCollection(id: .id2, .init(name: "List", url: "https://github.com/foo/bar/list.json"))
         try await collection.save(on: app.db)
         try await collection.$packages.attach([p1, p2], on: app.db)
 
@@ -158,7 +158,7 @@ class CustomCollectionTests: AppTestCase {
         // setup
         let pkg = Package(id: .id0, url: "1".asGithubUrl.url)
         try await pkg.save(on: app.db)
-        let collection = CustomCollection(id: .id1, name: "List", url: "https://github.com/foo/bar/list.json")
+        let collection = CustomCollection(id: .id1, .init(name: "List", url: "https://github.com/foo/bar/list.json"))
         try await collection.save(on: app.db)
         try await collection.$packages.attach(pkg, on: app.db)
         do {
@@ -196,7 +196,7 @@ class CustomCollectionTests: AppTestCase {
         // setup
         let pkg = Package(id: .id0, url: "1".asGithubUrl.url)
         try await pkg.save(on: app.db)
-        let collection = CustomCollection(id: .id1, name: "List", url: "https://github.com/foo/bar/list.json")
+        let collection = CustomCollection(id: .id1, .init(name: "List", url: "https://github.com/foo/bar/list.json"))
         try await collection.save(on: app.db)
         try await collection.$packages.attach(pkg, on: app.db)
         do {
@@ -232,7 +232,7 @@ class CustomCollectionTests: AppTestCase {
 
     func test_CustomCollection_reconcile() async throws {
         // Test reconciliation of a custom collection against a list of package URLs
-        let collection = CustomCollection(id: .id0, name: "List", url: "https://github.com/foo/bar/list.json")
+        let collection = CustomCollection(id: .id0, .init(name: "List", url: "https://github.com/foo/bar/list.json"))
         try await collection.save(on: app.db)
         try await Package(id: .id1, url: URL("https://a")).save(on: app.db)
         try await Package(id: .id2, url: URL("https://b")).save(on: app.db)

--- a/Tests/AppTests/CustomCollectionTests.swift
+++ b/Tests/AppTests/CustomCollectionTests.swift
@@ -20,6 +20,7 @@ import Dependencies
 
 
 class CustomCollectionTests: AppTestCase {
+
     func test_CustomCollection_save() async throws {
         // MUT
         try await CustomCollection(id: .id0, name: "List", url: "https://github.com/foo/bar/list.json")
@@ -51,4 +52,36 @@ class CustomCollectionTests: AppTestCase {
                       "was: \(msg)")
         }
     }
+
+    func test_CustomCollectionPackage_attach() async throws {
+        // setup
+        let pkg = Package(id: .id0, url: "1".asGithubUrl.url)
+        try await pkg.save(on: app.db)
+        let collection = CustomCollection(id: .id1, name: "List", url: "https://github.com/foo/bar/list.json")
+        try await collection.save(on: app.db)
+
+        // MUT
+        try await collection.$packages.attach(pkg, on: app.db)
+
+        do { // validate
+            let count = try await CustomCollectionPackage.query(on: app.db).count()
+            XCTAssertEqual(count, 1)
+            let pivot = try await CustomCollectionPackage.query(on: app.db).first().unwrap()
+            try await pivot.$package.load(on: app.db)
+            XCTAssertEqual(pivot.package.id, .id0)
+            XCTAssertEqual(pivot.package.url, "1".asGithubUrl)
+            try await pivot.$customCollection.load(on: app.db)
+            XCTAssertEqual(pivot.customCollection.id, .id1)
+            XCTAssertEqual(pivot.customCollection.name, "List")
+        }
+
+        do { // ensure package is unique per list
+            try await collection.$packages.attach(pkg, on: app.db)
+        } catch {
+            let msg = String(reflecting: error)
+            XCTAssert(msg.contains(#"duplicate key value violates unique constraint "uq:custom_collections+packages.custom_collection_id+custom_coll""#),
+                      "was: \(msg)")
+        }
+    }
+
 }

--- a/Tests/AppTests/CustomCollectionTests.swift
+++ b/Tests/AppTests/CustomCollectionTests.swift
@@ -1,0 +1,54 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import XCTest
+
+@testable import App
+
+import Dependencies
+
+
+class CustomCollectionTests: AppTestCase {
+    func test_CustomCollection_save() async throws {
+        // MUT
+        try await CustomCollection(id: .id0, name: "List", url: "https://github.com/foo/bar/list.json")
+            .save(on: app.db)
+
+        do { // validate
+            let collection = try await CustomCollection.find(.id0, on: app.db).unwrap()
+            XCTAssertEqual(collection.name, "List")
+            XCTAssertEqual(collection.url, "https://github.com/foo/bar/list.json")
+        }
+
+        do { // ensure name is unique
+            try await CustomCollection(name: "List", url: "https://github.com/foo/bar/other-list.json")
+                .save(on: app.db)
+            XCTFail("Expected failure")
+        } catch {
+            let msg = String(reflecting: error)
+            XCTAssert(msg.contains(#"duplicate key value violates unique constraint "uq:custom_collections.name""#),
+                      "was: \(msg)")
+        }
+
+        do { // ensure url is unique
+            try await CustomCollection(name: "List 2", url: "https://github.com/foo/bar/list.json")
+                .save(on: app.db)
+            XCTFail("Expected failure")
+        } catch {
+            let msg = String(reflecting: error)
+            XCTAssert(msg.contains(#"duplicate key value violates unique constraint "uq:custom_collections.url""#),
+                      "was: \(msg)")
+        }
+    }
+}

--- a/Tests/AppTests/CustomCollectionTests.swift
+++ b/Tests/AppTests/CustomCollectionTests.swift
@@ -53,6 +53,36 @@ class CustomCollectionTests: AppTestCase {
         }
     }
 
+    func test_CustomCollection_findOrCreate() async throws {
+        do { // initial call creates collection
+            // MUT
+            let res = try await CustomCollection.findOrCreate(on: app.db, .init(name: "List", url: "url"))
+
+            // validate
+            XCTAssertEqual(res.name, "List")
+            XCTAssertEqual(res.url, "url")
+
+            let c = try await CustomCollection.query(on: app.db).all()
+            XCTAssertEqual(c.count, 1)
+            XCTAssertEqual(c.first?.name, "List")
+            XCTAssertEqual(c.first?.url, "url")
+        }
+
+        do { // re-running is idempotent
+            // MUT
+            let res = try await CustomCollection.findOrCreate(on: app.db, .init(name: "List", url: "url"))
+
+            // validate
+            XCTAssertEqual(res.name, "List")
+            XCTAssertEqual(res.url, "url")
+
+            let c = try await CustomCollection.query(on: app.db).all()
+            XCTAssertEqual(c.count, 1)
+            XCTAssertEqual(c.first?.name, "List")
+            XCTAssertEqual(c.first?.url, "url")
+        }
+    }
+
     func test_CustomCollectionPackage_attach() async throws {
         // setup
         let pkg = Package(id: .id0, url: "1".asGithubUrl.url)

--- a/Tests/AppTests/CustomCollectionTests.swift
+++ b/Tests/AppTests/CustomCollectionTests.swift
@@ -106,4 +106,22 @@ class CustomCollectionTests: AppTestCase {
         }
     }
 
+    func test_CustomCollection_packages() async throws {
+        // setup
+        let p1 = Package(id: .id0, url: "1".asGithubUrl.url)
+        try await p1.save(on: app.db)
+        let p2 = Package(id: .id1, url: "2".asGithubUrl.url)
+        try await p2.save(on: app.db)
+        let collection = CustomCollection(id: .id2, name: "List", url: "https://github.com/foo/bar/list.json")
+        try await collection.save(on: app.db)
+        try await collection.$packages.attach([p1, p2], on: app.db)
+
+        do { // MUT
+            let collection = try await CustomCollection.find(.id2, on: app.db).unwrap()
+            try await collection.$packages.load(on: app.db)
+            let packages = collection.packages
+            XCTAssertEqual(Set(packages.map(\.id)) , Set([.id0, .id1]))
+        }
+    }
+
 }

--- a/Tests/AppTests/CustomCollectionTests.swift
+++ b/Tests/AppTests/CustomCollectionTests.swift
@@ -124,4 +124,80 @@ class CustomCollectionTests: AppTestCase {
         }
     }
 
+    func test_CustomCollection_cascade() async throws {
+        // setup
+        let pkg = Package(id: .id0, url: "1".asGithubUrl.url)
+        try await pkg.save(on: app.db)
+        let collection = CustomCollection(id: .id1, name: "List", url: "https://github.com/foo/bar/list.json")
+        try await collection.save(on: app.db)
+        try await collection.$packages.attach(pkg, on: app.db)
+        do {
+            let count = try await CustomCollection.query(on: app.db).count()
+            XCTAssertEqual(count, 1)
+        }
+        do {
+            let count = try await CustomCollectionPackage.query(on: app.db).count()
+            XCTAssertEqual(count, 1)
+        }
+        do {
+            let count = try await Package.query(on: app.db).count()
+            XCTAssertEqual(count, 1)
+        }
+
+        // MUT
+        try await collection.delete(on: app.db)
+
+        // validation
+        do {
+            let count = try await CustomCollection.query(on: app.db).count()
+            XCTAssertEqual(count, 0)
+        }
+        do {
+            let count = try await CustomCollectionPackage.query(on: app.db).count()
+            XCTAssertEqual(count, 0)
+        }
+        do {
+            let count = try await Package.query(on: app.db).count()
+            XCTAssertEqual(count, 1)
+        }
+    }
+
+    func test_Package_cascade() async throws {
+        // setup
+        let pkg = Package(id: .id0, url: "1".asGithubUrl.url)
+        try await pkg.save(on: app.db)
+        let collection = CustomCollection(id: .id1, name: "List", url: "https://github.com/foo/bar/list.json")
+        try await collection.save(on: app.db)
+        try await collection.$packages.attach(pkg, on: app.db)
+        do {
+            let count = try await CustomCollection.query(on: app.db).count()
+            XCTAssertEqual(count, 1)
+        }
+        do {
+            let count = try await CustomCollectionPackage.query(on: app.db).count()
+            XCTAssertEqual(count, 1)
+        }
+        do {
+            let count = try await Package.query(on: app.db).count()
+            XCTAssertEqual(count, 1)
+        }
+
+        // MUT
+        try await pkg.delete(on: app.db)
+
+        // validation
+        do {
+            let count = try await CustomCollection.query(on: app.db).count()
+            XCTAssertEqual(count, 1)
+        }
+        do {
+            let count = try await CustomCollectionPackage.query(on: app.db).count()
+            XCTAssertEqual(count, 0)
+        }
+        do {
+            let count = try await Package.query(on: app.db).count()
+            XCTAssertEqual(count, 0)
+        }
+    }
+
 }

--- a/Tests/AppTests/MastodonTests.swift
+++ b/Tests/AppTests/MastodonTests.swift
@@ -58,6 +58,8 @@ final class MastodonTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
+            $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }
+            $0.packageListRepository.fetchCustomCollection = { @Sendable _, _ in [] }
         } operation: {
             // run first two processing steps
             try await reconcile(client: app.client, database: app.db)

--- a/Tests/AppTests/MetricsTests.swift
+++ b/Tests/AppTests/MetricsTests.swift
@@ -14,6 +14,7 @@
 
 @testable import App
 
+import Dependencies
 import Prometheus
 import XCTest
 
@@ -98,14 +99,18 @@ class MetricsTests: AppTestCase {
     }
 
     func test_reconcileDurationSeconds() async throws {
-        // setup
-        Current.fetchPackageList = { _ in ["1", "2", "3"].asURLs }
+        try await withDependencies {
+            $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }
+        } operation: {
+            // setup
+            Current.fetchPackageList = { _ in ["1", "2", "3"].asURLs }
 
-        // MUT
-        try await reconcile(client: app.client, database: app.db)
+            // MUT
+            try await reconcile(client: app.client, database: app.db)
 
-        // validation
-        XCTAssert((AppMetrics.reconcileDurationSeconds?.get()) ?? 0 > 0)
+            // validation
+            XCTAssert((AppMetrics.reconcileDurationSeconds?.get()) ?? 0 > 0)
+        }
     }
 
     func test_ingestDurationSeconds() async throws {

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -136,6 +136,14 @@ final class PackageTests: AppTestCase {
         XCTAssertEqual(res.map(\.url), ["https://foo.com/1"])
     }
 
+    func test_filter_by_urls() async throws {
+        for url in ["https://foo.com/1", "https://foo.com/2", "https://foo.com/a", "https://foo.com/A"] {
+            try await Package(url: url.url).save(on: app.db)
+        }
+        let res = try await Package.query(on: app.db).filter(by: ["https://foo.com/2", "https://foo.com/a"]).all()
+        XCTAssertEqual(res.map(\.url), ["https://foo.com/2", "https://foo.com/a"])
+    }
+
     func test_repository() async throws {
         let pkg = try await savePackage(on: app.db, "1")
         do {

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -297,6 +297,7 @@ final class PackageTests: AppTestCase {
     func test_isNew() async throws {
         try await withDependencies {
             $0.date.now = .now
+            $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }
         } operation: {
             // setup
             let url = "1".asGithubUrl

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -160,6 +160,8 @@ class PipelineTests: AppTestCase {
     func test_processing_pipeline() async throws {
         try await withDependencies {
             $0.date.now = .now
+            $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }
+            $0.packageListRepository.fetchCustomCollection = { @Sendable _, _ in [] }
         } operation: {
             // Test pipeline pick-up end to end
             // setup

--- a/Tests/AppTests/ReconcilerTests.swift
+++ b/Tests/AppTests/ReconcilerTests.swift
@@ -35,13 +35,13 @@ class ReconcilerTests: AppTestCase {
         XCTAssertEqual(urls.map(\.absoluteString).sorted(), ["1", "2", "3"])
     }
 
-    func test_basic_reconciliation() async throws {
+    func test_reconcileMainPackageList() async throws {
         // setup
         let urls = ["1", "2", "3"]
         Current.fetchPackageList = { _ in urls.asURLs }
 
         // MUT
-        try await reconcile(client: app.client, database: app.db)
+        _ = try await reconcileMainPackageList(client: app.client, database: app.db)
 
         // validate
         let packages = try await Package.query(on: app.db).all()
@@ -55,7 +55,7 @@ class ReconcilerTests: AppTestCase {
         }
     }
 
-    func test_adds_and_deletes() async throws {
+    func test_reconcileMainPackageList_adds_and_deletes() async throws {
         // save intial set of packages 1, 2, 3
         for url in ["1", "2", "3"].asURLs {
             try await Package(url: url).save(on: app.db)
@@ -66,14 +66,14 @@ class ReconcilerTests: AppTestCase {
         Current.fetchPackageList = { _ in urls.asURLs }
 
         // MUT
-        try await reconcile(client: app.client, database: app.db)
+        _ = try await reconcileMainPackageList(client: app.client, database: app.db)
 
         // validate
         let packages = try await Package.query(on: app.db).all()
         XCTAssertEqual(packages.map(\.url).sorted(), urls.sorted())
     }
 
-    func test_packageDenyList() async throws {
+    func test_reconcileMainPackageList_packageDenyList() async throws {
         // Save the intial set of packages
         for url in ["1", "2", "3"].asURLs {
             try await Package(url: url).save(on: app.db)
@@ -88,14 +88,14 @@ class ReconcilerTests: AppTestCase {
         Current.fetchPackageDenyList = { _ in packageDenyList.asURLs }
 
         // MUT
-        try await reconcile(client: app.client, database: app.db)
+        _ = try await reconcileMainPackageList(client: app.client, database: app.db)
 
         // validate
         let packages = try await Package.query(on: app.db).all()
         XCTAssertEqual(packages.map(\.url).sorted(), ["1", "3", "5"])
     }
 
-    func test_packageDenyList_caseSensitivity() async throws {
+    func test_reconcileMainPackageList_packageDenyList_caseSensitivity() async throws {
         // Save the intial set of packages
         for url in ["https://example.com/one/one", "https://example.com/two/two"].asURLs {
             try await Package(url: url).save(on: app.db)
@@ -110,7 +110,7 @@ class ReconcilerTests: AppTestCase {
         Current.fetchPackageDenyList = { _ in packageDenyList.asURLs }
 
         // MUT
-        try await reconcile(client: app.client, database: app.db)
+        _ = try await reconcileMainPackageList(client: app.client, database: app.db)
 
         // validate
         let packages = try await Package.query(on: app.db).all()
@@ -204,6 +204,10 @@ class ReconcilerTests: AppTestCase {
             XCTAssertEqual(collection.packages.first?.url, "1")
             XCTAssertEqual(collection.packages.last?.url, "50")
         }
+    }
+
+    func test_reconcile() async throws {
+        XCTFail("Implement integration test for both parts, main list + custom collection")
     }
 
 }


### PR DESCRIPTION
This adds scheme and reconciliation support for custom package collections (#2957) and reads the SSWG package's sandbox, incubating, and graduated package lists (from a temporary location).

Does not include any visual representation or use of the data in search yet.