### PR TITLE
Fix 3527

### DIFF
--- a/Sources/App/Views/PackageController/PackageShow+View.swift
+++ b/Sources/App/Views/PackageController/PackageShow+View.swift
@@ -261,6 +261,7 @@ extension PackageShow {
                         .li(
                             .a(
                                 .href(homepageUrl),
+                                .data(named: "turbo", value: String(false)),
                                 "Package Homepage"
                             )
                         )

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView.1.html
@@ -312,7 +312,7 @@
                   </div>
                 </li>
                 <li>
-                  <a href="https://swiftpackageindex.com/">Package Homepage</a>
+                  <a href="https://swiftpackageindex.com/" data-turbo="false">Package Homepage</a>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_binary_targets.1.html
@@ -316,7 +316,7 @@
                   </div>
                 </li>
                 <li>
-                  <a href="https://swiftpackageindex.com/">Package Homepage</a>
+                  <a href="https://swiftpackageindex.com/" data-turbo="false">Package Homepage</a>
                 </li>
               </ul>
             </section>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_customCollection.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_customCollection.1.html
@@ -315,7 +315,7 @@
                   </div>
                 </li>
                 <li>
-                  <a href="https://swiftpackageindex.com/">Package Homepage</a>
+                  <a href="https://swiftpackageindex.com/" data-turbo="false">Package Homepage</a>
                 </li>
               </ul>
             </section>


### PR DESCRIPTION
Fixes #3527 

This is only a problem in the very small number of cases where the GitHub package homepage is set to an SPI URL. This disables Turbo in those situations so it does not clash with DocC's Vue library, just like we do with the Documentation link. 