### PR TITLE
Add overflow-wrap: break-word to code

### DIFF
--- a/FrontEnd/styles/base.scss
+++ b/FrontEnd/styles/base.scss
@@ -83,6 +83,7 @@ pre {
 
 code {
     font-size: 14px;
+    overflow-wrap: break-word;
 }
 
 blockquote {


### PR DESCRIPTION
Currently long `code` goes off the end of the page and results in a horizontal scroll bar, as seen here: https://swiftpackageindex.com/finnvoor/SwiftUIFX

![Arc - SwiftUIFX – Swift Package Index@2x](https://github.com/user-attachments/assets/70a01ec9-fbfd-490c-8fb4-9b2d48eaed17)


This change wraps the code instead, which I think is nicer. Not sure if this is the best place to change it though.

![Arc - SwiftUIFX – Swift Package Index@2x](https://github.com/user-attachments/assets/16601c72-7cdc-4e7e-89af-27b0c2c21573)
