### PR TITLE
Issue 3655 swift testing part 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install unzip
         run: apt-get update && apt-get install -y unzip
       - name: Run tests
-        run: cp .env.testing.template .env.testing && make test
+        run: cp .env.testing.template .env.testing && make test-plain
         env:
           COLLECTION_SIGNING_PRIVATE_KEY: ${{ secrets.COLLECTION_SIGNING_PRIVATE_KEY }}
           DATABASE_HOST: postgres

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ run:
 	swift run
 
 test-plain:
-	swift test --disable-automatic-resolution --sanitize=thread
+	swift test --disable-automatic-resolution --sanitize=thread --no-parallel
 
 test: xcbeautify
 	set -o pipefail \

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ build:
 run:
 	swift run
 
+test-plain:
+	swift test --disable-automatic-resolution --sanitize=thread
+
 test: xcbeautify
 	set -o pipefail \
 	&& swift test --disable-automatic-resolution --sanitize=thread \

--- a/Package.swift
+++ b/Package.swift
@@ -94,7 +94,6 @@ let package = Package(
                 swiftSettings: swiftSettings),
         .testTarget(name: "AppTests",
                     dependencies: [
-                        .product(name: "DependenciesTestSupport", package: "swift-dependencies"),
                         .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
                         .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
                         .product(name: "XCTVapor", package: "vapor"),

--- a/Package.swift
+++ b/Package.swift
@@ -94,6 +94,7 @@ let package = Package(
                 swiftSettings: swiftSettings),
         .testTarget(name: "AppTests",
                     dependencies: [
+                        .product(name: "DependenciesTestSupport", package: "swift-dependencies"),
                         .product(name: "SnapshotTesting", package: "swift-snapshot-testing"),
                         .product(name: "InlineSnapshotTesting", package: "swift-snapshot-testing"),
                         .product(name: "XCTVapor", package: "vapor"),

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -180,7 +180,7 @@ extension Analyze {
         // 2024-10-05 sas: We need to explicitly weave dependencies into the `transaction` closure, because escaping closures strip them.
         // https://github.com/pointfreeco/swift-dependencies/discussions/283#discussioncomment-10846172
         // This might not be needed in Vapor 5 / FluentKit 2
-        // TODO: verify this is still needed once we upgrade to Vapor 5 / FluentKit 2
+        // TODO: verify if this is still needed once we upgrade to Vapor 5 / FluentKit 2
         try await withEscapedDependencies { dependencies in
             try await database.transaction { tx in
                 try await dependencies.yield {

--- a/Tests/AppTests/AnalyzeErrorTests.swift
+++ b/Tests/AppTests/AnalyzeErrorTests.swift
@@ -12,56 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import Testing
-
 @testable import App
 
 import Dependencies
 import Fluent
 import ShellOut
-
-
-#warning("Move this")
+import Testing
 import Vapor
-private func withApp(_ setup: (Application) async throws -> Void = { _ in },
-                     _ updateValuesForOperation: (inout DependencyValues) async throws -> Void = { _ in },
-                     _ logHandler: LogHandler? = nil,
-                     environment: Environment = .testing,
-                     _ test: (Application) async throws -> Void) async throws {
-    try await AppTestCase.setupDb(environment)
-    let app = try await AppTestCase.setupApp(environment)
-
-    return try await run {
-        try await setup(app)
-        try await withDependencies(updateValuesForOperation) {
-            let logger = logHandler.map { handler in Logger(label: "test", factory: { _ in handler }) }
-            try await withDependencies {
-                if let logger {
-                    $0.logger.set(to: logger)
-                }
-            } operation: {
-                try await test(app)
-            }
-        }
-    } defer: {
-        try await app.asyncShutdown()
-    }
-}
-
-
-
-private func defaultShellRun(command: ShellOutCommand, path: String) throws -> String {
-    switch command {
-        case .swiftDumpPackage where path.hasSuffix("foo-1"):
-            return packageSwift1
-
-        case .swiftDumpPackage where path.hasSuffix("foo-2"):
-            return packageSwift2
-
-        default:
-            return ""
-    }
-}
 
 
 // Test analysis error handling.
@@ -253,6 +210,20 @@ extension AnalyzeErrorTests {
             """
             ])
         }
+    }
+}
+
+
+private func defaultShellRun(command: ShellOutCommand, path: String) throws -> String {
+    switch command {
+        case .swiftDumpPackage where path.hasSuffix("foo-1"):
+            return packageSwift1
+
+        case .swiftDumpPackage where path.hasSuffix("foo-2"):
+            return packageSwift2
+
+        default:
+            return ""
     }
 }
 

--- a/Tests/AppTests/AnalyzeErrorTests.swift
+++ b/Tests/AppTests/AnalyzeErrorTests.swift
@@ -17,7 +17,6 @@ import Testing
 @testable import App
 
 import Dependencies
-import DependenciesTestSupport
 import Fluent
 import ShellOut
 

--- a/Tests/AppTests/AnalyzeErrorTests.swift
+++ b/Tests/AppTests/AnalyzeErrorTests.swift
@@ -242,7 +242,7 @@ extension AnalyzeErrorTests {
 }
 
 
-let packageSwift1 = #"""
+private let packageSwift1 = #"""
                     {
                       "name": "foo-1",
                       "products": [
@@ -258,7 +258,7 @@ let packageSwift1 = #"""
                     }
                     """#
 
-let packageSwift2 = #"""
+private let packageSwift2 = #"""
                     {
                       "name": "foo-2",
                       "products": [

--- a/Tests/AppTests/Helpers/CapturingLogger.swift
+++ b/Tests/AppTests/Helpers/CapturingLogger.swift
@@ -22,6 +22,7 @@ struct CapturingLogger: LogHandler {
     }
 
     var logs = QueueIsolated<[LogEntry]>([])
+    var logLevel: Logger.Level = .warning
 
     func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, source: String, file: String, function: String, line: UInt) {
         logs.withValue { logs in
@@ -39,8 +40,7 @@ struct CapturingLogger: LogHandler {
         set { }
     }
 
-    var logLevel: Logger.Level {
-        get { return .warning }
-        set { }
+    func reset() {
+        logs.withValue { $0 = [] }
     }
 }

--- a/Tests/AppTests/Helpers/TestSupport.swift
+++ b/Tests/AppTests/Helpers/TestSupport.swift
@@ -1,0 +1,44 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+@testable import App
+
+import Dependencies
+import Vapor
+
+
+func withApp(_ setup: (Application) async throws -> Void = { _ in },
+             _ updateValuesForOperation: (inout DependencyValues) async throws -> Void = { _ in },
+             _ logHandler: LogHandler? = nil,
+             environment: Environment = .testing,
+             _ test: (Application) async throws -> Void) async throws {
+    try await AppTestCase.setupDb(environment)
+    let app = try await AppTestCase.setupApp(environment)
+
+    return try await run {
+        try await setup(app)
+        try await withDependencies(updateValuesForOperation) {
+            let logger = logHandler.map { handler in Logger(label: "test", factory: { _ in handler }) }
+            try await withDependencies {
+                if let logger {
+                    $0.logger.set(to: logger)
+                }
+            } operation: {
+                try await test(app)
+            }
+        }
+    } defer: {
+        try await app.asyncShutdown()
+    }
+}


### PR DESCRIPTION
This converts `AnalyzeErrorTests` to Swift Testing.

It was a quite a bit more involved than expected, because `override func invokeTest` does not (yet) have an equivalent in Swift Testing. This should be [possible with Swift 6.1](https://forums.swift.org/t/converting-xctest-invoketest-to-swift-testing/77692/4).

