### PR TITLE
Fix for prod crash when accessing custom package collection

### DIFF
--- a/Sources/App/Controllers/CustomCollectionsController.swift
+++ b/Sources/App/Controllers/CustomCollectionsController.swift
@@ -32,6 +32,7 @@ enum CustomCollectionsController {
             .field(Version.self, \.$packageName)
             .filter(CustomCollection.self, \.$key == key)
             .sort(Repository.self, \.$name)
+            .field(\.$scoreDetails)
             .page(page, size: pageSize)
     }
 


### PR DESCRIPTION
I'll self-merge and add a regression test separately and look into how this broke after deploying the fix. As it is right now, this should _always_ be crashing but it definitely wasn't previously.

I've reproduced the crash locally and that this change fixes it.

Fixes #3618.