### PR TITLE
Restore standard indentation in SiteURL

### DIFF
--- a/Sources/App/Core/SiteURL.swift
+++ b/Sources/App/Core/SiteURL.swift
@@ -40,47 +40,47 @@ enum Api: Resourceable, Sendable {
 
     var path: String {
         switch self {
-        case let .builds(.value(id), next):
-            return "builds/\(id.uuidString)/\(next.path)"
-        case .builds(.key, _):
-            fatalError("path must not be called with a name parameter")
-        case .dependencies:
-            return "dependencies"
-        case let .packages(.value(owner), .value(repo), next):
-            return "packages/\(owner)/\(repo)/\(next.path)"
-        case .packages:
-            fatalError("path must not be called with a name parameter")
-        case .packageCollections:
-            return "package-collections"
-        case .version:
-            return "version"
-        case let .versions(.value(id), next):
-            return "versions/\(id.uuidString)/\(next.path)"
-        case .versions(.key, _):
-            fatalError("path must not be called with a name parameter")
-        case .search:
-            return "search"
+            case let .builds(.value(id), next):
+                return "builds/\(id.uuidString)/\(next.path)"
+            case .builds(.key, _):
+                fatalError("path must not be called with a name parameter")
+            case .dependencies:
+                return "dependencies"
+            case let .packages(.value(owner), .value(repo), next):
+                return "packages/\(owner)/\(repo)/\(next.path)"
+            case .packages:
+                fatalError("path must not be called with a name parameter")
+            case .packageCollections:
+                return "package-collections"
+            case .version:
+                return "version"
+            case let .versions(.value(id), next):
+                return "versions/\(id.uuidString)/\(next.path)"
+            case .versions(.key, _):
+                fatalError("path must not be called with a name parameter")
+            case .search:
+                return "search"
         }
     }
 
     var pathComponents: [PathComponent] {
         switch self {
-        case let .builds(.key, remainder):
-            return ["builds", ":id"] + remainder.pathComponents
-        case .builds(.value, _):
-            fatalError("pathComponents must not be called with a value parameter")
-        case let .packages(.key, .key, remainder):
-            return ["packages", ":owner", ":repository"] + remainder.pathComponents
-        case .packages:
-            fatalError("pathComponents must not be called with a value parameter")
-        case .packageCollections:
-            return ["package-collections"]
-        case .dependencies, .search, .version:
-            return [.init(stringLiteral: path)]
-        case let .versions(.key, remainder):
-            return ["versions", ":id"] + remainder.pathComponents
-        case .versions(.value, _):
-            fatalError("pathComponents must not be called with a value parameter")
+            case let .builds(.key, remainder):
+                return ["builds", ":id"] + remainder.pathComponents
+            case .builds(.value, _):
+                fatalError("pathComponents must not be called with a value parameter")
+            case let .packages(.key, .key, remainder):
+                return ["packages", ":owner", ":repository"] + remainder.pathComponents
+            case .packages:
+                fatalError("pathComponents must not be called with a value parameter")
+            case .packageCollections:
+                return ["package-collections"]
+            case .dependencies, .search, .version:
+                return [.init(stringLiteral: path)]
+            case let .versions(.key, remainder):
+                return ["versions", ":id"] + remainder.pathComponents
+            case .versions(.value, _):
+                fatalError("pathComponents must not be called with a value parameter")
         }
     }
 
@@ -141,216 +141,216 @@ enum SiteURL: Resourceable, Sendable {
 
     var path: String {
         switch self {
-        case .addAPackage:
-            return "add-a-package"
+            case .addAPackage:
+                return "add-a-package"
 
-        case let .api(next):
-            return "api/\(next.path)"
+            case let .api(next):
+                return "api/\(next.path)"
 
-        case let .author(.value(owner)):
-            return owner
+            case let .author(.value(owner)):
+                return owner
 
-        case .author:
-            fatalError("invalid path: \(self)")
+            case .author:
+                fatalError("invalid path: \(self)")
 
-        case .blog:
-            return "blog"
+            case .blog:
+                return "blog"
 
-        case .blogFeed:
-            return "blog/feed.xml"
+            case .blogFeed:
+                return "blog/feed.xml"
 
-        case let .blogPost(.value(slug)):
-            return "blog/\(slug)"
+            case let .blogPost(.value(slug)):
+                return "blog/\(slug)"
 
-        case .blogPost:
-            fatalError("invalid path: \(self)")
+            case .blogPost:
+                fatalError("invalid path: \(self)")
 
-        case let .builds(.value(id)):
-            return "builds/\(id.uuidString)"
+            case let .builds(.value(id)):
+                return "builds/\(id.uuidString)"
 
-        case .builds(.key):
-            fatalError("invalid path: \(self)")
+            case .builds(.key):
+                fatalError("invalid path: \(self)")
 
-        case .buildMonitor:
-            return "build-monitor"
+            case .buildMonitor:
+                return "build-monitor"
 
-        case let .collections(.value(key)):
-            return "collections/\(key.urlPathEncoded)"
+            case let .collections(.value(key)):
+                return "collections/\(key.urlPathEncoded)"
 
-        case .collections(.key):
-            fatalError("invalid path: \(self)")
+            case .collections(.key):
+                fatalError("invalid path: \(self)")
 
-        case let .docs(next):
-            return "docs/\(next.path)"
+            case let .docs(next):
+                return "docs/\(next.path)"
 
-        case .faq:
-            return "faq"
+            case .faq:
+                return "faq"
 
-        case .home:
-            return ""
+            case .home:
+                return ""
 
-        case let .images(name):
-            return "images/\(name)"
+            case let .images(name):
+                return "images/\(name)"
 
-        case let .javascripts(name):
-            return "/\(name).js"
+            case let .javascripts(name):
+                return "/\(name).js"
 
-        case let .keywords(.value(keyword)):
-            return "keywords/\(keyword)"
+            case let .keywords(.value(keyword)):
+                return "keywords/\(keyword)"
 
-        case .keywords:
-            fatalError("invalid path: \(self)")
+            case .keywords:
+                fatalError("invalid path: \(self)")
 
-        case let .package(.value(owner), .value(repo), .none):
-            let owner = owner.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? owner
-            let repo = repo.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? repo
-            return "\(owner)/\(repo)"
+            case let .package(.value(owner), .value(repo), .none):
+                let owner = owner.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? owner
+                let repo = repo.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? repo
+                return "\(owner)/\(repo)"
 
-        case let .package(owner, repo, .some(next)):
-            return "\(Self.package(owner, repo, .none).path)/\(next.path)"
+            case let .package(owner, repo, .some(next)):
+                return "\(Self.package(owner, repo, .none).path)/\(next.path)"
 
-        case .package:
-            fatalError("invalid path: \(self)")
+            case .package:
+                fatalError("invalid path: \(self)")
 
-        case let .packageCollectionKeyword(.value(keyword)):
-            return "keywords/\(keyword)/collection.json"
+            case let .packageCollectionKeyword(.value(keyword)):
+                return "keywords/\(keyword)/collection.json"
 
-        case .packageCollectionKeyword(.key):
-            fatalError("invalid path: \(self)")
+            case .packageCollectionKeyword(.key):
+                fatalError("invalid path: \(self)")
 
-        case let .packageCollectionAuthor(.value(owner)):
-            return "\(owner)/collection.json"
+            case let .packageCollectionAuthor(.value(owner)):
+                return "\(owner)/collection.json"
 
-        case .packageCollectionAuthor(.key):
-            fatalError("invalid path: \(self)")
+            case .packageCollectionAuthor(.key):
+                fatalError("invalid path: \(self)")
 
-        case let .packageCollectionCustom(.value(key)):
-            return "collections/\(key.urlPathEncoded)/collection.json"
+            case let .packageCollectionCustom(.value(key)):
+                return "collections/\(key.urlPathEncoded)/collection.json"
 
-        case .packageCollectionCustom(.key):
-            fatalError("invalid path: \(self)")
+            case .packageCollectionCustom(.key):
+                fatalError("invalid path: \(self)")
 
-        case .packageCollections:
-            return "package-collections"
+            case .packageCollections:
+                return "package-collections"
 
-        case .privacy:
-            return "privacy"
+            case .privacy:
+                return "privacy"
 
-        case .readyForSwift6:
-            return "ready-for-swift-6"
+            case .readyForSwift6:
+                return "ready-for-swift-6"
 
-        case .rssPackages:
-            return "packages.rss"
+            case .rssPackages:
+                return "packages.rss"
 
-        case .rssReleases:
-            return "releases.rss"
+            case .rssReleases:
+                return "releases.rss"
 
-        case .search:
-            return "search"
+            case .search:
+                return "search"
 
-        case .siteMapIndex:
-            return "sitemap.xml"
+            case .siteMapIndex:
+                return "sitemap.xml"
 
-        case .siteMapStaticPages:
-            return "sitemap-static-pages.xml"
+            case .siteMapStaticPages:
+                return "sitemap-static-pages.xml"
 
-        case .supporters:
-            return "supporters"
+            case .supporters:
+                return "supporters"
 
-        case let .stylesheets(name):
-            return "/\(name).css"
+            case let .stylesheets(name):
+                return "/\(name).css"
 
-        case .tryInPlayground:
-            return "try-in-a-playground"
+            case .tryInPlayground:
+                return "try-in-a-playground"
 
-        case .healthCheck:
-            return "health-check"
+            case .healthCheck:
+                return "health-check"
 
-        case .validateSPIManifest:
-            return "validate-spi-manifest"
+            case .validateSPIManifest:
+                return "validate-spi-manifest"
         }
     }
 
     var pathComponents: [PathComponent] {
         switch self {
-        case .addAPackage,
-                .blog,
-                .buildMonitor,
-                .faq,
-                .home,
-                .packageCollections,
-                .privacy,
-                .readyForSwift6,
-                .rssPackages,
-                .rssReleases,
-                .search,
-                .siteMapIndex,
-                .siteMapStaticPages,
-                .supporters,
-                .tryInPlayground,
-                .healthCheck,
-                .validateSPIManifest:
-            return [.init(stringLiteral: path)]
+            case .addAPackage,
+                    .blog,
+                    .buildMonitor,
+                    .faq,
+                    .home,
+                    .packageCollections,
+                    .privacy,
+                    .readyForSwift6,
+                    .rssPackages,
+                    .rssReleases,
+                    .search,
+                    .siteMapIndex,
+                    .siteMapStaticPages,
+                    .supporters,
+                    .tryInPlayground,
+                    .healthCheck,
+                    .validateSPIManifest:
+                return [.init(stringLiteral: path)]
 
-        case let .api(next):
-            return ["api"] + next.pathComponents
+            case let .api(next):
+                return ["api"] + next.pathComponents
 
-        case .author:
-            return [":owner"]
+            case .author:
+                return [":owner"]
 
-        case .blogFeed:
-            return ["blog", "feed.xml"]
+            case .blogFeed:
+                return ["blog", "feed.xml"]
 
-        case .blogPost:
-            return ["blog", ":slug"]
+            case .blogPost:
+                return ["blog", ":slug"]
 
-        case .builds(.key):
-            return ["builds", ":id"]
+            case .builds(.key):
+                return ["builds", ":id"]
 
-        case .builds(.value):
-            fatalError("pathComponents must not be called with a value parameter")
+            case .builds(.value):
+                fatalError("pathComponents must not be called with a value parameter")
 
-        case .collections(.key):
-            return ["collections", ":key"]
+            case .collections(.key):
+                return ["collections", ":key"]
 
-        case .collections(.value):
-            fatalError("pathComponents must not be called with a value parameter")
+            case .collections(.value):
+                fatalError("pathComponents must not be called with a value parameter")
 
-        case let .docs(next):
-            return ["docs"] + next.pathComponents
+            case let .docs(next):
+                return ["docs"] + next.pathComponents
 
-        case .keywords:
-            return ["keywords", ":keyword"]
+            case .keywords:
+                return ["keywords", ":keyword"]
 
-        case .package(.key, .key, .none):
-            return [":owner", ":repository"]
+            case .package(.key, .key, .none):
+                return [":owner", ":repository"]
 
-        case let .package(k1, k2, .some(next)):
-            return Self.package(k1, k2, .none).pathComponents + next.pathComponents
+            case let .package(k1, k2, .some(next)):
+                return Self.package(k1, k2, .none).pathComponents + next.pathComponents
 
-        case .package:
-            fatalError("pathComponents must not be called with a value parameter")
+            case .package:
+                fatalError("pathComponents must not be called with a value parameter")
 
-        case .packageCollectionKeyword(.key):
-            return ["keywords", ":keyword", "collection.json"]
+            case .packageCollectionKeyword(.key):
+                return ["keywords", ":keyword", "collection.json"]
 
-        case .packageCollectionKeyword(.value):
-            fatalError("pathComponents must not be called with a value parameter")
+            case .packageCollectionKeyword(.value):
+                fatalError("pathComponents must not be called with a value parameter")
 
-        case .packageCollectionAuthor(.key):
-            return [":owner", "collection.json"]
+            case .packageCollectionAuthor(.key):
+                return [":owner", "collection.json"]
 
-        case .packageCollectionAuthor(.value):
-            fatalError("pathComponents must not be called with a value parameter")
+            case .packageCollectionAuthor(.value):
+                fatalError("pathComponents must not be called with a value parameter")
 
-        case .packageCollectionCustom(.key):
-            return ["collections", ":key", "collection.json"]
+            case .packageCollectionCustom(.key):
+                return ["collections", ":key", "collection.json"]
 
-        case .packageCollectionCustom(.value):
-            fatalError("pathComponents must not be called with a value parameter")
+            case .packageCollectionCustom(.value):
+                fatalError("pathComponents must not be called with a value parameter")
 
-        case .images, .javascripts, .stylesheets:
-            fatalError("invalid resource path for routing - only use in static HTML (DSL)")
+            case .images, .javascripts, .stylesheets:
+                fatalError("invalid resource path for routing - only use in static HTML (DSL)")
         }
     }
 


### PR DESCRIPTION
I don't know what was going wrong with my Xcode in #3609, but it was indenting SiteURL all wrong. I've not changed this option since installing Xcode, but it got it wrong when I submitted #3609. 🙄

![Screenshot 2025-02-05 at 09 56 11@2x](https://github.com/user-attachments/assets/c2e6af4b-98ef-4dac-9f27-841e432e3968)
