### PR TITLE
Issue 3469 dependency transition 13

### DIFF
--- a/Sources/App/Commands/Ingestion.swift
+++ b/Sources/App/Commands/Ingestion.swift
@@ -258,12 +258,13 @@ enum Ingestion {
 
     static func fetchMetadata(client: Client, package: Package, owner: String, repository: String) async throws(Github.Error) -> (Github.Metadata, Github.License?, Github.Readme?) {
         @Dependency(\.environment) var environment
+        @Dependency(\.github) var github
         if environment.shouldFail(failureMode: .fetchMetadataFailed) {
             throw Github.Error.requestFailed(.internalServerError)
         }
 
         async let metadata = try await Current.fetchMetadata(client, owner, repository)
-        async let license = await Current.fetchLicense(client, owner, repository)
+        async let license = await github.fetchLicense(client, owner, repository)
         async let readme = await Current.fetchReadme(client, owner, repository)
 
         do {

--- a/Sources/App/Commands/Ingestion.swift
+++ b/Sources/App/Commands/Ingestion.swift
@@ -264,7 +264,7 @@ enum Ingestion {
         }
 
         async let metadata = try await Current.fetchMetadata(client, owner, repository)
-        async let license = await github.fetchLicense(client, owner, repository)
+        async let license = await github.fetchLicense(owner, repository)
         async let readme = await Current.fetchReadme(client, owner, repository)
 
         do {

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -23,7 +23,6 @@ import FoundationNetworking
 
 
 struct AppEnvironment: Sendable {
-    var fetchLicense: @Sendable (_ client: Client, _ owner: String, _ repository: String) async -> Github.License?
     var fetchMetadata: @Sendable (_ client: Client, _ owner: String, _ repository: String) async throws(Github.Error) -> Github.Metadata
     var fetchReadme: @Sendable (_ client: Client, _ owner: String, _ repository: String) async -> Github.Readme?
     var fetchS3Readme: @Sendable (_ client: Client, _ owner: String, _ repository: String) async throws -> String
@@ -66,7 +65,6 @@ extension AppEnvironment {
     nonisolated(unsafe) static var logger: Logger!
 
     static let live = AppEnvironment(
-        fetchLicense: { client, owner, repo in await Github.fetchLicense(client:client, owner: owner, repository: repo) },
         fetchMetadata: { client, owner, repo throws(Github.Error) in try await Github.fetchMetadata(client:client, owner: owner, repository: repo) },
         fetchReadme: { client, owner, repo in await Github.fetchReadme(client:client, owner: owner, repository: repo) },
         fetchS3Readme: { client, owner, repo in try await S3Readme.fetchReadme(client:client, owner: owner, repository: repo) },

--- a/Sources/App/Core/Dependencies/GithubClient.swift
+++ b/Sources/App/Core/Dependencies/GithubClient.swift
@@ -15,17 +15,22 @@
 
 import Dependencies
 import DependenciesMacros
+#warning("temporary, until we drop Client")
+import protocol Vapor.Client
 
 
 @DependencyClient
 struct GithubClient {
-
+#warning("drop Client parameter")
+    var fetchLicense: @Sendable (_ client: Client, _ owner: String, _ repository: String) async -> Github.License?
 }
 
 
 extension GithubClient: DependencyKey {
     static var liveValue: Self {
-        .init()
+        .init(
+            fetchLicense: { client, owner, repo in await Github.fetchLicense(client:client, owner: owner, repository: repo) }
+        )
     }
 }
 

--- a/Sources/App/Core/Dependencies/GithubClient.swift
+++ b/Sources/App/Core/Dependencies/GithubClient.swift
@@ -15,21 +15,18 @@
 
 import Dependencies
 import DependenciesMacros
-#warning("temporary, until we drop Client")
-import protocol Vapor.Client
 
 
 @DependencyClient
 struct GithubClient {
-#warning("drop Client parameter")
-    var fetchLicense: @Sendable (_ client: Client, _ owner: String, _ repository: String) async -> Github.License?
+    var fetchLicense: @Sendable (_ owner: String, _ repository: String) async -> Github.License?
 }
 
 
 extension GithubClient: DependencyKey {
     static var liveValue: Self {
         .init(
-            fetchLicense: { client, owner, repo in await Github.fetchLicense(client:client, owner: owner, repository: repo) }
+            fetchLicense: { owner, repo in await Github.fetchLicense(owner: owner, repository: repo) }
         )
     }
 }

--- a/Sources/App/Core/Dependencies/GithubClient.swift
+++ b/Sources/App/Core/Dependencies/GithubClient.swift
@@ -1,0 +1,43 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import Dependencies
+import DependenciesMacros
+
+
+@DependencyClient
+struct GithubClient {
+
+}
+
+
+extension GithubClient: DependencyKey {
+    static var liveValue: Self {
+        .init()
+    }
+}
+
+
+extension GithubClient: TestDependencyKey {
+    static var testValue: Self { Self() }
+}
+
+
+extension DependencyValues {
+    var github: GithubClient {
+        get { self[GithubClient.self] }
+        set { self[GithubClient.self] = newValue }
+    }
+}

--- a/Sources/App/Core/Dependencies/HTTPClient.swift
+++ b/Sources/App/Core/Dependencies/HTTPClient.swift
@@ -23,7 +23,9 @@ struct HTTPClient {
     typealias Request = Vapor.HTTPClient.Request
     typealias Response = Vapor.HTTPClient.Response
 
+    var get: @Sendable (_ url: String, _ headers: HTTPHeaders) async throws -> Response
     var post: @Sendable (_ url: String, _ headers: HTTPHeaders, _ body: Data?) async throws -> Response
+
     var fetchDocumentation: @Sendable (_ url: URI) async throws -> Response
     var fetchHTTPStatusCode: @Sendable (_ url: String) async throws -> HTTPStatus
     var mastodonPost: @Sendable (_ message: String) async throws -> Void
@@ -33,6 +35,10 @@ struct HTTPClient {
 extension HTTPClient: DependencyKey {
     static var liveValue: HTTPClient {
         .init(
+            get: { url, headers in
+                let req = try Request(url: url, method: .GET, headers: headers)
+                return try await Vapor.HTTPClient.shared.execute(request: req).get()
+            },
             post: { url, headers, body in
                 let req = try Request(url: url, method: .POST, headers: headers, body: body.map({.data($0)}))
                 return try await Vapor.HTTPClient.shared.execute(request: req).get()

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -175,12 +175,6 @@ extension Github {
         return try decoder.decode(T.self, from: body)
     }
 
-    @available(*, deprecated)
-    static func fetchLicense(client: Client, owner: String, repository: String) async -> License? {
-        let uri = Github.apiUri(owner: owner, repository: repository, resource: .license)
-        return try? await Github.fetchResource(Github.License.self, client: client, uri: uri)
-    }
-
     static func fetchLicense(owner: String, repository: String) async -> License? {
         let url = Github.apiURL(owner: owner, repository: repository, resource: .license)
         return try? await Github.fetchResource(Github.License.self, url: url)

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -108,7 +108,8 @@ extension Github {
                 return "https://api.github.com/repos/\(owner)/\(repository)/\(resource.rawValue)"
         }
     }
-
+    
+    @available(*, deprecated)
     static func fetch(client: Client, uri: URI, headers: [(String, String)] = []) async throws -> (content: String, etag: String?) {
         guard let token = Current.githubToken() else {
             throw Error.missingToken
@@ -170,7 +171,7 @@ extension Github {
 
         guard response.status == .ok else { throw Error.requestFailed(response.status) }
         guard let body = response.body else { throw Github.Error.noBody }
-        
+
         return try decoder.decode(T.self, from: body)
     }
 

--- a/Tests/AppTests/IngestionTests.swift
+++ b/Tests/AppTests/IngestionTests.swift
@@ -36,7 +36,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
-            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+            $0.github.fetchLicense = { @Sendable _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(10))
@@ -66,7 +66,7 @@ class IngestionTests: AppTestCase {
     func test_ingest_continue_on_error() async throws {
         // Test completion of ingestion despite early error
         try await withDependencies {
-            $0.github.fetchLicense = { @Sendable _, _, _ in Github.License(htmlUrl: "license") }
+            $0.github.fetchLicense = { @Sendable _, _ in Github.License(htmlUrl: "license") }
         } operation: {
             // setup
             let packages = try await savePackages(on: app.db, ["https://github.com/foo/1",
@@ -312,7 +312,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
-            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+            $0.github.fetchLicense = { @Sendable _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(testUrls.count))
@@ -340,7 +340,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
-            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+            $0.github.fetchLicense = { @Sendable _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(10))
@@ -393,7 +393,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
-            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+            $0.github.fetchLicense = { @Sendable _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(10))
@@ -461,7 +461,7 @@ class IngestionTests: AppTestCase {
     func test_ingest_storeS3Readme() async throws {
         try await withDependencies {
             $0.date.now = .now
-            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+            $0.github.fetchLicense = { @Sendable _, _ in nil }
         } operation: {
             // setup
             let app = self.app!
@@ -579,7 +579,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
-            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+            $0.github.fetchLicense = { @Sendable _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(1))
@@ -610,7 +610,7 @@ class IngestionTests: AppTestCase {
         do { // first ingestion, no readme has been saved
             try await withDependencies {
                 $0.date.now = .now
-                $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+                $0.github.fetchLicense = { @Sendable _, _ in nil }
             } operation: {
                 // MUT
                 let app = self.app!
@@ -631,7 +631,7 @@ class IngestionTests: AppTestCase {
         // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/761
         try await withDependencies {
             // use live fetch request for fetchLicense, whose behaviour we want to test ...
-            $0.github.fetchLicense = { @Sendable client, owner, repo in await Github.fetchLicense(client: client, owner: owner, repository: repo) }
+            $0.github.fetchLicense = { @Sendable owner, repo in await Github.fetchLicense(owner: owner, repository: repo) }
         } operation: {
             // setup
             let pkg = Package(url: "https://github.com/foo/1")

--- a/Tests/AppTests/IngestionTests.swift
+++ b/Tests/AppTests/IngestionTests.swift
@@ -36,6 +36,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
+            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(10))
@@ -311,6 +312,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
+            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(testUrls.count))
@@ -338,6 +340,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
+            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(10))
@@ -390,6 +393,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
+            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(10))
@@ -457,6 +461,7 @@ class IngestionTests: AppTestCase {
     func test_ingest_storeS3Readme() async throws {
         try await withDependencies {
             $0.date.now = .now
+            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
         } operation: {
             // setup
             let app = self.app!
@@ -574,6 +579,7 @@ class IngestionTests: AppTestCase {
 
         try await withDependencies {
             $0.date.now = .now
+            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
         } operation: {
             // MUT
             try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(1))
@@ -604,6 +610,7 @@ class IngestionTests: AppTestCase {
         do { // first ingestion, no readme has been saved
             try await withDependencies {
                 $0.date.now = .now
+                $0.github.fetchLicense = { @Sendable _, _, _ in nil }
             } operation: {
                 // MUT
                 let app = self.app!

--- a/Tests/AppTests/MastodonTests.swift
+++ b/Tests/AppTests/MastodonTests.swift
@@ -25,7 +25,7 @@ final class MastodonTests: AppTestCase {
         let message = QueueIsolated<String?>(nil)
         try await withDependencies {
             $0.environment.allowSocialPosts = { true }
-            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+            $0.github.fetchLicense = { @Sendable _, _ in nil }
             $0.httpClient.mastodonPost = { @Sendable msg in
                 if message.value == nil {
                     message.setValue(msg)

--- a/Tests/AppTests/MastodonTests.swift
+++ b/Tests/AppTests/MastodonTests.swift
@@ -25,6 +25,7 @@ final class MastodonTests: AppTestCase {
         let message = QueueIsolated<String?>(nil)
         try await withDependencies {
             $0.environment.allowSocialPosts = { true }
+            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
             $0.httpClient.mastodonPost = { @Sendable msg in
                 if message.value == nil {
                     message.setValue(msg)

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -22,7 +22,6 @@ import Vapor
 extension AppEnvironment {
     static func mock(eventLoop: EventLoop) -> Self {
         .init(
-            fetchLicense: { _, _, _ in .init(htmlUrl: "https://github.com/foo/bar/blob/main/LICENSE") },
             fetchMetadata: { _, _, _ in .mock },
             fetchReadme: { _,  _, _ in .init(html: "readme html", htmlUrl: "readme html url", imagesToCache: []) },
             fetchS3Readme: { _, _, _ in "" },

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -311,6 +311,7 @@ final class PackageTests: AppTestCase {
         let url = "1".asGithubUrl
         try await withDependencies {
             $0.date.now = .now
+            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
             $0.packageListRepository.fetchPackageList = { @Sendable _ in [url.url] }
             $0.packageListRepository.fetchPackageDenyList = { @Sendable _ in [] }
             $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -311,7 +311,7 @@ final class PackageTests: AppTestCase {
         let url = "1".asGithubUrl
         try await withDependencies {
             $0.date.now = .now
-            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+            $0.github.fetchLicense = { @Sendable _, _ in nil }
             $0.packageListRepository.fetchPackageList = { @Sendable _ in [url.url] }
             $0.packageListRepository.fetchPackageDenyList = { @Sendable _ in [] }
             $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -161,6 +161,7 @@ class PipelineTests: AppTestCase {
         let urls = ["1", "2", "3"].asGithubUrls
         try await withDependencies {
             $0.date.now = .now
+            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
             $0.packageListRepository.fetchPackageList = { @Sendable _ in urls.asURLs }
             $0.packageListRepository.fetchPackageDenyList = { @Sendable _ in [] }
             $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -161,7 +161,7 @@ class PipelineTests: AppTestCase {
         let urls = ["1", "2", "3"].asGithubUrls
         try await withDependencies {
             $0.date.now = .now
-            $0.github.fetchLicense = { @Sendable _, _, _ in nil }
+            $0.github.fetchLicense = { @Sendable _, _ in nil }
             $0.packageListRepository.fetchPackageList = { @Sendable _ in urls.asURLs }
             $0.packageListRepository.fetchPackageDenyList = { @Sendable _ in [] }
             $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }


### PR DESCRIPTION
This is the first step to move the Github related dependencies into a `GithubClient` `DependencyClient`.

This step moves `fetchLicense` and also drops the `client` parameter from its function call. This trickles through to a few functions in `Github` which now have `client`-free overloads. The outdated versions are marked with deprecation warnings. These will all go away once we've fully transition alle three Github dependency functions over to `GithubClient`.