### PR TITLE
Fix performance issue

### DIFF
--- a/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+Model.swift
+++ b/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+Model.swift
@@ -51,13 +51,13 @@ extension MaintainerInfoIndex {
                                valueToCopy: badgeMarkdown(for: type))
         }
 
-        func packageScoreCategories() -> Node<HTML.BodyContext> {
-            .forEach(0..<scoreCategories.count, { index in
+        static func packageScoreCategories(for categories: [PackageScore]) -> Node<HTML.BodyContext> {
+            return .forEach(0..<categories.count, { index in
                     .div(
                         .class("score-trait"),
-                        .p("\(scoreCategories[index].title)"),
-                        .p("\(scoreCategories[index].score) points"),
-                        .p("\(scoreCategories[index].description)")
+                        .p("\(categories[index].title)"),
+                        .p("\(categories[index].score) points"),
+                        .p("\(categories[index].description)")
                     )
             })
         }
@@ -66,7 +66,7 @@ extension MaintainerInfoIndex {
             "https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/discussions/2591"
         }
 
-        var scoreCategories: [PackageScore] {
+        func scoreCategories() -> [PackageScore] {
             guard let scoreDetails else { return [] }
             return Score.Category.allCases
                 .sorted { $0.title < $1.title }

--- a/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
+++ b/Sources/App/Views/PackageController/MaintainerInfo/MaintainerInfoIndex+View.swift
@@ -70,7 +70,8 @@ enum MaintainerInfoIndex {
         }
 
         override func content() -> Node<HTML.BodyContext> {
-            .div(
+            let scoreCategories = model.scoreCategories()
+            return .div(
                 .h2("Information for \(model.packageName) Maintainers"),
                 .p(
                     .text("Are you the author, or a maintainer of "),
@@ -188,7 +189,7 @@ enum MaintainerInfoIndex {
                         "This package has a total score of \(model.score) points. The Swift Package Index uses package score in combination with the relevancy of a search query to influence the ordering of search results."
                     ),
                     .p(
-                        "The score is currently evaluated based on \(model.scoreCategories.count) traits, and the breakdown of each trait is shown below."
+                        "The score is currently evaluated based on \(scoreCategories.count) traits, and the breakdown of each trait is shown below."
                     ),
                     .div(
                         .class("package-score"),
@@ -196,7 +197,7 @@ enum MaintainerInfoIndex {
                     ),
                     .div(
                         .class("package-score-breakdown"),
-                        model.packageScoreCategories()
+                        Model.packageScoreCategories(for: scoreCategories)
                     ),
                     .p(
                         "The package score is a work in progress. We have an ",

--- a/Tests/AppTests/MaintainerInfoIndexModelTests.swift
+++ b/Tests/AppTests/MaintainerInfoIndexModelTests.swift
@@ -52,12 +52,12 @@ struct MaintainerInfoIndexModelTests {
 
         do {
             model.scoreDetails?.numberOfDependencies = 0
-            let categories = model.scoreCategories
+            let categories = model.scoreCategories()
             #expect(categories["Dependencies"]?.description == "Has no dependencies.")
         }
         do {
             model.scoreDetails?.numberOfDependencies = nil
-            let categories = model.scoreCategories
+            let categories = model.scoreCategories()
             #expect(categories["Dependencies"]?.description == "No dependency information available.")
         }
     }


### PR DESCRIPTION
Fix for slow runtime: more than half the time spent in `WebpageSnapshotTests` was spent in `MaintainerInfoIndex_document` (5s out of 10s on my machine).