### PR TITLE
Issue 3469 dependency transition 17

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -555,7 +555,8 @@ extension Analyze {
 
         do {
             let packageManifest = try await dumpPackage(at: cacheDir)
-            let spiManifest = Current.loadSPIManifest(cacheDir)
+            @Dependency(\.environment) var environment
+            let spiManifest = environment.loadSPIManifest(cacheDir)
 
             return PackageInfo(packageManifest: packageManifest,
                                spiManifest: spiManifest)

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -30,7 +30,6 @@ struct AppEnvironment: Sendable {
     var gitlabApiToken: @Sendable () -> String?
     var gitlabPipelineToken: @Sendable () -> String?
     var gitlabPipelineLimit: @Sendable () -> Int
-    var hideStagingBanner: @Sendable () -> Bool
     var maintenanceMessage: @Sendable () -> String?
     var loadSPIManifest: @Sendable (String) -> SPIManifest.Manifest?
     var logger: @Sendable () -> Logger
@@ -77,10 +76,6 @@ extension AppEnvironment {
         gitlabPipelineLimit: {
             Environment.get("GITLAB_PIPELINE_LIMIT").flatMap(Int.init)
             ?? Constants.defaultGitlabPipelineLimit
-        },
-        hideStagingBanner: {
-            Environment.get("HIDE_STAGING_BANNER").flatMap(\.asBool)
-                ?? Constants.defaultHideStagingBanner
         },
         maintenanceMessage: {
             Environment.get("MAINTENANCE_MESSAGE").flatMap(\.trimmed)

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -45,7 +45,6 @@ struct AppEnvironment: Sendable {
                                   _ readme: String) async throws(S3Readme.Error) -> String
     var storeS3ReadmeImages: @Sendable (_ client: Client,
                                         _ imagesToCache: [Github.Readme.ImageToCache]) async throws(S3Readme.Error) -> Void
-    var timeZone: @Sendable () -> TimeZone
     var triggerBuild: @Sendable (_ client: Client,
                                  _ buildId: Build.Id,
                                  _ cloneURL: String,
@@ -102,7 +101,6 @@ extension AppEnvironment {
         storeS3ReadmeImages: { client, images throws(S3Readme.Error) in
             try await S3Readme.storeReadmeImages(client: client, imagesToCache: images)
         },
-        timeZone: { .current },
         triggerBuild: { client, buildId, cloneURL, isDocBuild, platform, ref, swiftVersion, versionID in
             try await Gitlab.Builder.triggerBuild(client: client,
                                                   buildId: buildId,

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -30,7 +30,6 @@ struct AppEnvironment: Sendable {
     var gitlabApiToken: @Sendable () -> String?
     var gitlabPipelineToken: @Sendable () -> String?
     var gitlabPipelineLimit: @Sendable () -> Int
-    var loadSPIManifest: @Sendable (String) -> SPIManifest.Manifest?
     var logger: @Sendable () -> Logger
     var metricsPushGatewayUrl: @Sendable () -> String?
     var plausibleBackendReportingSiteID: @Sendable () -> String?
@@ -75,7 +74,6 @@ extension AppEnvironment {
             Environment.get("GITLAB_PIPELINE_LIMIT").flatMap(Int.init)
             ?? Constants.defaultGitlabPipelineLimit
         },
-        loadSPIManifest: { path in SPIManifest.Manifest.load(in: path) },
         logger: { logger },
         metricsPushGatewayUrl: { Environment.get("METRICS_PUSHGATEWAY_URL") },
         plausibleBackendReportingSiteID: { Environment.get("PLAUSIBLE_BACKEND_REPORTING_SITE_ID") },

--- a/Sources/App/Core/AppEnvironment.swift
+++ b/Sources/App/Core/AppEnvironment.swift
@@ -30,7 +30,6 @@ struct AppEnvironment: Sendable {
     var gitlabApiToken: @Sendable () -> String?
     var gitlabPipelineToken: @Sendable () -> String?
     var gitlabPipelineLimit: @Sendable () -> Int
-    var maintenanceMessage: @Sendable () -> String?
     var loadSPIManifest: @Sendable (String) -> SPIManifest.Manifest?
     var logger: @Sendable () -> Logger
     var metricsPushGatewayUrl: @Sendable () -> String?
@@ -75,9 +74,6 @@ extension AppEnvironment {
         gitlabPipelineLimit: {
             Environment.get("GITLAB_PIPELINE_LIMIT").flatMap(Int.init)
             ?? Constants.defaultGitlabPipelineLimit
-        },
-        maintenanceMessage: {
-            Environment.get("MAINTENANCE_MESSAGE").flatMap(\.trimmed)
         },
         loadSPIManifest: { path in SPIManifest.Manifest.load(in: path) },
         logger: { logger },

--- a/Sources/App/Core/Dependencies/EnvironmentClient.swift
+++ b/Sources/App/Core/Dependencies/EnvironmentClient.swift
@@ -40,6 +40,7 @@ struct EnvironmentClient {
     var collectionSigningPrivateKey: @Sendable () -> Data?
     var current: @Sendable () -> Environment = { XCTFail("current"); return .development }
     var dbId: @Sendable () -> String?
+    var hideStagingBanner: @Sendable () -> Bool = { XCTFail("hideStagingBanner"); return Constants.defaultHideStagingBanner }
     var mastodonCredentials: @Sendable () -> Mastodon.Credentials?
     var random: @Sendable (_ range: ClosedRange<Double>) -> Double = { XCTFail("random"); return Double.random(in: $0) }
 
@@ -102,6 +103,10 @@ extension EnvironmentClient: DependencyKey {
             },
             current: { (try? Environment.detect()) ?? .development },
             dbId: { Environment.get("DATABASE_ID") },
+            hideStagingBanner: {
+                Environment.get("HIDE_STAGING_BANNER").flatMap(\.asBool)
+                    ?? Constants.defaultHideStagingBanner
+            },
             mastodonCredentials: {
                 Environment.get("MASTODON_ACCESS_TOKEN")
                     .map(Mastodon.Credentials.init(accessToken:))
@@ -134,7 +139,7 @@ extension EnvironmentClient {
 extension EnvironmentClient: TestDependencyKey {
     static var testValue: Self {
         // sas 2024-11-22:
-        // For a few attributes we provide a default value overriding the XCTFail, because theis use is too
+        // For a few attributes we provide a default value overriding the XCTFail, because their use is too
         // pervasive and would require the vast majority of tests to be wrapped with `withDependencies`.
         // We can do so at a later time once more tests are transitioned over for other dependencies. This is
         // the exact same default behaviour we had with the Current dependency injection. It did not have
@@ -143,6 +148,7 @@ extension EnvironmentClient: TestDependencyKey {
         var mock = Self()
         mock.appVersion = { "test" }
         mock.current = { .development }
+        mock.hideStagingBanner = { false }
         return mock
     }
 }

--- a/Sources/App/Core/Dependencies/EnvironmentClient.swift
+++ b/Sources/App/Core/Dependencies/EnvironmentClient.swift
@@ -14,6 +14,7 @@
 
 import Dependencies
 import DependenciesMacros
+import SPIManifest
 import Vapor
 
 
@@ -41,6 +42,7 @@ struct EnvironmentClient {
     var current: @Sendable () -> Environment = { XCTFail("current"); return .development }
     var dbId: @Sendable () -> String?
     var hideStagingBanner: @Sendable () -> Bool = { XCTFail("hideStagingBanner"); return Constants.defaultHideStagingBanner }
+    var loadSPIManifest: @Sendable (String) -> SPIManifest.Manifest?
     var maintenanceMessage: @Sendable () -> String?
     var mastodonCredentials: @Sendable () -> Mastodon.Credentials?
     var random: @Sendable (_ range: ClosedRange<Double>) -> Double = { XCTFail("random"); return Double.random(in: $0) }
@@ -108,6 +110,7 @@ extension EnvironmentClient: DependencyKey {
                 Environment.get("HIDE_STAGING_BANNER").flatMap(\.asBool)
                     ?? Constants.defaultHideStagingBanner
             },
+            loadSPIManifest: { path in SPIManifest.Manifest.load(in: path) },
             maintenanceMessage: {
                 Environment.get("MAINTENANCE_MESSAGE").flatMap(\.trimmed)
             },

--- a/Sources/App/Core/Dependencies/EnvironmentClient.swift
+++ b/Sources/App/Core/Dependencies/EnvironmentClient.swift
@@ -41,6 +41,7 @@ struct EnvironmentClient {
     var current: @Sendable () -> Environment = { XCTFail("current"); return .development }
     var dbId: @Sendable () -> String?
     var hideStagingBanner: @Sendable () -> Bool = { XCTFail("hideStagingBanner"); return Constants.defaultHideStagingBanner }
+    var maintenanceMessage: @Sendable () -> String?
     var mastodonCredentials: @Sendable () -> Mastodon.Credentials?
     var random: @Sendable (_ range: ClosedRange<Double>) -> Double = { XCTFail("random"); return Double.random(in: $0) }
 
@@ -106,6 +107,9 @@ extension EnvironmentClient: DependencyKey {
             hideStagingBanner: {
                 Environment.get("HIDE_STAGING_BANNER").flatMap(\.asBool)
                     ?? Constants.defaultHideStagingBanner
+            },
+            maintenanceMessage: {
+                Environment.get("MAINTENANCE_MESSAGE").flatMap(\.trimmed)
             },
             mastodonCredentials: {
                 Environment.get("MASTODON_ACCESS_TOKEN")

--- a/Sources/App/Core/Dependencies/HTTPClient.swift
+++ b/Sources/App/Core/Dependencies/HTTPClient.swift
@@ -110,5 +110,14 @@ extension HTTPClient.Response {
     static var notFound: Self { .init(status: .notFound) }
     static var tooManyRequests: Self { .init(status: .tooManyRequests) }
     static var ok: Self { .init(status: .ok) }
+
+    static func ok(body: String, headers: HTTPHeaders = .init()) -> Self {
+        .init(status: .ok, headers: headers, body: .init(string: body))
+    }
+
+    static func ok<T: Encodable>(jsonEncode value: T, headers: HTTPHeaders = .init()) throws -> Self {
+        let data = try JSONEncoder().encode(value)
+        return .init(status: .ok, headers: headers, body: .init(data: data))
+    }
 }
 #endif

--- a/Sources/App/Core/Extensions/Date+ext.swift
+++ b/Sources/App/Core/Extensions/Date+ext.swift
@@ -18,26 +18,29 @@ import Dependencies
 
 extension DateFormatter {
     static var mediumDateFormatter: DateFormatter {
+        @Dependency(\.timeZone) var timeZone
         let formatter = DateFormatter()
         formatter.dateStyle = .medium
         formatter.locale = .init(identifier: "en_GB")
-        formatter.timeZone = Current.timeZone()
+        formatter.timeZone = timeZone
         return formatter
     }
 
     static var longDateFormatter: DateFormatter {
+        @Dependency(\.timeZone) var timeZone
         let formatter = DateFormatter()
         formatter.dateStyle = .long
         formatter.locale = .init(identifier: "en_GB")
-        formatter.timeZone = Current.timeZone()
+        formatter.timeZone = timeZone
         return formatter
     }
 
     static var yearMonthDayDateFormatter: DateFormatter {
+        @Dependency(\.timeZone) var timeZone
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.locale = .init(identifier: "en_GB")
-        formatter.timeZone = Current.timeZone()
+        formatter.timeZone = timeZone
         return formatter
     }
 

--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -278,8 +278,8 @@ class PublicPage {
     /// A staging banner, which only appears on the staging/development server.
     /// - Returns: Either a <div> element, or nothing.
     final func stagingBanner() -> Node<HTML.BodyContext> {
-        guard !Current.hideStagingBanner() else { return .empty }
         @Dependency(\.environment) var environment
+        guard !environment.hideStagingBanner() else { return .empty }
         if environment.current() == .development {
             return .div(
                 .class("staging"),

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -26,7 +26,7 @@ func routes(_ app: Application) throws {
 
     do {  // home page
         app.get { req in
-            if let maintenanceMessage = Current.maintenanceMessage() {
+            if let maintenanceMessage = environment.maintenanceMessage() {
                 let model = MaintenanceMessageIndex.Model(markdown: maintenanceMessage)
                 return MaintenanceMessageIndex.View(path: req.url.path, model: model).document()
             } else {

--- a/Tests/AppTests/AppEnvironmentTests.swift
+++ b/Tests/AppTests/AppEnvironmentTests.swift
@@ -12,10 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import XCTest
+
 @testable import App
 
+import Dependencies
 import Vapor
-import XCTest
 
 
 class AppEnvironmentTests: XCTestCase {
@@ -31,26 +33,30 @@ class AppEnvironmentTests: XCTestCase {
 
     func test_maintenanceMessage() throws {
         defer { unsetenv("MAINTENANCE_MESSAGE") }
-        Current.maintenanceMessage = AppEnvironment.live.maintenanceMessage
-        do {
-            unsetenv("MAINTENANCE_MESSAGE")
-            XCTAssertEqual(Current.maintenanceMessage(), nil)
-        }
-        do {
-            setenv("MAINTENANCE_MESSAGE", "foo", 1)
-            XCTAssertEqual(Current.maintenanceMessage(), "foo")
-        }
-        do {
-            setenv("MAINTENANCE_MESSAGE", "", 1)
-            XCTAssertEqual(Current.maintenanceMessage(), nil)
-        }
-        do {
-            setenv("MAINTENANCE_MESSAGE", " ", 1)
-            XCTAssertEqual(Current.maintenanceMessage(), nil)
-        }
-        do {
-            setenv("MAINTENANCE_MESSAGE", " \t\n ", 1)
-            XCTAssertEqual(Current.maintenanceMessage(), nil)
+        withDependencies {
+            $0.environment.maintenanceMessage = EnvironmentClient.liveValue.maintenanceMessage
+        } operation: {
+            @Dependency(\.environment) var environment
+            do {
+                unsetenv("MAINTENANCE_MESSAGE")
+                XCTAssertEqual(environment.maintenanceMessage(), nil)
+            }
+            do {
+                setenv("MAINTENANCE_MESSAGE", "foo", 1)
+                XCTAssertEqual(environment.maintenanceMessage(), "foo")
+            }
+            do {
+                setenv("MAINTENANCE_MESSAGE", "", 1)
+                XCTAssertEqual(environment.maintenanceMessage(), nil)
+            }
+            do {
+                setenv("MAINTENANCE_MESSAGE", " ", 1)
+                XCTAssertEqual(environment.maintenanceMessage(), nil)
+            }
+            do {
+                setenv("MAINTENANCE_MESSAGE", " \t\n ", 1)
+                XCTAssertEqual(environment.maintenanceMessage(), nil)
+            }
         }
     }
 

--- a/Tests/AppTests/BlogActionsModelTests.swift
+++ b/Tests/AppTests/BlogActionsModelTests.swift
@@ -37,36 +37,40 @@ class BlogActionsModelTests: AppTestCase {
             """.data(using: .utf8)
         }
 
-        try withDependencies {  // Ensure dev shows all summaries
-            $0.environment.current = { .development }
+        try withDependencies {
+            $0.timeZone = .utc
         } operation: {
-            // MUT
-            let summaries = try BlogActions.Model().summaries
+            try withDependencies {  // Ensure dev shows all summaries
+                $0.environment.current = { .development }
+            } operation: {
+                // MUT
+                let summaries = try BlogActions.Model().summaries
 
-            XCTAssertEqual(summaries.count, 2)
-            XCTAssertEqual(summaries.map(\.slug), ["post-2", "post-1"])
-            XCTAssertEqual(summaries.map(\.published), [false, true])
+                XCTAssertEqual(summaries.count, 2)
+                XCTAssertEqual(summaries.map(\.slug), ["post-2", "post-1"])
+                XCTAssertEqual(summaries.map(\.published), [false, true])
 
-            let firstSummary = try XCTUnwrap(summaries).first
+                let firstSummary = try XCTUnwrap(summaries).first
 
-            // Note that we are testing that the first item in this list is the *last* item in the source YAML
-            // as the init should reverse the order of posts so that they display in reverse chronological order
-            XCTAssertEqual(firstSummary, BlogActions.Model.PostSummary(slug: "post-2",
-                                                                       title: "Blog post title two",
-                                                                       summary: "Summary of blog post two",
-                                                                       publishedAt: DateFormatter.yearMonthDayDateFormatter.date(from: "2024-01-02")!,
-                                                                       published: false))
-        }
+                // Note that we are testing that the first item in this list is the *last* item in the source YAML
+                // as the init should reverse the order of posts so that they display in reverse chronological order
+                XCTAssertEqual(firstSummary, BlogActions.Model.PostSummary(slug: "post-2",
+                                                                           title: "Blog post title two",
+                                                                           summary: "Summary of blog post two",
+                                                                           publishedAt: DateFormatter.yearMonthDayDateFormatter.date(from: "2024-01-02")!,
+                                                                           published: false))
+            }
 
-        try withDependencies {  // Ensure prod shows only published summaries
-            $0.environment.current = { .production }
-        } operation: {
-            // MUT
-            let summaries = try BlogActions.Model().summaries
+            try withDependencies {  // Ensure prod shows only published summaries
+                $0.environment.current = { .production }
+            } operation: {
+                // MUT
+                let summaries = try BlogActions.Model().summaries
 
-            // validate
-            XCTAssertEqual(summaries.map(\.slug), ["post-1"])
-            XCTAssertEqual(summaries.map(\.published), [true])
+                // validate
+                XCTAssertEqual(summaries.map(\.slug), ["post-1"])
+                XCTAssertEqual(summaries.map(\.published), [true])
+            }
         }
     }
 
@@ -88,11 +92,15 @@ class BlogActionsModelTests: AppTestCase {
         // setup
         Current.fileManager = .live
 
-        // MUT
-        let summaries = try BlogActions.Model.allSummaries()
-
-        // validate
-        XCTAssert(summaries.count > 0)
+        try withDependencies {
+            $0.timeZone = .utc
+        } operation: {
+            // MUT
+            let summaries = try BlogActions.Model.allSummaries()
+            
+            // validate
+            XCTAssert(summaries.count > 0)
+        }
     }
 
 }

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -469,19 +469,3 @@ class GithubTests: AppTestCase {
     }
 
 }
-
-
-private extension HTTPClient.Response {
-    static func ok(body: String, headers: HTTPHeaders = .init()) -> Self {
-        .init(status: .ok, headers: headers, body: .init(string: body))
-    }
-
-    static func ok(fixture: String) throws -> Self {
-        try .init(status: .ok, body: .init(data: fixtureData(for: fixture)))
-    }
-
-    static func ok<T: Encodable>(jsonEncode value: T) throws -> Self {
-        let data = try JSONEncoder().encode(value)
-        return .init(status: .ok, body: .init(data: data))
-    }
-}

--- a/Tests/AppTests/IngestionTests.swift
+++ b/Tests/AppTests/IngestionTests.swift
@@ -431,6 +431,7 @@ class IngestionTests: AppTestCase {
         try await withDependencies {
             $0.date.now = .now
             $0.environment.allowSocialPosts = { false }
+            $0.environment.loadSPIManifest = { _ in nil }
         } operation: { [db = app.db] in
             Current.fileManager.fileExists = { @Sendable _ in true }
             Current.git.commitCount = { @Sendable _ in 1 }

--- a/Tests/AppTests/MastodonTests.swift
+++ b/Tests/AppTests/MastodonTests.swift
@@ -25,6 +25,7 @@ final class MastodonTests: AppTestCase {
         let message = QueueIsolated<String?>(nil)
         try await withDependencies {
             $0.environment.allowSocialPosts = { true }
+            $0.environment.loadSPIManifest = { _ in nil }
             $0.github.fetchLicense = { @Sendable _, _ in nil }
             $0.github.fetchMetadata = { @Sendable owner, repository in .mock(owner: owner, repository: repository) }
             $0.github.fetchReadme = { @Sendable _, _ in nil }

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -29,7 +29,6 @@ extension AppEnvironment {
             gitlabApiToken: { nil },
             gitlabPipelineToken: { nil },
             gitlabPipelineLimit: { Constants.defaultGitlabPipelineLimit },
-            loadSPIManifest: { _ in nil },
             logger: { logger },
             metricsPushGatewayUrl: { "http://pushgateway:9091" },
             plausibleBackendReportingSiteID: { nil },

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -29,7 +29,6 @@ extension AppEnvironment {
             gitlabApiToken: { nil },
             gitlabPipelineToken: { nil },
             gitlabPipelineLimit: { Constants.defaultGitlabPipelineLimit },
-            hideStagingBanner: { false },
             maintenanceMessage: { nil },
             loadSPIManifest: { _ in nil },
             logger: { logger },

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -41,7 +41,6 @@ extension AppEnvironment {
             siteURL: { Environment.get("SITE_URL") ?? "http://localhost:8080" },
             storeS3Readme: { _, _, _ in "s3ObjectUrl" },
             storeS3ReadmeImages: { _, _ in },
-            timeZone: { .utc },
             triggerBuild: { _, _, _, _, _, _, _, _ in .init(status: .ok, webUrl: "http://web_url") }
         )
     }

--- a/Tests/AppTests/Mocks/AppEnvironment+mock.swift
+++ b/Tests/AppTests/Mocks/AppEnvironment+mock.swift
@@ -29,7 +29,6 @@ extension AppEnvironment {
             gitlabApiToken: { nil },
             gitlabPipelineToken: { nil },
             gitlabPipelineLimit: { Constants.defaultGitlabPipelineLimit },
-            maintenanceMessage: { nil },
             loadSPIManifest: { _ in nil },
             logger: { logger },
             metricsPushGatewayUrl: { "http://pushgateway:9091" },

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -568,7 +568,7 @@ class PackageController_routesTests: SnapshotTestCase {
         try await withDependencies {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
-            $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.httpClient.fetchDocumentation = { @Sendable _ in .ok(body: .mockIndexHTML()) }
             $0.timeZone = .utc
         } operation: {
             // setup
@@ -652,7 +652,7 @@ class PackageController_routesTests: SnapshotTestCase {
         try await withDependencies {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
-            $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML(baseURL: "/owner/package/1.0.0")) }
+            $0.httpClient.fetchDocumentation = { @Sendable _ in .ok(body: .mockIndexHTML(baseURL: "/owner/package/1.0.0")) }
             $0.timeZone = .utc
         } operation: {
             // setup
@@ -727,7 +727,7 @@ class PackageController_routesTests: SnapshotTestCase {
         //   /owner/package/documentation/{reference} + various path elements
         try await withDependencies {
             $0.environment.awsDocsBucket = { "docs-bucket" }
-            $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.httpClient.fetchDocumentation = { @Sendable _ in .ok(body: .mockIndexHTML()) }
             $0.timeZone = .utc
         } operation: {
             // setup
@@ -807,7 +807,7 @@ class PackageController_routesTests: SnapshotTestCase {
         // Test documentation routes when no archive is in the path
         try await withDependencies {
             $0.environment.awsDocsBucket = { "docs-bucket" }
-            $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.httpClient.fetchDocumentation = { @Sendable _ in .ok(body: .mockIndexHTML()) }
         } operation: {
             // setup
             let pkg = try await savePackage(on: app.db, "1")
@@ -1162,7 +1162,7 @@ class PackageController_routesTests: SnapshotTestCase {
         try await withDependencies {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
-            $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.httpClient.fetchDocumentation = { @Sendable _ in .ok(body: .mockIndexHTML()) }
             $0.timeZone = .utc
         } operation: {
             // setup
@@ -1228,7 +1228,7 @@ class PackageController_routesTests: SnapshotTestCase {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.environment.dbId = { nil }
-            $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.httpClient.fetchDocumentation = { @Sendable _ in .ok(body: .mockIndexHTML()) }
             $0.timeZone = .utc
         } operation: {
             // setup
@@ -1330,7 +1330,7 @@ class PackageController_routesTests: SnapshotTestCase {
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.httpClient.fetchDocumentation = { @Sendable uri in
                 // embed uri.path in the body as a simple way to test the requested url
-                    .init(status: .ok, body: .init(string: "<p>\(uri.path)</p>"))
+                    .ok(body: "<p>\(uri.path)</p>")
             }
             $0.timeZone = .utc
         } operation: {
@@ -1488,7 +1488,7 @@ class PackageController_routesTests: SnapshotTestCase {
         try await withDependencies {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
-            $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.httpClient.fetchDocumentation = { @Sendable _ in .ok(body: .mockIndexHTML()) }
             $0.timeZone = .utc
         } operation: {
             // setup
@@ -1653,10 +1653,10 @@ private extension String {
                     """#
 }
 
-private extension ByteBuffer {
+private extension String {
     static func mockIndexHTML(baseURL: String = "/") -> Self {
         let baseURL = baseURL.hasSuffix("/") ? baseURL : baseURL + "/"
-        return .init(string: """
+        return """
             <!doctype html>
             <html lang="en-US">
 
@@ -1680,6 +1680,6 @@ private extension ByteBuffer {
             </body>
 
             </html>
-            """)
+            """
     }
 }

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -1488,6 +1488,7 @@ class PackageController_routesTests: SnapshotTestCase {
         try await withDependencies {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
+            $0.environment.loadSPIManifest = { _ in nil }
             $0.httpClient.fetchDocumentation = { @Sendable _ in .ok(body: .mockIndexHTML()) }
             $0.timeZone = .utc
         } operation: {

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -569,6 +569,7 @@ class PackageController_routesTests: SnapshotTestCase {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.timeZone = .utc
         } operation: {
             // setup
             let pkg = try await savePackage(on: app.db, "1")
@@ -652,6 +653,7 @@ class PackageController_routesTests: SnapshotTestCase {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML(baseURL: "/owner/package/1.0.0")) }
+            $0.timeZone = .utc
         } operation: {
             // setup
             let pkg = try await savePackage(on: app.db, "1")
@@ -726,6 +728,7 @@ class PackageController_routesTests: SnapshotTestCase {
         try await withDependencies {
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.timeZone = .utc
         } operation: {
             // setup
             let pkg = try await savePackage(on: app.db, "1")
@@ -1126,6 +1129,7 @@ class PackageController_routesTests: SnapshotTestCase {
         try await withDependencies {
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.httpClient.fetchDocumentation = App.HTTPClient.echoURL()
+            $0.timeZone = .utc
         } operation: {
             // The `packageName` property on the `Version` has been set to the lower-cased version so
             // we can be sure the canonical URL is built from the properties on the `Repository` model.
@@ -1159,6 +1163,7 @@ class PackageController_routesTests: SnapshotTestCase {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.timeZone = .utc
         } operation: {
             // setup
             let pkg = try await savePackage(on: app.db, "1")
@@ -1224,6 +1229,7 @@ class PackageController_routesTests: SnapshotTestCase {
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.environment.dbId = { nil }
             $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.timeZone = .utc
         } operation: {
             // setup
             let pkg = try await savePackage(on: app.db, "1")
@@ -1326,6 +1332,7 @@ class PackageController_routesTests: SnapshotTestCase {
                 // embed uri.path in the body as a simple way to test the requested url
                     .init(status: .ok, body: .init(string: "<p>\(uri.path)</p>"))
             }
+            $0.timeZone = .utc
         } operation: {
             // setup
             let pkg = try await savePackage(on: app.db, "1")
@@ -1482,6 +1489,7 @@ class PackageController_routesTests: SnapshotTestCase {
             $0.currentReferenceCache = .disabled
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.httpClient.fetchDocumentation = { @Sendable _ in .init(status: .ok, body: .mockIndexHTML()) }
+            $0.timeZone = .utc
         } operation: {
             // setup
             let pkg = try await savePackage(on: app.db, "https://github.com/foo/bar".url, processingStage: .ingestion)

--- a/Tests/AppTests/PipelineTests.swift
+++ b/Tests/AppTests/PipelineTests.swift
@@ -161,6 +161,7 @@ class PipelineTests: AppTestCase {
         let urls = ["1", "2", "3"].asGithubUrls
         try await withDependencies {
             $0.date.now = .now
+            $0.environment.loadSPIManifest = { _ in nil }
             $0.github.fetchLicense = { @Sendable _, _ in nil }
             $0.github.fetchMetadata = { @Sendable owner, repository in .mock(owner: owner, repository: repository) }
             $0.github.fetchReadme = { @Sendable _, _ in nil }

--- a/Tests/AppTests/ReAnalyzeVersionsTests.swift
+++ b/Tests/AppTests/ReAnalyzeVersionsTests.swift
@@ -29,6 +29,7 @@ class ReAnalyzeVersionsTests: AppTestCase {
         try await withDependencies {
             $0.date.now = .t0
             $0.environment.allowSocialPosts = { true }
+            $0.environment.loadSPIManifest = { _ in nil }
             $0.httpClient.mastodonPost = { @Sendable _ in }
         } operation: {
             // setup
@@ -108,14 +109,6 @@ class ReAnalyzeVersionsTests: AppTestCase {
                     .mock(description: "rel 1.2.3", tagName: "1.2.3")
                 ]
                 try await r.save(on: app.db)
-                // Package has gained a SPI manifest
-                Current.loadSPIManifest = { path in
-                    if path.hasSuffix("foo-1") {
-                        return .init(builder: .init(configs: [.init(documentationTargets: ["DocTarget"])]))
-                    } else {
-                        return nil
-                    }
-                }
             }
             do {  // assert running analysis again does not update existing versions
                 try await Analyze.analyze(client: app.client,
@@ -188,6 +181,7 @@ class ReAnalyzeVersionsTests: AppTestCase {
         let cutoff = Date.t1
         try await withDependencies {
             $0.date.now = .t2
+            $0.environment.loadSPIManifest = { _ in nil }
         } operation: {
             let pkg = try await savePackage(on: app.db,
                                             "https://github.com/foo/1".url,

--- a/Tests/AppTests/RoutesTests.swift
+++ b/Tests/AppTests/RoutesTests.swift
@@ -83,8 +83,8 @@ final class RoutesTests: AppTestCase {
     func test_maintenanceMessage() throws {
         try withDependencies {
             $0.environment.dbId = { nil }
+            $0.environment.maintenanceMessage = { "MAINTENANCE_MESSAGE" }
         } operation: {
-            Current.maintenanceMessage = { "MAINTENANCE_MESSAGE" }
 
             try app.test(.GET, "/") { res in
                 XCTAssertContains(res.body.string, "MAINTENANCE_MESSAGE")

--- a/Tests/AppTests/SitemapTests.swift
+++ b/Tests/AppTests/SitemapTests.swift
@@ -142,14 +142,12 @@ class SitemapTests: SnapshotTestCase {
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.httpClient.fetchDocumentation = { @Sendable url in
                 guard url.path.hasSuffix("/owner/repo0/default/linkable-paths.json") else { throw Abort(.notFound) }
-                return .init(status: .ok,
-                             body: .init(string: """
+                return .ok(body: """
                             [
                                 "/documentation/foo/bar/1",
                                 "/documentation/foo/bar/2",
                             ]
                             """)
-                )
             }
         } operation: {
             // setup
@@ -187,14 +185,12 @@ class SitemapTests: SnapshotTestCase {
             $0.environment.awsDocsBucket = { "docs-bucket" }
             $0.httpClient.fetchDocumentation = { @Sendable url in
                 guard url.path.hasSuffix("/owner/repo0/a-b/linkable-paths.json") else { throw Abort(.notFound) }
-                return .init(status: .ok,
-                             body: .init(string: """
+                return .ok(body: """
                             [
                                 "/documentation/foo/bar/1",
                                 "/documentation/foo/bar/2",
                             ]
                             """)
-                )
             }
         } operation: {
             // setup

--- a/Tests/AppTests/Util.swift
+++ b/Tests/AppTests/Util.swift
@@ -108,3 +108,10 @@ func makeBody(_ data: Data) -> ByteBuffer {
     buffer.writeBytes(data)
     return buffer
 }
+
+
+extension HTTPClient.Response {
+    static func ok(fixture: String) throws -> Self {
+        try .init(status: .ok, body: .init(data: fixtureData(for: fixture)))
+    }
+}

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -34,6 +34,7 @@ class WebpageSnapshotTests: SnapshotTestCase {
         withDependencies {
             $0.environment.current = { .production }
             $0.environment.dbId = { "db-id" }
+            $0.timeZone = .utc
         } operation: {
             super.invokeTest()
         }


### PR DESCRIPTION
This moves a few simple env variable dependencies and loadSPIManifest over to `EnvironmentClient`. It also replaces `Current.timeZone` with the built-in `timeZone` dependency.