### PR TITLE
Add support for Mermaid charts to README files

### DIFF
--- a/FrontEnd/scripts/controllers/readme_controller.js
+++ b/FrontEnd/scripts/controllers/readme_controller.js
@@ -16,60 +16,44 @@ import { Controller } from '@hotwired/stimulus'
 import mermaid from 'mermaid'
 
 export class ReadmeController extends Controller {
-    onThemeChange(darkMode) {
-        // If `darkMode` isn't passed, get the current value
-        if (darkMode == undefined) {
-            darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches
-            console.log('actually dark mode is', darkMode)
-        }
-
-        // Get all mermaid diagrams
-        const mermaidDivs = document.querySelectorAll('pre[lang="mermaid"]')
-
-        for (const div of Array.from(mermaidDivs)) {
-            // Get the diagram code
-            const json = div.parentElement.parentElement.getAttribute('data-json')
-            if (!json) {
-                continue
-            }
-            const diagramCode = JSON.parse(json).data
-            if (diagramCode) {
-                try {
-                    // Clear the existing diagram
-                    div.innerHTML = diagramCode
-                    div.removeAttribute('data-processed')
-                } catch (error) {
-                    console.error('Error re-rendering mermaid diagram:', error)
-                }
-            }
-        }
-
-        mermaid.initialize({
-            theme: darkMode ? 'dark' : undefined,
-            nodeSpacing: 50,
-            rankSpacing: 50,
-            curve: 'basis',
-        })
-
-        // Rather then preprocess the HTML in Swift we just change the selector to use `lang` attribute instead of `class`
-        mermaid.run({
-            querySelector: 'pre[lang="mermaid"]',
-        })
+    frameLoaded() {
+        this.navigateToAnchorFromLocation()
+        this.renderMermaidDiagrams()
     }
-    navigateToAnchorFromLocation() {
-        // listen for changes to color scheme
-        if (typeof window !== 'undefined') {
-            const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
 
-            // Add listener for system preference changes
-            mediaQuery.addEventListener('change', (e) => {
-                this.onThemeChange(e.matches)
-            })
+    async renderMermaidDiagrams() {
+        // Replace all Mermaid chart sources with rendered diagrams.
+        const mermaidSectionElements = document.querySelectorAll('section[data-type="mermaid"]')
+        for (const [index, mermaidSectionElement] of Array.from(mermaidSectionElements).entries()) {
+            // No need to parse the JSON, the chart source is in a `data-plain` attribute.
+            const mermaidDataElement = mermaidSectionElement.querySelector('[data-plain]')
+            if (!mermaidDataElement) continue
+            const chartDefinition = mermaidDataElement.getAttribute('data-plain')
+            if (!chartDefinition) continue
+
+            // Make a container with *both* light and dark charts.
+            const chartContainer = document.createElement('div')
+            chartContainer.classList.add('mermaid-chart')
+            mermaidDataElement.appendChild(chartContainer)
+
+            // The documentation says not to call `initialize` more than once, but it is the
+            // only way to switch themes and it's the only way to get this working.
+            mermaid.initialize({ theme: 'default', nodeSpacing: 50, rankSpacing: 50, curve: 'basis' })
+            const lightRenderResult = await mermaid.render(`mermaid-chart-light-${index}`, chartDefinition)
+            chartContainer.insertAdjacentHTML('beforeend', lightRenderResult.svg)
+
+            mermaid.initialize({ theme: 'dark', nodeSpacing: 50, rankSpacing: 50, curve: 'basis' })
+            const darkRenderResult = await mermaid.render(`mermaid-chart-dark-${index}`, chartDefinition)
+            chartContainer.insertAdjacentHTML('beforeend', darkRenderResult.svg)
+
+            // Clean up the superfluous loading element.
+            const loadingElement = mermaidSectionElement.querySelector('.js-render-enrichment-loader')
+            if (!loadingElement) continue
+            loadingElement.remove()
         }
+    }
 
-        // setup mermaid diagrams
-        this.onThemeChange()
-
+    navigateToAnchorFromLocation() {
         // If the browser has an anchor in the URL that may be inside the README then
         // we should attempt to scroll it into view once the README is loaded.
         const hash = window.location.hash

--- a/FrontEnd/scripts/controllers/readme_controller.js
+++ b/FrontEnd/scripts/controllers/readme_controller.js
@@ -16,55 +16,60 @@ import { Controller } from '@hotwired/stimulus'
 import mermaid from 'mermaid'
 
 export class ReadmeController extends Controller {
-    notifyObservers(darkMode) {
-              console.log("dark mode is", darkMode)
+    onThemeChange(darkMode) {
+        // If `darkMode` isn't passed, get the current value
         if (darkMode == undefined) {
             darkMode = window.matchMedia('(prefers-color-scheme: dark)').matches
-            console.log("actually dark mode is", darkMode)
+            console.log('actually dark mode is', darkMode)
         }
-        
+
         // Get all mermaid diagrams
-    const mermaidDivs = document.querySelectorAll('pre[lang="mermaid"]');
+        const mermaidDivs = document.querySelectorAll('pre[lang="mermaid"]')
 
-    console.log("mermaidDivs", mermaidDivs.length)
-    // Re-render each diagram
-    for (const div of Array.from(mermaidDivs)) {
-      const json = div.parentElement.parentElement.getAttribute('data-json');
-      if (!json) {
-        continue
-      }
-      const diagramContent = JSON.parse(json).data;
-      if (diagramContent) {
-        try {
-          // Clear the existing diagram
-          div.innerHTML = diagramContent;
-          div.removeAttribute('data-processed')
-        } catch (error) {
-          console.error('Error re-rendering mermaid diagram:', error);
+        for (const div of Array.from(mermaidDivs)) {
+            // Get the diagram code
+            const json = div.parentElement.parentElement.getAttribute('data-json')
+            if (!json) {
+                continue
+            }
+            const diagramCode = JSON.parse(json).data
+            if (diagramCode) {
+                try {
+                    // Clear the existing diagram
+                    div.innerHTML = diagramCode
+                    div.removeAttribute('data-processed')
+                } catch (error) {
+                    console.error('Error re-rendering mermaid diagram:', error)
+                }
+            }
         }
-      }
-    }
 
-    mermaid.initialize({
-        theme: darkMode ? 'dark' : undefined,
-         'nodeSpacing': 50, 'rankSpacing': 50, 'curve': 'basis'
-    })
+        mermaid.initialize({
+            theme: darkMode ? 'dark' : undefined,
+            nodeSpacing: 50,
+            rankSpacing: 50,
+            curve: 'basis',
+        })
+
+        // Rather then preprocess the HTML in Swift we just change the selector to use `lang` attribute instead of `class`
         mermaid.run({
             querySelector: 'pre[lang="mermaid"]',
-        });
+        })
     }
     navigateToAnchorFromLocation() {
+        // listen for changes to color scheme
         if (typeof window !== 'undefined') {
-            const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-            
+            const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
             // Add listener for system preference changes
             mediaQuery.addEventListener('change', (e) => {
-                console.log("dark mode changed")
-              this.notifyObservers(e.matches);
-            });
-          }
-       this.notifyObservers();
-        console.log("Mermaid initialized")
+                this.onThemeChange(e.matches)
+            })
+        }
+
+        // setup mermaid diagrams
+        this.onThemeChange()
+
         // If the browser has an anchor in the URL that may be inside the README then
         // we should attempt to scroll it into view once the README is loaded.
         const hash = window.location.hash
@@ -72,6 +77,5 @@ export class ReadmeController extends Controller {
 
         const hashElement = this.element.querySelector(hash)
         if (hashElement) hashElement.scrollIntoView()
-
     }
 }

--- a/FrontEnd/scripts/controllers/readme_controller.js
+++ b/FrontEnd/scripts/controllers/readme_controller.js
@@ -36,8 +36,8 @@ export class ReadmeController extends Controller {
             chartContainer.classList.add('mermaid-chart')
             mermaidDataElement.appendChild(chartContainer)
 
-            // The documentation says not to call `initialize` more than once, but it is the
-            // only way to switch themes and it's the only way to get this working.
+            // The documentation says not to call `initialize` more than once. That said, it's
+            // the only way to switch themes and therefore the only way to get this working.
             mermaid.initialize({ theme: 'default', nodeSpacing: 50, rankSpacing: 50, curve: 'basis' })
             const lightRenderResult = await mermaid.render(`mermaid-chart-light-${index}`, chartDefinition)
             chartContainer.insertAdjacentHTML('beforeend', lightRenderResult.svg)
@@ -45,11 +45,6 @@ export class ReadmeController extends Controller {
             mermaid.initialize({ theme: 'dark', nodeSpacing: 50, rankSpacing: 50, curve: 'basis' })
             const darkRenderResult = await mermaid.render(`mermaid-chart-dark-${index}`, chartDefinition)
             chartContainer.insertAdjacentHTML('beforeend', darkRenderResult.svg)
-
-            // Clean up the superfluous loading element.
-            const loadingElement = mermaidSectionElement.querySelector('.js-render-enrichment-loader')
-            if (!loadingElement) continue
-            loadingElement.remove()
         }
     }
 

--- a/FrontEnd/styles/readme.scss
+++ b/FrontEnd/styles/readme.scss
@@ -138,6 +138,30 @@
     .markdown-alert-caution {
         color: var(--mid-red);
     }
+
+    .mermaid-chart {
+        display: flex;
+        justify-content: center;
+        padding: 30px 0;
+    }
+
+    section[data-type='mermaid'] {
+        pre {
+            display: none;
+        }
+
+        @media (prefers-color-scheme: light) {
+            [id^='mermaid-chart-dark'] {
+                display: none;
+            }
+        }
+
+        @media (prefers-color-scheme: dark) {
+            [id^='mermaid-chart-light'] {
+                display: none;
+            }
+        }
+    }
 }
 
 g-emoji {

--- a/FrontEnd/styles/readme.scss
+++ b/FrontEnd/styles/readme.scss
@@ -146,7 +146,8 @@
     }
 
     section[data-type='mermaid'] {
-        pre {
+        pre,
+        .js-render-enrichment-loader {
             display: none;
         }
 

--- a/Makefile
+++ b/Makefile
@@ -95,10 +95,7 @@ analyze:
 db-up: db-up-dev db-up-test
 
 db-up-dev:
-	docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 \
-	-e PGDATA=/pgdata \
-	--tmpfs /pgdata:rw,noexec,nosuid,size=1024m \
-	-d postgres:16-alpine
+	docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 -d postgres:16-alpine
 
 # Keep test db on postgres:13 for now, to make local testing faster. See
 # https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3360#issuecomment-2331103211

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,10 @@ analyze:
 db-up: db-up-dev db-up-test
 
 db-up-dev:
-	docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 -d postgres:16-alpine
+	docker run --name spi_dev -e POSTGRES_DB=spi_dev -e POSTGRES_USER=spi_dev -e POSTGRES_PASSWORD=xxx -p 6432:5432 \
+	-e PGDATA=/pgdata \
+	--tmpfs /pgdata:rw,noexec,nosuid,size=1024m \
+	-d postgres:16-alpine
 
 # Keep test db on postgres:13 for now, to make local testing faster. See
 # https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3360#issuecomment-2331103211

--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -327,7 +327,7 @@ extension PackageShow {
                                         .value(model.repositoryName),
                                         .readme).relativeURL(),
                 .data(named: "controller", value: "readme"),
-                .data(named: "action", value: "turbo:frame-load->readme#navigateToAnchorFromLocation"),
+                .data(named: "action", value: "turbo:frame-load->readme#frameLoaded"),
                 .div(.spinner())
             )
         }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -359,7 +359,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_app_store_incompatible_license.1.html
@@ -359,7 +359,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -363,7 +363,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_canonicalURL_noImageSnapshots.1.html
@@ -356,7 +356,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/owner/repo/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/owner/repo/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_customCollection.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_customCollection.1.html
@@ -362,7 +362,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_emoji_summary.1.html
@@ -356,7 +356,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_few_keywords.1.html
@@ -387,7 +387,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_many_keywords.1.html
@@ -562,7 +562,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_authors_activity.1.html
@@ -351,7 +351,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_builds.1.html
@@ -242,7 +242,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_no_license.1.html
@@ -359,7 +359,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_open_source_license.1.html
@@ -358,7 +358,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_other_license.1.html
@@ -359,7 +359,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_single_row_tables.1.html
@@ -294,7 +294,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_withPackageFundingLinks.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_withPackageFundingLinks.1.html
@@ -364,7 +364,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_with_documentation_link.1.html
@@ -359,7 +359,7 @@
             </ul>
           </nav>
           <section data-tab-bar-target="content">
-            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#navigateToAnchorFromLocation">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
               <div>
                 <div class="spinner">
                   <div class="rect1"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
                 "@hotwired/stimulus": "^3.2.1",
                 "@hotwired/turbo": "^7.3.0",
                 "highlight.js": "^11.10.0",
+                "mermaid": "^11.3.0",
                 "normalize.css": "^8.0.1",
                 "vega": "^5.30.0",
                 "vega-tooltip": "^0.35.1"
@@ -23,6 +24,26 @@
                 "stylelint-config-standard-scss": "^13.1.0",
                 "stylelint-order": "^6.0.4",
                 "stylelint-scss": "^6.8.1"
+            }
+        },
+        "node_modules/@antfu/install-pkg": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-0.4.1.tgz",
+            "integrity": "sha512-T7yB5QNG29afhWVkVq7XeIMBa5U/vs9mX69YqayXypPRmYzUmzwnYltplHmPtZ4HPCn+sQKeXW8I47wCbuBOjw==",
+            "dependencies": {
+                "package-manager-detector": "^0.2.0",
+                "tinyexec": "^0.3.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@antfu/utils": {
+            "version": "0.7.10",
+            "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.10.tgz",
+            "integrity": "sha512-+562v9k4aI80m1+VuMHehNJWLOFjBnXn3tdOitzD0il5b7smkSBal4+a3oKiQTbrwMmN/TBUMDvbdoWDehgOww==",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -58,11 +79,50 @@
                 "node": ">=6.9.0"
             }
         },
+        "node_modules/@braintree/sanitize-url": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.0.tgz",
+            "integrity": "sha512-o+UlMLt49RvtCASlOMW0AkHnabN9wR9rwCCherxO0yG4Npy34GkvrAqdXQvrhNs+jh+gkK8gB8Lf05qL/O7KWg=="
+        },
         "node_modules/@bufbuild/protobuf": {
             "version": "1.7.2",
             "dev": true,
             "license": "(Apache-2.0 AND BSD-3-Clause)",
             "peer": true
+        },
+        "node_modules/@chevrotain/cst-dts-gen": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+            "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+            "dependencies": {
+                "@chevrotain/gast": "11.0.3",
+                "@chevrotain/types": "11.0.3",
+                "lodash-es": "4.17.21"
+            }
+        },
+        "node_modules/@chevrotain/gast": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+            "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+            "dependencies": {
+                "@chevrotain/types": "11.0.3",
+                "lodash-es": "4.17.21"
+            }
+        },
+        "node_modules/@chevrotain/regexp-to-ast": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
+            "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA=="
+        },
+        "node_modules/@chevrotain/types": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+            "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ=="
+        },
+        "node_modules/@chevrotain/utils": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+            "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ=="
         },
         "node_modules/@csstools/css-parser-algorithms": {
             "version": "3.0.1",
@@ -555,6 +615,33 @@
                 "node": ">= 14"
             }
         },
+        "node_modules/@iconify/types": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+            "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg=="
+        },
+        "node_modules/@iconify/utils": {
+            "version": "2.1.33",
+            "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-2.1.33.tgz",
+            "integrity": "sha512-jP9h6v/g0BIZx0p7XGJJVtkVnydtbgTgt9mVNcGDYwaa7UhdHdI9dvoq+gKj9sijMSJKxUPEG2JyjsgXjxL7Kw==",
+            "dependencies": {
+                "@antfu/install-pkg": "^0.4.0",
+                "@antfu/utils": "^0.7.10",
+                "@iconify/types": "^2.0.0",
+                "debug": "^4.3.6",
+                "kolorist": "^1.8.0",
+                "local-pkg": "^0.5.0",
+                "mlly": "^1.7.1"
+            }
+        },
+        "node_modules/@mermaid-js/parser": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-0.3.0.tgz",
+            "integrity": "sha512-HsvL6zgE5sUPGgkIDlmAWR1HTNHz2Iy11BAWPTa4Jjabkpguy4Ze2gzfLrg6pdRuBvFwgUYyxiaNqZwrEEXepA==",
+            "dependencies": {
+                "langium": "3.0.0"
+            }
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "dev": true,
@@ -608,6 +695,17 @@
             "version": "7946.0.4",
             "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.4.tgz",
             "integrity": "sha512-MHmwBtCb7OCv1DSivz2UNJXPGU/1btAWRKlqJ2saEhVJkpkvqHMMaOpKg0v4sAbDWSQekHGvPVMM8nQ+Jen03Q=="
+        },
+        "node_modules/acorn": {
+            "version": "8.13.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.13.0.tgz",
+            "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
         },
         "node_modules/ajv": {
             "version": "8.12.0",
@@ -768,6 +866,30 @@
                 "node": ">=4"
             }
         },
+        "node_modules/chevrotain": {
+            "version": "11.0.3",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+            "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+            "dependencies": {
+                "@chevrotain/cst-dts-gen": "11.0.3",
+                "@chevrotain/gast": "11.0.3",
+                "@chevrotain/regexp-to-ast": "11.0.3",
+                "@chevrotain/types": "11.0.3",
+                "@chevrotain/utils": "11.0.3",
+                "lodash-es": "4.17.21"
+            }
+        },
+        "node_modules/chevrotain-allstar": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+            "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+            "dependencies": {
+                "lodash-es": "^4.17.21"
+            },
+            "peerDependencies": {
+                "chevrotain": "^11.0.0"
+            }
+        },
         "node_modules/chokidar": {
             "version": "3.6.0",
             "dev": true,
@@ -818,6 +940,19 @@
             "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
             "engines": {
                 "node": ">= 10"
+            }
+        },
+        "node_modules/confbox": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="
+        },
+        "node_modules/cose-base": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+            "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+            "dependencies": {
+                "layout-base": "^1.0.0"
             }
         },
         "node_modules/cosmiconfig": {
@@ -884,6 +1019,89 @@
                 "node": ">=4"
             }
         },
+        "node_modules/cytoscape": {
+            "version": "3.30.3",
+            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.30.3.tgz",
+            "integrity": "sha512-HncJ9gGJbVtw7YXtIs3+6YAFSSiKsom0amWc33Z7QbylbY2JGMrA0yz4EwrdTScZxnwclXeEZHzO5pxoy0ZE4g==",
+            "engines": {
+                "node": ">=0.10"
+            }
+        },
+        "node_modules/cytoscape-cose-bilkent": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+            "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+            "dependencies": {
+                "cose-base": "^1.0.0"
+            },
+            "peerDependencies": {
+                "cytoscape": "^3.2.0"
+            }
+        },
+        "node_modules/cytoscape-fcose": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+            "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+            "dependencies": {
+                "cose-base": "^2.2.0"
+            },
+            "peerDependencies": {
+                "cytoscape": "^3.2.0"
+            }
+        },
+        "node_modules/cytoscape-fcose/node_modules/cose-base": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+            "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+            "dependencies": {
+                "layout-base": "^2.0.0"
+            }
+        },
+        "node_modules/cytoscape-fcose/node_modules/layout-base": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+            "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg=="
+        },
+        "node_modules/d3": {
+            "version": "7.9.0",
+            "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+            "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+            "dependencies": {
+                "d3-array": "3",
+                "d3-axis": "3",
+                "d3-brush": "3",
+                "d3-chord": "3",
+                "d3-color": "3",
+                "d3-contour": "4",
+                "d3-delaunay": "6",
+                "d3-dispatch": "3",
+                "d3-drag": "3",
+                "d3-dsv": "3",
+                "d3-ease": "3",
+                "d3-fetch": "3",
+                "d3-force": "3",
+                "d3-format": "3",
+                "d3-geo": "3",
+                "d3-hierarchy": "3",
+                "d3-interpolate": "3",
+                "d3-path": "3",
+                "d3-polygon": "3",
+                "d3-quadtree": "3",
+                "d3-random": "3",
+                "d3-scale": "4",
+                "d3-scale-chromatic": "3",
+                "d3-selection": "3",
+                "d3-shape": "3",
+                "d3-time": "3",
+                "d3-time-format": "4",
+                "d3-timer": "3",
+                "d3-transition": "3",
+                "d3-zoom": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/d3-array": {
             "version": "3.2.4",
             "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -895,10 +1113,55 @@
                 "node": ">=12"
             }
         },
+        "node_modules/d3-axis": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+            "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-brush": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+            "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "3",
+                "d3-transition": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-chord": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+            "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+            "dependencies": {
+                "d3-path": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/d3-color": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
             "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-contour": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+            "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+            "dependencies": {
+                "d3-array": "^3.2.0"
+            },
             "engines": {
                 "node": ">=12"
             }
@@ -922,6 +1185,18 @@
                 "node": ">=12"
             }
         },
+        "node_modules/d3-drag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-selection": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/d3-dsv": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
@@ -941,6 +1216,25 @@
                 "json2tsv": "bin/json2dsv.js",
                 "tsv2csv": "bin/dsv2dsv.js",
                 "tsv2json": "bin/dsv2json.js"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-fetch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+            "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+            "dependencies": {
+                "d3-dsv": "1 - 3"
             },
             "engines": {
                 "node": ">=12"
@@ -1025,6 +1319,14 @@
                 "node": ">=12"
             }
         },
+        "node_modules/d3-polygon": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+            "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/d3-quadtree": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
@@ -1032,6 +1334,49 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/d3-random": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+            "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-sankey": {
+            "version": "0.12.3",
+            "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+            "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+            "dependencies": {
+                "d3-array": "1 - 2",
+                "d3-shape": "^1.2.0"
+            }
+        },
+        "node_modules/d3-sankey/node_modules/d3-array": {
+            "version": "2.12.1",
+            "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+            "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+            "dependencies": {
+                "internmap": "^1.0.0"
+            }
+        },
+        "node_modules/d3-sankey/node_modules/d3-path": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+            "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg=="
+        },
+        "node_modules/d3-sankey/node_modules/d3-shape": {
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+            "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+            "dependencies": {
+                "d3-path": "1"
+            }
+        },
+        "node_modules/d3-sankey/node_modules/internmap": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+            "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
         },
         "node_modules/d3-scale": {
             "version": "4.0.2",
@@ -1056,6 +1401,14 @@
                 "d3-color": "1 - 3",
                 "d3-interpolate": "1 - 3"
             },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-selection": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
             "engines": {
                 "node": ">=12"
             }
@@ -1101,11 +1454,57 @@
                 "node": ">=12"
             }
         },
+        "node_modules/d3-transition": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-dispatch": "1 - 3",
+                "d3-ease": "1 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "d3-selection": "2 - 3"
+            }
+        },
+        "node_modules/d3-zoom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "2 - 3",
+                "d3-transition": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/dagre-d3-es": {
+            "version": "7.0.10",
+            "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.10.tgz",
+            "integrity": "sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==",
+            "dependencies": {
+                "d3": "^7.8.2",
+                "lodash-es": "^4.17.21"
+            }
+        },
+        "node_modules/dayjs": {
+            "version": "1.11.13",
+            "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+            "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="
+        },
         "node_modules/debug": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
             "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
-            "dev": true,
             "dependencies": {
                 "ms": "^2.1.3"
             },
@@ -1136,6 +1535,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/dompurify": {
+            "version": "3.1.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
+            "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
         },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
@@ -1379,6 +1783,11 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/hachure-fill": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+            "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "dev": true,
@@ -1595,6 +2004,29 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
+        "node_modules/katex": {
+            "version": "0.16.11",
+            "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.11.tgz",
+            "integrity": "sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==",
+            "funding": [
+                "https://opencollective.com/katex",
+                "https://github.com/sponsors/katex"
+            ],
+            "dependencies": {
+                "commander": "^8.3.0"
+            },
+            "bin": {
+                "katex": "cli.js"
+            }
+        },
+        "node_modules/katex/node_modules/commander": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+            "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -1603,6 +2035,11 @@
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
+        },
+        "node_modules/khroma": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+            "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
         },
         "node_modules/kind-of": {
             "version": "6.0.3",
@@ -1618,16 +2055,72 @@
             "integrity": "sha512-tBECoUqNFbyAY4RrbqsBQqDFpGXAEbdD5QKr8kACx3+rnArmuuR22nKQWKazvp07N9yjTyDZaw/20UIH8tL9DQ==",
             "dev": true
         },
+        "node_modules/kolorist": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.8.0.tgz",
+            "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ=="
+        },
+        "node_modules/langium": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/langium/-/langium-3.0.0.tgz",
+            "integrity": "sha512-+Ez9EoiByeoTu/2BXmEaZ06iPNXM6thWJp02KfBO/raSMyCJ4jw7AkWWa+zBCTm0+Tw1Fj9FOxdqSskyN5nAwg==",
+            "dependencies": {
+                "chevrotain": "~11.0.3",
+                "chevrotain-allstar": "~0.3.0",
+                "vscode-languageserver": "~9.0.1",
+                "vscode-languageserver-textdocument": "~1.0.11",
+                "vscode-uri": "~3.0.8"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            }
+        },
+        "node_modules/layout-base": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+            "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg=="
+        },
         "node_modules/lines-and-columns": {
             "version": "1.2.4",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/local-pkg": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.5.0.tgz",
+            "integrity": "sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==",
+            "dependencies": {
+                "mlly": "^1.4.2",
+                "pkg-types": "^1.0.3"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/lodash-es": {
+            "version": "4.17.21",
+            "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+            "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
         },
         "node_modules/lodash.truncate": {
             "version": "4.4.2",
             "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
             "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
             "dev": true
+        },
+        "node_modules/marked": {
+            "version": "13.0.3",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-13.0.3.tgz",
+            "integrity": "sha512-rqRix3/TWzE9rIoFGIn8JmsVfhiuC8VIQ8IdX5TfzmeBucdY05/0UlzKaw0eVtpcN/OdVFpBk7CjKGo9iHJ/zA==",
+            "bin": {
+                "marked": "bin/marked.js"
+            },
+            "engines": {
+                "node": ">= 18"
+            }
         },
         "node_modules/mathml-tag-names": {
             "version": "2.1.3",
@@ -1663,6 +2156,32 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/mermaid": {
+            "version": "11.3.0",
+            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.3.0.tgz",
+            "integrity": "sha512-fFmf2gRXLtlGzug4wpIGN+rQdZ30M8IZEB1D3eZkXNqC7puhqeURBcD/9tbwXsqBO+A6Nzzo3MSSepmnw5xSeg==",
+            "dependencies": {
+                "@braintree/sanitize-url": "^7.0.1",
+                "@iconify/utils": "^2.1.32",
+                "@mermaid-js/parser": "^0.3.0",
+                "cytoscape": "^3.29.2",
+                "cytoscape-cose-bilkent": "^4.1.0",
+                "cytoscape-fcose": "^2.2.0",
+                "d3": "^7.9.0",
+                "d3-sankey": "^0.12.3",
+                "dagre-d3-es": "7.0.10",
+                "dayjs": "^1.11.10",
+                "dompurify": "^3.0.11 <3.1.7",
+                "katex": "^0.16.9",
+                "khroma": "^2.1.0",
+                "lodash-es": "^4.17.21",
+                "marked": "^13.0.2",
+                "roughjs": "^4.6.6",
+                "stylis": "^4.3.1",
+                "ts-dedent": "^2.2.0",
+                "uuid": "^9.0.1"
+            }
+        },
         "node_modules/micromatch": {
             "version": "4.0.8",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -1676,11 +2195,21 @@
                 "node": ">=8.6"
             }
         },
+        "node_modules/mlly": {
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.7.2.tgz",
+            "integrity": "sha512-tN3dvVHYVz4DhSXinXIk7u9syPYaJvio118uomkovAtWBT+RdbP6Lfh/5Lvo519YMmwBafwlh20IPTXIStscpA==",
+            "dependencies": {
+                "acorn": "^8.12.1",
+                "pathe": "^1.1.2",
+                "pkg-types": "^1.2.0",
+                "ufo": "^1.5.4"
+            }
+        },
         "node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-            "dev": true
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/nanoid": {
             "version": "3.3.7",
@@ -1730,6 +2259,11 @@
             "version": "8.0.1",
             "license": "MIT"
         },
+        "node_modules/package-manager-detector": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.2.tgz",
+            "integrity": "sha512-VgXbyrSNsml4eHWIvxxG/nTL4wgybMTXCV2Un/+yEc3aDKKU6nQBZjbeP3Pl3qm9Qg92X/1ng4ffvCeD/zwHgg=="
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "dev": true,
@@ -1758,6 +2292,11 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/path-data-parser": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+            "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="
+        },
         "node_modules/path-parse": {
             "version": "1.0.7",
             "dev": true,
@@ -1770,6 +2309,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -1786,6 +2330,30 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/pkg-types": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.2.1.tgz",
+            "integrity": "sha512-sQoqa8alT3nHjGuTjuKgOnvjo4cljkufdtLMnO2LBP/wRwuDlo1tkaEdMxCRhyGRPacv/ztlZgDPm2b7FAmEvw==",
+            "dependencies": {
+                "confbox": "^0.1.8",
+                "mlly": "^1.7.2",
+                "pathe": "^1.1.2"
+            }
+        },
+        "node_modules/points-on-curve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+            "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A=="
+        },
+        "node_modules/points-on-path": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+            "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+            "dependencies": {
+                "path-data-parser": "0.1.0",
+                "points-on-curve": "0.2.0"
             }
         },
         "node_modules/postcss": {
@@ -2004,6 +2572,17 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
             "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+        },
+        "node_modules/roughjs": {
+            "version": "4.6.6",
+            "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+            "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+            "dependencies": {
+                "hachure-fill": "^0.5.2",
+                "path-data-parser": "^0.1.0",
+                "points-on-curve": "^0.2.0",
+                "points-on-path": "^0.2.1"
+            }
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
@@ -2411,6 +2990,11 @@
                 "node": ">= 4"
             }
         },
+        "node_modules/stylis": {
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.4.tgz",
+            "integrity": "sha512-osIBl6BGUmSfDkyH2mB7EFvCJntXDrLhKjHTRj/rK6xLH0yuPrHULDRQzKokSOD4VoorhtKpfcfW1GAntu8now=="
+        },
         "node_modules/supports-color": {
             "version": "8.1.1",
             "dev": true,
@@ -2506,6 +3090,11 @@
                 "node": ">=8"
             }
         },
+        "node_modules/tinyexec": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.1.tgz",
+            "integrity": "sha512-WiCJLEECkO18gwqIp6+hJg0//p23HXp4S+gGtAKu3mI2F2/sXC4FvHvXvB0zJVVaTPhx1/tOwdbRsa1sOBIKqQ=="
+        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2541,11 +3130,24 @@
             "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
             "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
         },
+        "node_modules/ts-dedent": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+            "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+            "engines": {
+                "node": ">=6.10"
+            }
+        },
         "node_modules/tslib": {
             "version": "2.6.2",
             "dev": true,
             "license": "0BSD",
             "peer": true
+        },
+        "node_modules/ufo": {
+            "version": "1.5.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.5.4.tgz",
+            "integrity": "sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ=="
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
@@ -2560,6 +3162,18 @@
             "version": "1.0.2",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/uuid": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+            "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
         },
         "node_modules/varint": {
             "version": "6.0.0",
@@ -2921,6 +3535,49 @@
                 "vega-statistics": "^1.9.0",
                 "vega-util": "^1.17.2"
             }
+        },
+        "node_modules/vscode-jsonrpc": {
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+            "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/vscode-languageserver": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+            "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+            "dependencies": {
+                "vscode-languageserver-protocol": "3.17.5"
+            },
+            "bin": {
+                "installServerIntoExtension": "bin/installServerIntoExtension"
+            }
+        },
+        "node_modules/vscode-languageserver-protocol": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+            "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+            "dependencies": {
+                "vscode-jsonrpc": "8.2.0",
+                "vscode-languageserver-types": "3.17.5"
+            }
+        },
+        "node_modules/vscode-languageserver-textdocument": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+            "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA=="
+        },
+        "node_modules/vscode-languageserver-types": {
+            "version": "3.17.5",
+            "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+            "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
+        },
+        "node_modules/vscode-uri": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.8.tgz",
+            "integrity": "sha512-AyFQ0EVmsOZOlAnxoFOGOq1SQDWAB7C6aqMGS23svWAllfOaxbuFvcT8D1i8z3Gyn8fraVeZNNmN6e9bxxXkKw=="
         },
         "node_modules/webidl-conversions": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
         "@hotwired/stimulus": "^3.2.1",
         "@hotwired/turbo": "^7.3.0",
         "highlight.js": "^11.10.0",
+        "mermaid": "^11.3.0",
         "normalize.css": "^8.0.1",
         "vega": "^5.30.0",
         "vega-tooltip": "^0.35.1"


### PR DESCRIPTION
Supercedes #3474

Well, what a rabbit hole this turned out to be!

Thank you so much @leogdion for this contribution, and please don’t take the fact that I completely rewrote it as any slight on your code.

Once I realised what you were doing with removing and then re-populating the `pre` element with the Mermaid source, it didn’t seem like the best approach. I changed things around and now we use `render` on `mermaid` to grab SVG data directly and insert _both_ a light and dark mode chart into a new container.

This has several advantages:

1. No need to run JavaScript when switching between light and dark mode. We can do with CSS just like we do for the rest of the site.
2. We get to style the div as we like. You mentioned on our call this afternoon that you wanted to try and centre the chart which I have now done. It also removes it from the unnecessary `pre` styling with a grey background. I think it looks better this way, and it gives more options for future styling.

The disadvantage is that we now need to render every chart twice. I can’t see that this would be a performance problem, but it’s something to watch out for.

Thank you again. This is a great step forward for README files on SPI!