### PR TITLE
Swift 6 tools version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 
 // Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
 //
@@ -112,10 +112,7 @@ let package = Package(
                     ],
                     swiftSettings: swiftSettings)
     ],
-    swiftLanguageVersions: [.v5]
+    swiftLanguageModes: [.v6]
 )
 
-var swiftSettings: [SwiftSetting] { [
-    .enableExperimentalFeature("StrictConcurrency"),
-    .enableUpcomingFeature("StrictConcurrency")
-] }
+var swiftSettings: [SwiftSetting] { [] }

--- a/Tests/AppTests/Util+ext.swift
+++ b/Tests/AppTests/Util+ext.swift
@@ -34,7 +34,7 @@ extension XCTestCase {
     func assertEquals<Root, Value: Equatable>(_ values: [Root],
                                               _ keyPath: KeyPath<Root, Value>,
                                               _ expectations: [Value],
-                                              file: StaticString = #file,
+                                              file: StaticString = #filePath,
                                               line: UInt = #line) {
         XCTAssertEqual(values.map { $0[keyPath: keyPath] },
                        expectations,

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -39,7 +39,7 @@ func fixtureUrl(for fixture: String) -> URL {
 }
 
 
-func fixturesDirectory(path: String = #file) -> URL {
+func fixturesDirectory(path: String = #filePath) -> URL {
     let url = URL(fileURLWithPath: path)
     let testsDir = url.deletingLastPathComponent()
     return testsDir.appendingPathComponent("Fixtures")


### PR DESCRIPTION
We're using three different locking mechanisms at the moment, `ActorIsolated`, `LockIsolated`, and`QueueIsolated`. I want us to use the new standard library `Mutex` instead, which requires macOS 15 and therefore Swift 6 tools version.

This pulls the tools version change ahead of that bigger change.