### PR TITLE
Issue 3469 dependency transition 15

### DIFF
--- a/Sources/App/Commands/Ingestion.swift
+++ b/Sources/App/Commands/Ingestion.swift
@@ -267,10 +267,11 @@ enum Ingestion {
         //   Sending 'github' into async let risks causing data races between async let uses and local uses
         @Dependency(\.github.fetchMetadata) var fetchMetadata
         @Dependency(\.github.fetchLicense) var fetchLicense
+        @Dependency(\.github.fetchReadme) var fetchReadme
 
         async let metadata = try await fetchMetadata(owner, repository)
         async let license = await fetchLicense(owner, repository)
-        async let readme = await Current.fetchReadme(client, owner, repository)
+        async let readme = await fetchReadme(owner, repository)
 
         do {
             return try await (metadata, license, readme)

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -23,7 +23,6 @@ import FoundationNetworking
 
 
 struct AppEnvironment: Sendable {
-    var fetchReadme: @Sendable (_ client: Client, _ owner: String, _ repository: String) async -> Github.Readme?
     var fetchS3Readme: @Sendable (_ client: Client, _ owner: String, _ repository: String) async throws -> String
     var fileManager: FileManager
     var getStatusCount: @Sendable (_ client: Client, _ status: Gitlab.Builder.Status) async throws -> Int
@@ -64,7 +63,6 @@ extension AppEnvironment {
     nonisolated(unsafe) static var logger: Logger!
 
     static let live = AppEnvironment(
-        fetchReadme: { client, owner, repo in await Github.fetchReadme(client:client, owner: owner, repository: repo) },
         fetchS3Readme: { client, owner, repo in try await S3Readme.fetchReadme(client:client, owner: owner, repository: repo) },
         fileManager: .live,
         getStatusCount: { client, status in

--- a/Sources/App/Core/Dependencies/GithubClient.swift
+++ b/Sources/App/Core/Dependencies/GithubClient.swift
@@ -23,6 +23,7 @@ import IssueReporting
 struct GithubClient {
     var fetchLicense: @Sendable (_ owner: String, _ repository: String) async -> Github.License?
     var fetchMetadata: @Sendable (_ owner: String, _ repository: String) async throws(Github.Error) -> Github.Metadata = { _,_ in reportIssue("fetchMetadata"); return .init() }
+    var fetchReadme: @Sendable (_ owner: String, _ repository: String) async -> Github.Readme?
 }
 
 
@@ -30,7 +31,8 @@ extension GithubClient: DependencyKey {
     static var liveValue: Self {
         .init(
             fetchLicense: { owner, repo in await Github.fetchLicense(owner: owner, repository: repo) },
-            fetchMetadata: { owner, repo throws(Github.Error) in try await Github.fetchMetadata(owner: owner, repository: repo) }
+            fetchMetadata: { owner, repo throws(Github.Error) in try await Github.fetchMetadata(owner: owner, repository: repo) },
+            fetchReadme: { owner, repo in await Github.fetchReadme(owner: owner, repository: repo) }
         )
     }
 }
@@ -40,7 +42,8 @@ extension GithubClient: TestDependencyKey {
     static var testValue: Self {
         .init(
             fetchLicense: { _, _ in unimplemented("fetchLicense"); return nil },
-            fetchMetadata: { _, _ in unimplemented("fetchMetadata"); return .init() }
+            fetchMetadata: { _, _ in unimplemented("fetchMetadata"); return .init() },
+            fetchReadme: { _, _ in unimplemented("fetchReadme"); return nil }
         )
     }
 }

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -208,31 +208,6 @@ extension Github {
         return try? await Github.fetchResource(Github.License.self, url: url)
     }
 
-    @available(*, deprecated)
-    static func fetchReadme(client: Client, owner: String, repository: String) async -> Readme? {
-        let uri = Github.apiUri(owner: owner, repository: repository, resource: .readme)
-
-        // Fetch readme html content
-        let readme = try? await Github.fetch(client: client, uri: uri, headers: [
-            ("Accept", "application/vnd.github.html+json")
-        ])
-        guard var html = readme?.content else { return nil }
-
-        // Fetch readme html url
-        let htmlUrl: String? = await {
-            struct Response: Decodable {
-                var htmlUrl: String
-            }
-            return try? await Github.fetchResource(Response.self, client: client, uri: uri).htmlUrl
-        }()
-        guard let htmlUrl else { return nil }
-
-        // Extract and replace images that need caching
-        let imagesToCache = replaceImagesRequiringCaching(owner: owner, repository: repository, readme: &html)
-
-        return .init(etag: readme?.etag, html: html, htmlUrl: htmlUrl, imagesToCache: imagesToCache)
-    }
-
     static func fetchReadme(owner: String, repository: String) async -> Readme? {
         let url = Github.apiURL(owner: owner, repository: repository, resource: .readme)
 

--- a/Sources/App/Core/Github.swift
+++ b/Sources/App/Core/Github.swift
@@ -37,28 +37,12 @@ enum Github {
         return decoder
     }
 
-    @available(*, deprecated)
-    static func rateLimit(response: ClientResponse) -> Int? {
-        guard
-            let header = response.headers.first(name: "X-RateLimit-Remaining"),
-            let limit = Int(header)
-        else { return nil }
-        return limit
-    }
-
     static func rateLimit(response: HTTPClient.Response) -> Int? {
         guard
             let header = response.headers.first(name: "X-RateLimit-Remaining"),
             let limit = Int(header)
         else { return nil }
         return limit
-    }
-
-    @available(*, deprecated)
-    static func isRateLimited(_ response: ClientResponse) -> Bool {
-        guard let limit = rateLimit(response: response) else { return false }
-        AppMetrics.githubRateLimitRemainingCount?.set(limit)
-        return response.status == .forbidden && limit == 0
     }
 
     static func isRateLimited(_ response: HTTPClient.Response) -> Bool {
@@ -95,45 +79,11 @@ extension Github {
         case readme
     }
 
-    @available(*, deprecated)
-    static func apiUri(owner: String, repository: String, resource: Resource)  -> URI {
-        switch resource {
-            case .license, .readme:
-                return URI(string: "https://api.github.com/repos/\(owner)/\(repository)/\(resource.rawValue)")
-        }
-    }
-
     static func apiURL(owner: String, repository: String, resource: Resource)  -> String {
         switch resource {
             case .license, .readme:
                 return "https://api.github.com/repos/\(owner)/\(repository)/\(resource.rawValue)"
         }
-    }
-
-    @available(*, deprecated)
-    static func fetch(client: Client, uri: URI, headers: [(String, String)] = []) async throws -> (content: String, etag: String?) {
-        guard let token = Current.githubToken() else {
-            throw Error.missingToken
-        }
-
-        let response = try await client.get(uri, headers: defaultHeaders(with: token).adding(contentsOf: headers))
-
-        guard !isRateLimited(response) else {
-            Current.logger().critical("rate limited while fetching uri \(uri)")
-            throw Error.requestFailed(.tooManyRequests)
-        }
-
-        guard response.status == .ok else {
-            Current.logger().warning("Github.fetch of '\(uri.path)' failed with status \(response.status)")
-            throw Error.requestFailed(response.status)
-        }
-
-        guard let body = response.body else {
-            Current.logger().warning("Github.fetch has no body")
-            throw Error.noBody
-        }
-
-        return (body.asString(), response.headers.first(name: .eTag))
     }
 
     static func fetch(url: String, headers: [(String, String)] = []) async throws -> (content: String, etag: String?) {
@@ -161,26 +111,6 @@ extension Github {
         }
 
         return (body.asString(), response.headers.first(name: .eTag))
-    }
-
-    @available(*, deprecated)
-    static func fetchResource<T: Decodable>(_ type: T.Type, client: Client, uri: URI) async throws -> T {
-        guard let token = Current.githubToken() else {
-            throw Error.missingToken
-        }
-
-        let response = try await client.get(uri, headers: defaultHeaders(with: token))
-
-        guard !isRateLimited(response) else {
-            Current.logger().critical("rate limited while fetching resource \(uri)")
-            throw Error.requestFailed(.tooManyRequests)
-        }
-
-        guard response.status == .ok else {
-            throw Error.requestFailed(response.status)
-        }
-
-        return try response.content.decode(T.self, using: decoder)
     }
 
     static func fetchResource<T: Decodable>(_ type: T.Type, url: String) async throws -> T {
@@ -239,44 +169,10 @@ extension Github {
 
 extension Github {
 
-    @available(*, deprecated)
-    static let graphQLApiUri = URI(string: "https://api.github.com/graphql")
     static let graphQLApiURL = "https://api.github.com/graphql"
 
     struct GraphQLQuery: Content {
         var query: String
-    }
-
-    @available(*, deprecated)
-    static func fetchResource<T: Decodable>(_ type: T.Type, client: Client, query: GraphQLQuery) async throws(Github.Error) -> T {
-        guard let token = Current.githubToken() else {
-            throw Error.missingToken
-        }
-
-        let response: ClientResponse
-        do {
-            response = try await client.post(Self.graphQLApiUri, headers: defaultHeaders(with: token)) {
-                try $0.content.encode(query)
-            }
-        } catch {
-            throw .postRequestFailed(graphQLApiUri.string, error)
-        }
-
-        guard !isRateLimited(response) else {
-            Current.logger().critical("rate limited while fetching resource \(T.self)")
-            throw Error.requestFailed(.tooManyRequests)
-        }
-
-        guard response.status == .ok else {
-            Current.logger().warning("fetchResource<\(T.self)> request failed with status \(response.status)")
-            throw Error.requestFailed(response.status)
-        }
-
-        do {
-            return try response.content.decode(T.self, using: decoder)
-        } catch {
-            throw .decodeContentFailed(graphQLApiUri.string, error)
-        }
     }
 
     static func fetchResource<T: Decodable>(_ type: T.Type, query: GraphQLQuery) async throws(Github.Error) -> T {

--- a/Tests/AppTests/MastodonTests.swift
+++ b/Tests/AppTests/MastodonTests.swift
@@ -27,6 +27,7 @@ final class MastodonTests: AppTestCase {
             $0.environment.allowSocialPosts = { true }
             $0.github.fetchLicense = { @Sendable _, _ in nil }
             $0.github.fetchMetadata = { @Sendable owner, repository in .mock(owner: owner, repository: repository) }
+            $0.github.fetchReadme = { @Sendable _, _ in nil }
             $0.httpClient.mastodonPost = { @Sendable msg in
                 if message.value == nil {
                     message.setValue(msg)

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -22,7 +22,6 @@ import Vapor
 extension AppEnvironment {
     static func mock(eventLoop: EventLoop) -> Self {
         .init(
-            fetchReadme: { _,  _, _ in .init(html: "readme html", htmlUrl: "readme html url", imagesToCache: []) },
             fetchS3Readme: { _, _, _ in "" },
             fileManager: .mock,
             getStatusCount: { _, _ in 100 },

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -313,6 +313,7 @@ final class PackageTests: AppTestCase {
             $0.date.now = .now
             $0.github.fetchLicense = { @Sendable _, _ in nil }
             $0.github.fetchMetadata = { @Sendable owner, repository in .mock(owner: owner, repository: repository) }
+            $0.github.fetchReadme = { @Sendable _, _ in nil }
             $0.packageListRepository.fetchPackageList = { @Sendable _ in [url.url] }
             $0.packageListRepository.fetchPackageDenyList = { @Sendable _ in [] }
             $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -163,6 +163,7 @@ class PipelineTests: AppTestCase {
             $0.date.now = .now
             $0.github.fetchLicense = { @Sendable _, _ in nil }
             $0.github.fetchMetadata = { @Sendable owner, repository in .mock(owner: owner, repository: repository) }
+            $0.github.fetchReadme = { @Sendable _, _ in nil }
             $0.packageListRepository.fetchPackageList = { @Sendable _ in urls.asURLs }
             $0.packageListRepository.fetchPackageDenyList = { @Sendable _ in [] }
             $0.packageListRepository.fetchCustomCollections = { @Sendable _ in [] }


### PR DESCRIPTION
This completes the transition of the Github dependencies over to `GithubClient` and cleans up the deprecation markers left from #3572 and #3575.