### PR TITLE
Add fullName (badge + name) model property, update collections page

### DIFF
--- a/Sources/App/Controllers/CustomCollectionsController.swift
+++ b/Sources/App/Controllers/CustomCollectionsController.swift
@@ -73,6 +73,7 @@ enum CustomCollectionsController {
         let model = CustomCollectionShow.Model(
             key: collection.key,
             name: collection.name,
+            badge: collection.badge,
             packages: packageInfo,
             page: query.page,
             hasMoreResults: page.hasMoreResults

--- a/Sources/App/Views/CustomCollection/CustomCollectionShow+Model.swift
+++ b/Sources/App/Views/CustomCollection/CustomCollectionShow+Model.swift
@@ -16,20 +16,31 @@ extension CustomCollectionShow {
     struct Model {
         var key: String
         var name: String
+        var badge: String?
         var packages: [PackageInfo]
         var page: Int
         var hasMoreResults: Bool
 
         internal init(key: String,
                       name: String,
+                      badge: String?,
                       packages: [PackageInfo],
                       page: Int,
                       hasMoreResults: Bool) {
             self.key = key
             self.name = name
+            self.badge = badge
             self.packages = packages
             self.page = page
             self.hasMoreResults = hasMoreResults
+        }
+
+        var fullName: String {
+            if let badge {
+                "\(badge) \(name)"
+            } else {
+                name
+            }
         }
     }
 }

--- a/Sources/App/Views/CustomCollection/CustomCollectionShow+View.swift
+++ b/Sources/App/Views/CustomCollection/CustomCollectionShow+View.swift
@@ -38,7 +38,8 @@ enum CustomCollectionShow {
         override func breadcrumbs() -> [Breadcrumb] {
             [
                 Breadcrumb(title: "Home", url: SiteURL.home.relativeURL()),
-                Breadcrumb(title: model.name)
+                Breadcrumb(title: "Collections"),
+                Breadcrumb(title: model.fullName)
             ]
         }
 
@@ -46,7 +47,7 @@ enum CustomCollectionShow {
             .group(
                 .h2(
                     .class("trimmed"),
-                    .text("\(model.name) package collection")
+                    .text("\(model.fullName) package collection")
                 ),
                 .p(
                     .text("The packages in this collection are part of a custom package collection, "),

--- a/Tests/AppTests/Mocks/CustomCollectionShow+mock.swift
+++ b/Tests/AppTests/Mocks/CustomCollectionShow+mock.swift
@@ -30,6 +30,7 @@ extension CustomCollectionShow.Model {
         ) }
         return .init(key: "custom-collection",
                      name: "Custom Collection",
+                     badge: "BADGE",
                      packages: packages, page: 1,
                      hasMoreResults: false)
     }

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_CustomCollectionShow.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_CustomCollectionShow.1.html
@@ -75,14 +75,17 @@
             </a>
           </li>
           <li>
-            <span>Custom Collection</span>
+            <span>Collections</span>
+          </li>
+          <li>
+            <span>BADGE Custom Collection</span>
           </li>
         </ul>
       </div>
     </nav>
     <main>
       <div class="inner">
-        <h2 class="trimmed">Custom Collection package collection</h2>
+        <h2 class="trimmed">BADGE Custom Collection package collection</h2>
         <p>The packages in this collection are part of a custom package collection, 
           <a href="/package-collections">usable in Xcode or SwiftPM</a>. You can find out more about custom package collections and how to request one in the 
           <a href="/blog/introducing-custom-package-collections">launch blog post</a>.


### PR DESCRIPTION
Update breadcrumb and use `fullName` to join badge with name in collection title:

<img width="740" alt="Screenshot 2024-11-20 at 10 49 33" src="https://github.com/user-attachments/assets/17fc4b6c-c40d-4115-98df-f33e70cd34f1">
