### PR TITLE
Gate custom collection links on the Package page to staging

### DIFF
--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -399,6 +399,10 @@ extension API.PackageController.GetRoute.Model {
     }
 
     func customCollectionsListItem() -> Node<HTML.ListContext> {
+        @Dependency(\.environment) var environment
+        guard environment.current() == .development
+        else { return .empty }
+
         guard customCollections.isEmpty == false
         else { return .empty }
 

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_customCollection.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/test_PackageShowView_customCollection.1.html
@@ -162,9 +162,6 @@
                   <a href="https://github.com/Alamofire/Alamofire/pulls">5 open pull requests</a>. The last issue was closed 5 days ago and the last pull request was merged/closed 6 days ago.
                 </li>
                 <li class="dependencies">This package depends on 2 other packages.</li>
-                <li class="custom-collections">Member of the 
-                  <a href="/collections/custom-collection">Custom Collection</a> collection.
-                </li>
                 <li class="license"> licensed</li>
                 <li class="stars">17 stars</li>
                 <li class="libraries">3 libraries</li>


### PR DESCRIPTION
This is only needed until the blog post is also live as there's a link on the custom collection page to it, which will be a broken link until #3538 is merged.

This keeps us deployable over the weekend without drawing too much attention to the custom collection pages.

I'm going to rebase #3538 on top of this now and remove these changes in that PR, so it all goes live together.