### PR TITLE
Added an `uptime-check` page that the automated uptime checkers can use

### DIFF
--- a/Sources/App/Controllers/HealthCheckController.swift
+++ b/Sources/App/Controllers/HealthCheckController.swift
@@ -16,7 +16,7 @@ import Fluent
 import Plot
 import Vapor
 
-enum UptimeCheckController {
+enum HealthCheckController {
 
     @Sendable
     static func show(req: Request) async throws -> String {

--- a/Sources/App/Controllers/UptimeCheckController.swift
+++ b/Sources/App/Controllers/UptimeCheckController.swift
@@ -1,0 +1,30 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Fluent
+import Plot
+import Vapor
+
+enum UptimeCheckController {
+
+    @Sendable
+    static func show(req: Request) async throws -> String {
+        // A package page query is a good test of whether the site is healthy.
+        let (_, _) = try await API.PackageController.GetRoute
+            .query(on: req.db,
+                   owner: "SwiftPackageIndex",
+                   repository: "SemanticVersion")
+        return "Success"
+    }
+}

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -134,6 +134,7 @@ enum SiteURL: Resourceable, Sendable {
     case stylesheets(String)
     case supporters
     case tryInPlayground
+    case uptimeCheck
     case validateSPIManifest
 
     var path: String {
@@ -254,6 +255,9 @@ enum SiteURL: Resourceable, Sendable {
         case .tryInPlayground:
             return "try-in-a-playground"
 
+        case .uptimeCheck:
+            return "uptime-check"
+
         case .validateSPIManifest:
             return "validate-spi-manifest"
         }
@@ -276,6 +280,7 @@ enum SiteURL: Resourceable, Sendable {
                 .siteMapStaticPages,
                 .supporters,
                 .tryInPlayground,
+                .uptimeCheck,
                 .validateSPIManifest:
             return [.init(stringLiteral: path)]
 

--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -134,7 +134,7 @@ enum SiteURL: Resourceable, Sendable {
     case stylesheets(String)
     case supporters
     case tryInPlayground
-    case uptimeCheck
+    case healthCheck
     case validateSPIManifest
 
     var path: String {
@@ -255,8 +255,8 @@ enum SiteURL: Resourceable, Sendable {
         case .tryInPlayground:
             return "try-in-a-playground"
 
-        case .uptimeCheck:
-            return "uptime-check"
+        case .healthCheck:
+            return "health-check"
 
         case .validateSPIManifest:
             return "validate-spi-manifest"
@@ -280,7 +280,7 @@ enum SiteURL: Resourceable, Sendable {
                 .siteMapStaticPages,
                 .supporters,
                 .tryInPlayground,
-                .uptimeCheck,
+                .healthCheck,
                 .validateSPIManifest:
             return [.init(stringLiteral: path)]
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -129,7 +129,7 @@ func routes(_ app: Application) throws {
     }
 
     do { // Uptime check
-        app.get(SiteURL.uptimeCheck.pathComponents, use: UptimeCheckController.show).excludeFromOpenAPI()
+        app.get(SiteURL.healthCheck.pathComponents, use: HealthCheckController.show).excludeFromOpenAPI()
     }
 
     do {  // spi.yml validation page

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -128,6 +128,10 @@ func routes(_ app: Application) throws {
         app.get(SiteURL.supporters.pathComponents, use: SupportersController.show).excludeFromOpenAPI()
     }
 
+    do { // Uptime check
+        app.get(SiteURL.uptimeCheck.pathComponents, use: UptimeCheckController.show).excludeFromOpenAPI()
+    }
+
     do {  // spi.yml validation page
         app.get(SiteURL.validateSPIManifest.pathComponents, use: ValidateSPIManifestController.show)
             .excludeFromOpenAPI()


### PR DESCRIPTION
Merge after #3609

Adds a simple uptime check route that exercises the database that we should monitor with the Azure and StatusPage checkers.

I'll set this page to cache this for 5 minutes which will prevent it being abused, but it will be a much more accurate test than the home page, which is cached for many hours.