### PR TITLE
Add “Has Documentation” Tag to Author and Keyword Views

### DIFF
--- a/Sources/App/Controllers/KeywordController.swift
+++ b/Sources/App/Controllers/KeywordController.swift
@@ -31,6 +31,7 @@ enum KeywordController {
             .filter(Repository.self, \.$keywords, .custom("@>"), [keyword])
             .sort(\.$score, .descending)
             .sort(Repository.self, \.$name)
+            .field(\.$scoreDetails)
             .page(page, size: pageSize)
     }
 

--- a/Sources/App/Views/PackageInfo.swift
+++ b/Sources/App/Views/PackageInfo.swift
@@ -39,7 +39,8 @@ extension PackageInfo {
                   repositoryName: repoName,
                   url: SiteURL.package(.value(repoOwner), .value(repoName), .none).relativeURL(),
                   stars: package.repository.stars,
-                  lastActivityAt: package.repository.lastActivityAt
+                  lastActivityAt: package.repository.lastActivityAt,
+                  hasDocs: package.model.scoreDetails?.hasDocumentation ?? false
         )
     }
 }


### PR DESCRIPTION
# Issue 

Closes #3413 

# Description

This pull request adds the “Has Documentation” tag to the Author and Keyword views, ensuring consistency with the Search view, where this tag was already present.

The implementation involved updating `PackageInfo` to include the `hasDocumentation` property from `scoreDetails`.

# Screenshots

* Search
<img src="https://github.com/user-attachments/assets/1d6d921e-b0eb-4fcc-898d-5ad574877aee" width="800">

* Authors
<img src="https://github.com/user-attachments/assets/81341317-9783-4345-976b-62a7d6b1c327" width="800">

* Keywords
<img src="https://github.com/user-attachments/assets/cbd800a0-b4cc-404c-9b4c-2ee465833655" width="800">
