### PR TITLE
Custom collections basic UI

### DIFF
--- a/FrontEnd/styles/package.scss
+++ b/FrontEnd/styles/package.scss
@@ -156,6 +156,17 @@
                     align-items: center;
                 }
             }
+            
+            li.custom-collections {
+                grid-column-start: span 2;
+                background-image: var(--image-tags);
+
+                a {
+                    display: flex;
+                    gap: 5px;
+                    align-items: center;
+                }
+            }
         }
 
         section.sidebar-links {

--- a/Sources/App/Commands/Reconcile.swift
+++ b/Sources/App/Commands/Reconcile.swift
@@ -138,8 +138,8 @@ func processPackageDenyList(packageList: [URL], denyList: [URL]) -> [URL] {
 }
 
 
-func reconcileCustomCollection(client: Client, database: Database, fullPackageList: [URL], _ dto: CustomCollection.DTO) async throws {
-    let collection = try await CustomCollection.findOrCreate(on: database, dto)
+func reconcileCustomCollection(client: Client, database: Database, fullPackageList: [URL], _ details: CustomCollection.Details) async throws {
+    let collection = try await CustomCollection.findOrCreate(on: database, details)
 
     // Limit incoming URLs to 50 since this is input outside of our control
     @Dependency(\.packageListRepository) var packageListRepository

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute+Model.swift
@@ -51,6 +51,7 @@ extension API.PackageController.GetRoute {
         var fundingLinks: [FundingLink]
         var swift6Readiness: Swift6Readiness?
         var forkedFromInfo: ForkedFromInfo?
+        var customCollections: [CustomCollection.Details]
 
         internal init(packageId: Package.Id,
                       repositoryOwner: String,
@@ -83,7 +84,8 @@ extension API.PackageController.GetRoute {
                       preReleaseReference: App.Reference?,
                       fundingLinks: [FundingLink] = [],
                       swift6Readiness: Swift6Readiness?,
-                      forkedFromInfo: ForkedFromInfo?
+                      forkedFromInfo: ForkedFromInfo?,
+                      customCollections: [CustomCollection.Details]
             ) {
             self.packageId = packageId
             self.repositoryOwner = repositoryOwner
@@ -126,6 +128,7 @@ extension API.PackageController.GetRoute {
             self.fundingLinks = fundingLinks
             self.swift6Readiness = swift6Readiness
             self.forkedFromInfo = forkedFromInfo
+            self.customCollections = customCollections
         }
 
         init?(result: API.PackageController.PackageResult,
@@ -136,7 +139,8 @@ extension API.PackageController.GetRoute {
               platformBuildInfo: BuildInfo<CompatibilityMatrix.PlatformCompatibility>?,
               weightedKeywords: [WeightedKeyword] = [],
               swift6Readiness: Swift6Readiness?,
-              forkedFromInfo: ForkedFromInfo?) {
+              forkedFromInfo: ForkedFromInfo?,
+              customCollections: [CustomCollection.Details]) {
             // we consider certain attributes as essential and return nil (raising .notFound)
             let repository = result.repository
             guard
@@ -182,7 +186,8 @@ extension API.PackageController.GetRoute {
                 preReleaseReference: result.preReleaseVersion?.reference,
                 fundingLinks: result.repository.fundingLinks,
                 swift6Readiness: swift6Readiness,
-                forkedFromInfo: forkedFromInfo
+                forkedFromInfo: forkedFromInfo,
+                customCollections: customCollections
             )
 
         }

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute.swift
@@ -47,7 +47,7 @@ extension API.PackageController {
                                                                         repository: repository)
             async let forkedFromInfo = forkedFromInfo(on: database, fork: packageResult.repository.forkedFrom)
 
-            let customCollections = await customCollections(on: database, package: packageResult.package)
+            async let customCollections = customCollections(on: database, package: packageResult.package)
 
             guard
                 let model = try await Self.Model(

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute.swift
@@ -47,6 +47,8 @@ extension API.PackageController {
                                                                         repository: repository)
             async let forkedFromInfo = forkedFromInfo(on: database, fork: packageResult.repository.forkedFrom)
 
+            let customCollections = await customCollections(on: database, package: packageResult.package)
+
             guard
                 let model = try await Self.Model(
                     result: packageResult,
@@ -57,7 +59,8 @@ extension API.PackageController {
                     platformBuildInfo: buildInfo.platform,
                     weightedKeywords: weightedKeywords,
                     swift6Readiness: buildInfo.swift6Readiness,
-                    forkedFromInfo: forkedFromInfo
+                    forkedFromInfo: forkedFromInfo,
+                    customCollections: customCollections
                 ),
                 let schema = API.PackageSchema(result: packageResult)
             else {
@@ -94,6 +97,15 @@ extension API.PackageController.GetRoute {
                 return await Model.ForkedFromInfo.query(on: database, packageId: id, fallbackURL: fallbackURL)
             case let .parentURL(url):
                 return .fromGitHub(url: url)
+        }
+    }
+
+    static func customCollections(on database: Database, package: Package) async -> [CustomCollection.Details] {
+        do {
+            try await package.$customCollections.load(on: database)
+            return package.customCollections.map(\.details)
+        } catch {
+            return []
         }
     }
 }

--- a/Sources/App/Controllers/API/API+PackageController+GetRoute.swift
+++ b/Sources/App/Controllers/API/API+PackageController+GetRoute.swift
@@ -101,6 +101,7 @@ extension API.PackageController.GetRoute {
     }
 
     static func customCollections(on database: Database, package: Package) async -> [CustomCollection.Details] {
+        guard Current.environment() == .development else { return [] }
         do {
             try await package.$customCollections.load(on: database)
             return package.customCollections.map(\.details)

--- a/Sources/App/Controllers/API/Types+WithExample.swift
+++ b/Sources/App/Controllers/API/Types+WithExample.swift
@@ -248,7 +248,8 @@ extension API.PackageController.GetRoute.Model: WithExample {
               releaseReference: .tag(1, 2, 3, "1.2.3"),
               preReleaseReference: nil,
               swift6Readiness: nil, 
-              forkedFromInfo: nil)
+              forkedFromInfo: nil,
+              customCollections: [])
     }
 }
 

--- a/Sources/App/Core/Dependencies/PackageListRepositoryClient.swift
+++ b/Sources/App/Core/Dependencies/PackageListRepositoryClient.swift
@@ -22,7 +22,7 @@ struct PackageListRepositoryClient {
     var fetchPackageList: @Sendable (_ client: Client) async throws -> [URL]
     var fetchPackageDenyList: @Sendable (_ client: Client) async throws -> [URL]
     var fetchCustomCollection: @Sendable (_ client: Client, _ url: URL) async throws -> [URL]
-    var fetchCustomCollections: @Sendable (_ client: Client) async throws -> [CustomCollection.DTO]
+    var fetchCustomCollections: @Sendable (_ client: Client) async throws -> [CustomCollection.Details]
 }
 
 
@@ -62,7 +62,7 @@ extension PackageListRepositoryClient: DependencyKey {
                 try await client
                     .get(Constants.customCollectionsUri)
                     .content
-                    .decode([CustomCollection.DTO].self, using: JSONDecoder())
+                    .decode([CustomCollection.Details].self, using: JSONDecoder())
             }
         )
     }

--- a/Sources/App/Models/CustomCollection.swift
+++ b/Sources/App/Models/CustomCollection.swift
@@ -47,7 +47,8 @@ final class CustomCollection: @unchecked Sendable, Model, Content {
     @Field(key: "url")
     var url: URL
 
-    // reference fields
+    // relationships
+
     @Siblings(through: CustomCollectionPackage.self, from: \.$customCollection, to: \.$package)
     var packages: [Package]
 

--- a/Sources/App/Models/CustomCollection.swift
+++ b/Sources/App/Models/CustomCollection.swift
@@ -67,7 +67,7 @@ final class CustomCollection: @unchecked Sendable, Model, Content {
 
 
 extension CustomCollection {
-    struct Details: Codable {
+    struct Details: Codable, Equatable {
         var name: String
         var description: String?
         var badge: String?
@@ -98,6 +98,10 @@ extension CustomCollection {
         try await $packages.attach(incoming[newIDs], on: database)
         let removedIDs = Set(existing.keys).subtracting(Set(incoming.keys))
         try await $packages.detach(existing[removedIDs], on: database)
+    }
+
+    var details: Details {
+        .init(name: name, description: description, badge: badge, url: url)
     }
 }
 

--- a/Sources/App/Models/CustomCollection.swift
+++ b/Sources/App/Models/CustomCollection.swift
@@ -54,33 +54,33 @@ final class CustomCollection: @unchecked Sendable, Model, Content {
 
     init() { }
 
-    init(id: Id? = nil, createdAt: Date? = nil, updatedAt: Date? = nil, _ dto: DTO) {
+    init(id: Id? = nil, createdAt: Date? = nil, updatedAt: Date? = nil, _ details: Details) {
         self.id = id
         self.createdAt = createdAt
         self.updatedAt = updatedAt
-        self.name = dto.name
-        self.description = dto.description
-        self.badge = dto.badge
-        self.url = dto.url
+        self.name = details.name
+        self.description = details.description
+        self.badge = details.badge
+        self.url = details.url
     }
 }
 
 
 extension CustomCollection {
-    struct DTO: Codable {
+    struct Details: Codable {
         var name: String
         var description: String?
         var badge: String?
         var url: URL
     }
 
-    static func findOrCreate(on database: Database, _ dto: DTO) async throws -> CustomCollection {
+    static func findOrCreate(on database: Database, _ details: Details) async throws -> CustomCollection {
         if let collection = try await CustomCollection.query(on: database)
-            .filter(\.$url == dto.url)
+            .filter(\.$url == details.url)
             .first() {
             return collection
         } else {
-            let collection = CustomCollection(dto)
+            let collection = CustomCollection(details)
             try await collection.save(on: database)
             return collection
         }

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -57,6 +57,9 @@ final class Package: @unchecked Sendable, Model, Content {
 
     // relationships
 
+    @Siblings(through: CustomCollectionPackage.self, from: \.$package, to: \.$customCollection)
+    var customCollections: [CustomCollection]
+
     @Children(for: \.$package)
     var repositories: [Repository]
 

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -399,13 +399,10 @@ extension API.PackageController.GetRoute.Model {
     }
 
     func customCollectionsItem() -> Node<HTML.ListContext> {
-        let collections: [CustomCollection.Details] = [
-            .init(name: "Collection 1", url: URL(string: "https://github.com/foo/bar/list1.json")!),
-            .init(name: "Collection 2", url: URL(string: "https://github.com/foo/bar/list2.json")!)
-        ]
+        guard !customCollections.isEmpty else { return .empty }
         return .li(
             .class("custom-collections"),
-            .forEach(collections, { collection in
+            .forEach(customCollections, { collection in
                     .a(
                         .href(collection.url),  // FIXME: link to custom collection page
                         .text("\(collection.name)")

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -399,8 +399,10 @@ extension API.PackageController.GetRoute.Model {
     }
 
     func customCollectionsItem() -> Node<HTML.ListContext> {
-        let collections: [CustomCollection] = [.init(.init(name: "Collection 1", url: URL(string: "https://github.com/foo/bar/list1.json")!)),
-                                               .init(.init(name: "Collection 2", url: URL(string: "https://github.com/foo/bar/list2.json")!))]
+        let collections: [CustomCollection.Details] = [
+            .init(name: "Collection 1", url: URL(string: "https://github.com/foo/bar/list1.json")!),
+            .init(name: "Collection 2", url: URL(string: "https://github.com/foo/bar/list2.json")!)
+        ]
         return .li(
             .class("custom-collections"),
             .forEach(collections, { collection in

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -398,6 +398,20 @@ extension API.PackageController.GetRoute.Model {
         }
     }
 
+    func customCollectionsItem() -> Node<HTML.ListContext> {
+        let collections: [CustomCollection] = [.init(.init(name: "Collection 1", url: URL(string: "https://github.com/foo/bar/list1.json")!)),
+                                               .init(.init(name: "Collection 2", url: URL(string: "https://github.com/foo/bar/list2.json")!))]
+        return .li(
+            .class("custom-collections"),
+            .forEach(collections, { collection in
+                    .a(
+                        .href(collection.url),  // FIXME: link to custom collection page
+                        .text("\(collection.name)")
+                    )
+            })
+        )
+    }
+
     func latestReleaseMetadata() -> Node<HTML.ListContext> {
         guard let dateLink = releases.stable else { return .empty }
         return releaseMetadata(dateLink, title: "Latest Release", cssClass: "stable")

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -180,7 +180,8 @@ extension PackageShow {
                     model.productTypeListItem(.plugin),
                     model.targetTypeListItem(.macro),
                     model.dataRaceSafeListItem(),
-                    model.keywordsListItem()
+                    model.keywordsListItem(),
+                    model.customCollectionsItem()
                 )
             )
         }

--- a/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
+++ b/Tests/AppTests/API+PackageController+GetRoute+ModelTests.swift
@@ -43,7 +43,8 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                      platformBuildInfo: nil,
                                                      weightedKeywords: [],
                                                      swift6Readiness: nil,
-                                                     forkedFromInfo: nil)
+                                                     forkedFromInfo: nil,
+                                                     customCollections: [])
 
         // validate
         XCTAssertNotNil(m)
@@ -66,7 +67,8 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                                        platformBuildInfo: nil,
                                                                        weightedKeywords: [],
                                                                        swift6Readiness: nil,
-                                                                       forkedFromInfo: nil))
+                                                                       forkedFromInfo: nil,
+                                                                       customCollections: []))
 
         // validate
         XCTAssertEqual(model.packageIdentity, "swift-bar")
@@ -89,7 +91,8 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                                        platformBuildInfo: nil,
                                                                        weightedKeywords: [],
                                                                        swift6Readiness: nil,
-                                                                       forkedFromInfo: nil))
+                                                                       forkedFromInfo: nil,
+                                                                       customCollections: []))
 
         // validate
         XCTAssertEqual(model.documentationTarget, .internal(docVersion: .reference("main"), archive: "archive1"))
@@ -116,7 +119,8 @@ class API_PackageController_GetRoute_ModelTests: SnapshotTestCase {
                                                                        platformBuildInfo: nil,
                                                                        weightedKeywords: [],
                                                                        swift6Readiness: nil,
-                                                                       forkedFromInfo: nil))
+                                                                       forkedFromInfo: nil,
+                                                                       customCollections: []))
 
         // validate
         XCTAssertEqual(model.documentationTarget, .external(url: "https://example.com/package/documentation"))

--- a/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
+++ b/Tests/AppTests/Mocks/API.PackageController.GetRoute.Model+mock.swift
@@ -129,7 +129,8 @@ extension API.PackageController.GetRoute.Model {
             releaseReference: .tag(5, 2, 0),
             preReleaseReference: .tag(5, 3, 0, "beta.1"),
             swift6Readiness: nil,
-            forkedFromInfo: nil
+            forkedFromInfo: nil,
+            customCollections: []
         )
     }
 }

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -282,6 +282,15 @@ class WebpageSnapshotTests: SnapshotTestCase {
         assertSnapshot(of: page, as: .html)
     }
 
+    func test_PackageShowView_customCollection() throws {
+        var model = API.PackageController.GetRoute.Model.mock
+        model.homepageUrl = "https://swiftpackageindex.com/"
+        model.customCollections = [.init(name: "Custom Collection", url: "https://github.com/foo/bar/list.json")]
+        let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
+
+        assertSnapshot(of: page, as: .html)
+    }
+
     func test_PackageReleasesView() throws {
         let model = PackageReleases.Model.mock
         let page = { PackageReleases.View(model: model).document() }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_customCollection.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_customCollection.1.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="en"><!--Version: test--><!--DB Id: db-id-->
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="UTF-8"/>
+    <meta property="og:site_name" content="The Swift Package Index"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <title>Alamofire &ndash; Swift Package Index</title>
+    <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
+    <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>
+    <meta name="description" content="Alamofire by Alamofire on the Swift Package Index – Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. V…"/>
+    <meta name="twitter:description" content="Alamofire by Alamofire on the Swift Package Index – Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. V…"/>
+    <meta property="og:description" content="Alamofire by Alamofire on the Swift Package Index – Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. V…"/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:image" content="http://localhost:8080/images/logo.png"/>
+    <meta property="og:image" content="http://localhost:8080/images/logo.png"/>
+    <link rel="shortcut icon" href="/images/logo-tiny.png" type="image/png"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index Blog" href="http://localhost:8080/blog/feed.xml"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added Packages" href="http://localhost:8080/packages.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Package Releases" href="http://localhost:8080/releases.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Package Releases" href="http://localhost:8080/releases.rss?major=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Package Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Package Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
+    <link rel="stylesheet" href="/shared.css?test" data-turbolinks-track="reload"/>
+    <link rel="stylesheet" href="/main.css?test" data-turbolinks-track="reload"/>
+    <script src="/shared.js?test" data-turbolinks-track="reload" defer></script>
+    <script src="/main.js?test" data-turbolinks-track="reload" defer></script><script async defer data-domain="swiftpackageindex.com" src="https://plausible.io/js/plausible.outbound-links.js"></script>
+<script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
+  </head>
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
+    <header>
+      <div class="inner">
+        <a href="/">
+          <h1>
+            <img alt="The Swift Package Index logo." src="/images/logo.svg"/>Swift Package Index
+          </h1>
+        </a>
+        <nav>
+          <ul>
+            <li>
+              <a class="supporters" href="/supporters">Supporters</a>
+            </li>
+            <li>
+              <a href="/add-a-package">Add a Package</a>
+            </li>
+            <li>
+              <a href="/blog">Blog</a>
+            </li>
+            <li>
+              <a href="/faq">FAQ</a>
+            </li>
+            <li class="search">
+              <form action="/search">
+                <input id="query" name="query" type="search" placeholder="Search" spellcheck="false" autocomplete="off" data-gramm="false" data-focus="false"/>
+                <button type="submit">
+                  <div title="Search"></div>
+                </button>
+              </form>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <p class="announcement">Track the adoption of Swift 6 strict concurrency checks for data race safety. How many packages are 
+      <a href="/ready-for-swift-6">Ready for Swift 6</a>?
+    </p>
+    <nav class="breadcrumbs">
+      <div class="inner">
+        <ul>
+          <li>
+            <a href="/">
+              <span>Home</span>
+            </a>
+          </li>
+          <li>
+            <a href="/Alamo">
+              <span>Alamofire</span>
+            </a>
+          </li>
+          <li>
+            <span>Alamofire</span>
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <main>
+      <div class="inner">
+        <div class="two-column v-end">
+          <div class="package-title">
+            <h2>Alamofire</h2>
+            <small>
+              <a href="https://github.com/Alamo">Alamo</a>
+              <span>/</span>
+              <a href="https://github.com/Alamo/Alamofire">Alamofire</a>
+            </small>
+          </div>
+          <div data-controller="modal-panel">
+            <button data-modal-panel-target="button" data-action="click->modal-panel#show">Use this Package</button>
+            <section class="use-this-package" data-modal-panel-target="panel">
+              <button class="close" data-action="click->modal-panel#hide">&times;</button>
+              <h4>When working with an Xcode project:</h4>
+              <form class="copyable-input">
+                <input type="text" data-button-name="Copy" data-event-name="Copy Xcodeproj Package URL Button" value="https://github.com/Alamofire/Swift-Alamofire.git" readonly/>
+              </form>
+              <h4>When working with a Swift Package Manager manifest:</h4>
+              <p>Select a package version:</p>
+              <div class="version">
+                <p>
+                  <span class="stable">5.2.0</span>
+                </p>
+                <form class="copyable-input">
+                  <input type="text" data-button-name="Copy" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Swift-Alamofire.git&quot;, from: &quot;5.2.0&quot;)" readonly/>
+                </form>
+              </div>
+              <div class="version">
+                <p>
+                  <span class="beta">5.3.0-beta.1</span>
+                </p>
+                <form class="copyable-input">
+                  <input type="text" data-button-name="Copy" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Swift-Alamofire.git&quot;, from: &quot;5.3.0-beta.1&quot;)" readonly/>
+                </form>
+              </div>
+              <div class="version">
+                <p>
+                  <span class="branch">main</span>
+                </p>
+                <form class="copyable-input">
+                  <input type="text" data-button-name="Copy" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Swift-Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
+                </form>
+              </div>
+              <div data-controller="use-this-package-panel">
+                <p>
+                  <label for="products">Select a product:</label>
+                  <select data-use-this-package-panel-target="select" data-action="input->use-this-package-panel#updateProductSnippet" name="products" id="products">
+                    <option data-package="swift-alamofire" data-product="lib1" data-type="library" value="lib1" label="lib1"/>
+                    <option data-package="swift-alamofire" data-product="lib2" data-type="library" value="lib2" label="lib2"/>
+                    <option data-package="swift-alamofire" data-product="lib3" data-type="library" value="lib3" label="lib3"/>
+                  </select>
+                </p>
+                <form class="copyable-input">
+                  <input type="text" data-use-this-package-panel-target="snippet" data-button-name="Copy" data-event-name="Copy SPM Manifest Product Code Snippet Button" readonly/>
+                </form>
+              </div>
+            </section>
+          </div>
+        </div>
+        <hr class="tight"/>
+        <p class="summary">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. Vivamus vehicula urna eget ipsum laoreet, sed porttitor sapien malesuada. Mauris faucibus tellus at augue vehicula, vitae aliquet felis ullamcorper. Praesent vitae leo rhoncus, egestas elit id, porttitor lacus. Cras ac bibendum mauris. Praesent luctus quis nulla sit amet tempus. Ut pharetra non augue sed pellentesque.</p>
+        <article class="details two-column">
+          <section>
+            <section>
+              <ul class="main-metadata">
+                <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
+                <li class="history">In development for 2 months, with 
+                  <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
+                  <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
+                </li>
+                <li class="activity">There are 
+                  <a href="https://github.com/Alamofire/Alamofire/issues">27 open issues</a> and 
+                  <a href="https://github.com/Alamofire/Alamofire/pulls">5 open pull requests</a>. The last issue was closed 5 days ago and the last pull request was merged/closed 6 days ago.
+                </li>
+                <li class="dependencies">This package depends on 2 other packages.</li>
+                <li class="license"> licensed</li>
+                <li class="stars">17 stars</li>
+                <li class="libraries">3 libraries</li>
+                <li class="executables">1 executable</li>
+                <li class="plugins">No plugins</li>
+                <li class="macros">2 macros</li>
+                <li class="custom-collections">
+                  <a href="https://github.com/foo/bar/list.json">Custom Collection</a>
+                </li>
+              </ul>
+            </section>
+            <hr class="minor"/>
+            <section class="main-compatibility">
+              <div class="title">
+                <h3>Compatibility</h3>
+                <a href="/Alamo/Alamofire/builds">Full Build Results</a>
+              </div>
+              <div class="matrices">
+                <a href="/Alamo/Alamofire/builds">
+                  <ul class="matrix compatibility">
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="stable">5.2.3</span> and 
+                          <span class="branch">main</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>6.0</div>
+                        <div>5.10</div>
+                        <div>5.9</div>
+                        <div>5.8</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="unknown" title="No build information available for Swift 5.10"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.8"></div>
+                      </div>
+                    </li>
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="beta">6.0.0-b1</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>6.0</div>
+                        <div>5.10</div>
+                        <div>5.9</div>
+                        <div>5.8</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                        <div class="incompatible" title="Build failed with Swift 5.8"></div>
+                      </div>
+                    </li>
+                  </ul>
+                </a>
+                <a href="/Alamo/Alamofire/builds">
+                  <ul class="matrix compatibility">
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="stable">5.2.3</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>iOS</div>
+                        <div>macOS</div>
+                        <div>visionOS</div>
+                        <div>watchOS</div>
+                        <div>tvOS</div>
+                        <div>Linux</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with iOS"></div>
+                        <div class="unknown" title="No build information available for macOS"></div>
+                        <div class="unknown" title="No build information available for visionOS"></div>
+                        <div class="unknown" title="No build information available for watchOS"></div>
+                        <div class="unknown" title="No build information available for tvOS"></div>
+                        <div class="unknown" title="No build information available for Linux"></div>
+                      </div>
+                    </li>
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="beta">6.0.0-b1</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>iOS</div>
+                        <div>macOS</div>
+                        <div>visionOS</div>
+                        <div>watchOS</div>
+                        <div>tvOS</div>
+                        <div>Linux</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with iOS"></div>
+                        <div class="compatible" title="Built successfully with macOS"></div>
+                        <div class="compatible" title="Built successfully with visionOS"></div>
+                        <div class="unknown" title="No build information available for watchOS"></div>
+                        <div class="compatible" title="Built successfully with tvOS"></div>
+                        <div class="compatible" title="Built successfully with Linux"></div>
+                      </div>
+                    </li>
+                    <li class="row">
+                      <div class="row-labels">
+                        <p>
+                          <span class="branch">main</span>
+                        </p>
+                      </div>
+                      <div class="column-labels">
+                        <div>iOS</div>
+                        <div>macOS</div>
+                        <div>visionOS</div>
+                        <div>watchOS</div>
+                        <div>tvOS</div>
+                        <div>Linux</div>
+                      </div>
+                      <div class="results">
+                        <div class="compatible" title="Built successfully with iOS"></div>
+                        <div class="compatible" title="Built successfully with macOS"></div>
+                        <div class="compatible" title="Built successfully with visionOS"></div>
+                        <div class="compatible" title="Built successfully with watchOS"></div>
+                        <div class="compatible" title="Built successfully with tvOS"></div>
+                        <div class="compatible" title="Built successfully with Linux"></div>
+                      </div>
+                    </li>
+                  </ul>
+                </a>
+              </div>
+            </section>
+          </section>
+          <section>
+            <section class="sidebar-links">
+              <ul>
+                <li>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                </li>
+                <li class="try-in-playground">
+                  <a href="spi-playgrounds://open?dependencies=Alamo/Alamofire">Try in a Playground</a>
+                  <div id="app-download-explainer" class="hidden">
+                    <strong>Launching the SPI Playgrounds app&hellip;</strong>
+                    <p>If nothing happens, you may not have the app installed. 
+                      <a href="/try-in-a-playground?dependencies=Alamo/Alamofire">Download the Swift Package Index Playgrounds app</a> and try again.
+                    </p>
+                  </div>
+                </li>
+                <li>
+                  <a href="https://swiftpackageindex.com/">Package Homepage</a>
+                </li>
+              </ul>
+            </section>
+            <hr class="minor"/>
+            <section class="sidebar-versions" aria-label="Versions">
+              <ul>
+                <li class="stable">
+                  <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
+                    <span class="stable">5.2.0</span>
+                  </a>
+                  <strong>Latest Release</strong>
+                  <small>Released 12 days ago</small>
+                </li>
+                <li class="beta">
+                  <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
+                    <span class="beta">5.3.0-beta.1</span>
+                  </a>
+                  <strong>Latest Beta Release</strong>
+                  <small>Released 4 days ago</small>
+                </li>
+                <li class="branch">
+                  <a href="https://github.com/Alamofire/Alamofire">
+                    <span class="branch">main</span>
+                  </a>
+                  <strong>Default Branch</strong>
+                  <small>Modified 12 minutes ago</small>
+                </li>
+              </ul>
+            </section>
+            <hr class="minor"/>
+            <section class="sidebar-package-authors">
+              <small>
+                <strong>Do you maintain this package?</strong> Get shields.io compatibility badges and learn how to control our build system. 
+                <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
+              </small>
+            </section>
+          </section>
+        </article>
+        <section data-controller="tab-bar">
+          <nav>
+            <ul class="tab-list">
+              <li id="readme" data-tab-bar-target="tab" data-action="click->tab-bar#updateTab">README</li>
+              <li id="releases" data-tab-bar-target="tab" data-action="click->tab-bar#updateTab">Release Notes</li>
+            </ul>
+          </nav>
+          <section data-tab-bar-target="content">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+              <div>
+                <div class="spinner">
+                  <div class="rect1"></div>
+                  <div class="rect2"></div>
+                  <div class="rect3"></div>
+                  <div class="rect4"></div>
+                  <div class="rect5"></div>
+                </div>
+              </div>
+            </turbo-frame>
+          </section>
+          <section data-tab-bar-target="content">
+            <turbo-frame id="releases_content" src="/Alamo/Alamofire/releases">
+              <div>
+                <div class="spinner">
+                  <div class="rect1"></div>
+                  <div class="rect2"></div>
+                  <div class="rect3"></div>
+                  <div class="rect4"></div>
+                  <div class="rect5"></div>
+                </div>
+              </div>
+            </turbo-frame>
+          </section>
+          <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <time datetime="2001-01-01">Last updated on 1 Jan 2001</time>
+          </p>
+        </section>
+      </div>
+    </main>
+    <footer>
+      <div class="inner">
+        <nav>
+          <ul>
+            <li>
+              <a href="/blog">Blog</a>
+            </li>
+            <li>
+              <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a>
+            </li>
+            <li>
+              <a href="/privacy">Privacy and Cookies</a>
+            </li>
+            <li>
+              <a href="https://swiftpackageindex.statuspage.io">Uptime and System Status</a>
+            </li>
+            <li>
+              <a href="/build-monitor">Build System Monitor</a>
+            </li>
+            <li>
+              <a href="https://mas.to/@SwiftPackageIndex">Mastodon</a>
+            </li>
+          </ul>
+          <small>The Swift Package Index is entirely funded by community sponsorship. Thank you to 
+            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server#funding-and-sponsorship">all our sponsors for their generosity</a>.
+          </small>
+          <small>The Swift Package Index is operated by SPI Operations Limited, a company registered in the UK with company number 13466692.</small>
+          <a rel="me" href="https://mas.to/@SwiftPackageIndex"></a>
+          <a rel="me" href="https://mas.to/@SwiftPackageUpdates"></a>
+        </nav>
+      </div>
+    </footer>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
+    <spi-debug-panel class="hidden">
+      <table>
+        <tbody>
+          <tr server-side>
+            <td>Package ID</td>
+            <td>CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE</td>
+          </tr>
+          <tr server-side>
+            <td>Score</td>
+            <td>10</td>
+          </tr>
+        </tbody>
+      </table>
+    </spi-debug-panel>
+  </body>
+</html>


### PR DESCRIPTION
This wires up a draft UI for displaying custom package collection membership on the package page.

The link currently goes to the source list on Github but I'll address this in a follow-up to link to a page with all packages in this particular custom collection (just like other collections).

![CleanShot 2024-10-25 at 12 10 37@2x](https://github.com/user-attachments/assets/7c951d55-fd7c-4cb5-86cd-fbeb3e0cbce4)
