### PR TITLE
Simplify logger client 2

### DIFF
--- a/Sources/App/Commands/Alerting.swift
+++ b/Sources/App/Commands/Alerting.swift
@@ -42,8 +42,10 @@ enum Alerting {
         }
 
         func run(using context: CommandContext, signature: Signature) async throws {
+            prepareDependencies {
+                $0.logger = Logger(component: "alerting")
+            }
             @Dependency(\.logger) var logger
-            logger.set(to: Logger(component: "alerting"))
 
             logger.info("Running alerting...")
 

--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -28,10 +28,13 @@ enum Analyze {
         var help: String { "Run package analysis (fetching git repository and inspecting content)" }
 
         func run(using context: CommandContext, signature: SPICommand.Signature) async throws {
+            prepareDependencies {
+                $0.logger = Logger(component: "analyze")
+            }
+            @Dependency(\.logger) var logger
+
             let client = context.application.client
             let db = context.application.db
-            @Dependency(\.logger) var logger
-            logger.set(to: Logger(component: "analyze"))
 
             Analyze.resetMetrics()
 
@@ -251,7 +254,7 @@ extension Analyze {
                                             attributes: nil)
         } catch {
             let error = AppError.genericError(nil, "Failed to create checkouts directory: \(error.localizedDescription)")
-            logger.logger.report(error: error)
+            logger.report(error: error)
         }
     }
 

--- a/Sources/App/Commands/Ingestion.swift
+++ b/Sources/App/Commands/Ingestion.swift
@@ -82,10 +82,13 @@ enum Ingestion {
         var help: String { "Run package ingestion (fetching repository metadata)" }
 
         func run(using context: CommandContext, signature: SPICommand.Signature) async {
+            prepareDependencies {
+                $0.logger = Logger(component: "ingest")
+            }
+            @Dependency(\.logger) var logger
+
             let client = context.application.client
             let db = context.application.db
-            @Dependency(\.logger) var logger
-            logger.set(to: Logger(component: "ingest"))
 
             Self.resetMetrics()
 

--- a/Sources/App/Commands/ReAnalyzeVersions.swift
+++ b/Sources/App/Commands/ReAnalyzeVersions.swift
@@ -43,14 +43,16 @@ enum ReAnalyzeVersions {
         var help: String { "Run version re-analysis" }
 
         func run(using context: CommandContext, signature: Signature) async throws {
-            let limit = signature.limit ?? defaultLimit
+            prepareDependencies {
+                $0.logger = Logger(component: "re-analyze-versions")
+            }
+            @Dependency(\.logger) var logger
+            @Dependency(\.date.now) var now
 
+            let limit = signature.limit ?? defaultLimit
             let client = context.application.client
             let db = context.application.db
-            @Dependency(\.logger) var logger
-            logger.set(to: Logger(component: "re-analyze-versions"))
 
-            @Dependency(\.date.now) var now
             if let id = signature.packageId {
                 logger.info("Re-analyzing versions (id: \(id)) ...")
                 do {

--- a/Sources/App/Commands/Reconcile.swift
+++ b/Sources/App/Commands/Reconcile.swift
@@ -23,14 +23,15 @@ struct ReconcileCommand: AsyncCommand {
     var help: String { "Reconcile package list with server" }
 
     func run(using context: CommandContext, signature: Signature) async throws {
+        prepareDependencies{
+            $0.logger = Logger(component: "reconcile")
+        }
         @Dependency(\.logger) var logger
-        logger.set(to: Logger(component: "reconcile"))
 
         logger.info("Reconciling...")
 
         do {
-            try await reconcile(client: context.application.client,
-                                database: context.application.db)
+            try await reconcile(client: context.application.client, database: context.application.db)
         } catch {
             logger.error("\(error)")
         }
@@ -38,8 +39,7 @@ struct ReconcileCommand: AsyncCommand {
         logger.info("done.")
 
         do {
-            try await AppMetrics.push(client: context.application.client,
-                                      jobName: "reconcile")
+            try await AppMetrics.push(client: context.application.client, jobName: "reconcile")
         } catch {
             logger.warning("\(error)")
         }

--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -55,8 +55,10 @@ struct TriggerBuildsCommand: AsyncCommand {
     }
 
     func run(using context: CommandContext, signature: Signature) async throws {
+        prepareDependencies {
+            $0.logger = Logger(component: "trigger-builds")
+        }
         @Dependency(\.logger) var logger
-        logger.set(to: Logger(component: "trigger-builds"))
 
         Self.resetMetrics()
 

--- a/Sources/App/Core/Dependencies/ShellClient.swift
+++ b/Sources/App/Core/Dependencies/ShellClient.swift
@@ -42,7 +42,7 @@ extension ShellClient: DependencyKey {
             run: { command, path in
                 @Dependency(\.logger) var logger
                 do {
-                    let res = try await ShellOut.shellOut(to: command, at: path, logger: logger.logger)
+                    let res = try await ShellOut.shellOut(to: command, at: path, logger: logger)
                     if !res.stderr.isEmpty {
                         logger.warning("stderr: \(res.stderr)")
                     }

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -27,9 +27,7 @@ public func configure(_ app: Application, databasePort: Int? = nil) async throws
     let _ = Bundle(path: "/Applications/InjectionIII.app/Contents/Resources/macOSInjection.bundle")?.load()
     #endif
 
-    @Dependency(\.logger) var logger
     app.logger.component = "server"
-    logger.set(to: app.logger)
 
     // It will be tempting to uncomment/re-add these lines in the future. We should not enable
     // server-side compression as long as we pass requests through Cloudflare, which compresses

--- a/Sources/Run/entrypoint.swift
+++ b/Sources/Run/entrypoint.swift
@@ -13,10 +13,8 @@
 // limitations under the License.
 
 import App
-import Dependencies
 import Logging
 import Vapor
-
 
 @main
 enum Entrypoint {
@@ -25,10 +23,6 @@ enum Entrypoint {
         try LoggingSystem.bootstrap(from: &env)
 
         let app = try await Application.make(env)
-
-        prepareDependencies {
-            $0.logger = app.logger
-        }
 
         do {
             try await configure(app)

--- a/Sources/Run/entrypoint.swift
+++ b/Sources/Run/entrypoint.swift
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 import App
+import Dependencies
 import Logging
 import Vapor
+
 
 @main
 enum Entrypoint {
@@ -23,6 +25,10 @@ enum Entrypoint {
         try LoggingSystem.bootstrap(from: &env)
 
         let app = try await Application.make(env)
+
+        prepareDependencies {
+            $0.logger = app.logger
+        }
 
         do {
             try await configure(app)

--- a/Tests/AppTests/AnalyzeErrorTests.swift
+++ b/Tests/AppTests/AnalyzeErrorTests.swift
@@ -66,7 +66,7 @@ extension AllTests.AnalyzeErrorTests {
             try await withDependencies {
                 $0.environment.loadSPIManifest = { _ in nil }
                 $0.fileManager.fileExists = { @Sendable _ in true }
-                $0.logger.set(to: capturingLogger)
+                $0.logger = .testLogger(capturingLogger)
                 $0.shell.run = { @Sendable cmd, path in
                     switch cmd {
                         case _ where cmd.description.contains("git clone https://github.com/foo/1"):
@@ -100,7 +100,7 @@ extension AllTests.AnalyzeErrorTests {
             try await withDependencies {
                 $0.environment.loadSPIManifest = { _ in nil }
                 $0.fileManager.fileExists = { @Sendable _ in true }
-                $0.logger.set(to: capturingLogger)
+                $0.logger = .testLogger(capturingLogger)
             } operation: {
                 // setup
                 let pkg = try await Package.find(badPackageID, on: app.db).unwrap()
@@ -130,7 +130,7 @@ extension AllTests.AnalyzeErrorTests {
             try await withDependencies {
                 $0.environment.loadSPIManifest = { _ in nil }
                 $0.fileManager.fileExists = { @Sendable _ in true }
-                $0.logger.set(to: capturingLogger)
+                $0.logger = .testLogger(capturingLogger)
                 $0.shell.run = { @Sendable cmd, path in
                     switch cmd {
                         case .gitCheckout(branch: "main", quiet: true) where path.hasSuffix("foo-1"):
@@ -166,7 +166,7 @@ extension AllTests.AnalyzeErrorTests {
                     }
                     return true
                 }
-                $0.logger.set(to: capturingLogger)
+                $0.logger = .testLogger(capturingLogger)
             } operation: {
                 // MUT
                 try await Analyze.analyze(client: app.client,

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -1059,6 +1059,7 @@ extension AllTests.AnalyzerTests {
         // points to the correct version of Xcode!
         try await withDependencies {
             $0.fileManager.fileExists = FileManagerClient.liveValue.fileExists(atPath:)
+            $0.logger = .noop
             $0.shell = .liveValue
         } operation: {
             // setup
@@ -1080,6 +1081,7 @@ extension AllTests.AnalyzerTests {
         // See also https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/1441
         try await withDependencies {
             $0.fileManager.fileExists = FileManagerClient.liveValue.fileExists(atPath:)
+            $0.logger = .noop
             $0.shell = .liveValue
         } operation: {
             // setup
@@ -1100,6 +1102,7 @@ extension AllTests.AnalyzerTests {
         // points to the correct version of Xcode!
         try await withDependencies {
             $0.fileManager.fileExists = FileManagerClient.liveValue.fileExists(atPath:)
+            $0.logger = .noop
             $0.shell = .liveValue
         } operation: {
             // setup
@@ -1126,6 +1129,9 @@ extension AllTests.AnalyzerTests {
         // NB: If this test fails on macOS make sure xcode-select -p
         // points to the correct version of Xcode!
         // setup
+        try await withDependencies {
+            $0.logger = .noop
+        } operation: {
         try await withTempDir { @Sendable tempDir in
             let fixture = fixturesDirectory()
                 .appendingPathComponent("5.9-Package-swift").path
@@ -1148,6 +1154,7 @@ extension AllTests.AnalyzerTests {
             assertSnapshot(of: json, as: .init(pathExtension: "json", diffing: .lines), named: "linux")
 #endif
         }
+    }
     }
 
     @Test func issue_577() async throws {

--- a/Tests/AppTests/AnalyzerTests.swift
+++ b/Tests/AppTests/AnalyzerTests.swift
@@ -1456,7 +1456,7 @@ extension AllTests.AnalyzerTests {
                 1\tPerson 2
                 """
                 }
-                $0.logger.set(to: capturingLogger)
+                $0.logger = .testLogger(capturingLogger)
                 $0.shell.run = { @Sendable _, _ in return "" }
             } operation: {
                 let pkgId = UUID()

--- a/Tests/AppTests/ErrorReportingTests.swift
+++ b/Tests/AppTests/ErrorReportingTests.swift
@@ -44,7 +44,7 @@ extension AllTests.ErrorReportingTests {
             try await withDependencies {
                 $0.date.now = .now
                 $0.github.fetchMetadata = { @Sendable _, _ throws(Github.Error) in throw Github.Error.invalidURL("1") }
-                $0.logger.set(to: capturingLogger)
+                $0.logger = .testLogger(capturingLogger)
             } operation: {
                 // MUT
                 try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(10))
@@ -63,7 +63,7 @@ extension AllTests.ErrorReportingTests {
             let capturingLogger = CapturingLogger()
             try await withDependencies {
                 $0.fileManager.fileExists = { @Sendable _ in true }
-                $0.logger.set(to: capturingLogger)
+                $0.logger = .testLogger(capturingLogger)
                 $0.shell.run = { @Sendable cmd, _ in
                     if cmd.description == "git tag" { return "1.0.0" }
                     // returning a blank string will cause an exception when trying to

--- a/Tests/AppTests/GithubTests.swift
+++ b/Tests/AppTests/GithubTests.swift
@@ -178,6 +178,7 @@ extension AllTests.GithubTests {
         await withDependencies {
             $0.github.token = { "secr3t" }
             $0.httpClient.post = { @Sendable _, _, _ in .badRequest }
+            $0.logger = .noop
         } operation: {
             do {
                 _ = try await Github.fetchMetadata(owner: "alamofire",
@@ -219,6 +220,7 @@ extension AllTests.GithubTests {
         await withDependencies {
             $0.github.token = { "secr3t" }
             $0.httpClient.post = { @Sendable _, _, _ in .tooManyRequests }
+            $0.logger = .noop
         } operation: {
             // MUT
             do {
@@ -273,7 +275,7 @@ extension AllTests.GithubTests {
             $0.httpClient.post = { @Sendable _, _, _ in
                     .init(status: .forbidden, headers: ["X-RateLimit-Remaining": "0"])
             }
-            $0.logger.set(to: capturingLogger)
+            $0.logger = .testLogger(capturingLogger)
         } operation: {
             // MUT
             do {
@@ -367,6 +369,7 @@ extension AllTests.GithubTests {
         await withDependencies {
             $0.github.token = { "secr3t" }
             $0.httpClient.get = { @Sendable _, headers in .notFound }
+            $0.logger = .noop
         } operation: {
             // MUT
             let res = await Github.fetchReadme(owner: "foo", repository: "bar")

--- a/Tests/AppTests/GitlabBuilderTests.swift
+++ b/Tests/AppTests/GitlabBuilderTests.swift
@@ -82,6 +82,7 @@ extension AllTests.GitlabBuilderTests {
                 )
                 return try .created(jsonEncode: Gitlab.Builder.Response(webUrl: "http://web_url"))
             }
+            $0.logger = .noop
         } operation: {
             // MUT
             _ = try await Gitlab.Builder.triggerBuild(buildId: buildId,
@@ -112,6 +113,7 @@ extension AllTests.GitlabBuilderTests {
                 #expect(swiftVersion == "6.0")
                 return try .created(jsonEncode: Gitlab.Builder.Response(webUrl: "http://web_url"))
             }
+            $0.logger = .noop
         } operation: {
             // MUT
             _ = try await Gitlab.Builder.triggerBuild(buildId: .id0,

--- a/Tests/AppTests/Helpers/TestSupport.swift
+++ b/Tests/AppTests/Helpers/TestSupport.swift
@@ -23,6 +23,10 @@ func withApp(_ setup: (Application) async throws -> Void = { _ in },
              _ updateValuesForOperation: (inout DependencyValues) async throws -> Void = { _ in },
              environment: Environment = .testing,
              _ test: (Application) async throws -> Void) async throws {
+    prepareDependencies {
+        $0.logger = .noop
+    }
+
     try await TestSupport.setupDb(environment)
     let app = try await TestSupport.setupApp(environment)
 
@@ -47,10 +51,6 @@ enum TestSupport {
     static func setupApp(_ environment: Environment, databasePort: Int? = nil) async throws -> Application {
         let app = try await Application.make(environment)
         try await configure(app, databasePort: databasePort)
-
-        // Silence app logging
-        app.logger = .init(label: "noop") { _ in SwiftLogNoOpLogHandler() }
-
         return app
     }
 

--- a/Tests/AppTests/IngestionTests.swift
+++ b/Tests/AppTests/IngestionTests.swift
@@ -413,7 +413,7 @@ extension AllTests.IngestionTests {
                         summary: "desc")
                 }
                 $0.github.fetchReadme = { @Sendable _, _ in nil }
-                $0.logger.set(to: capturingLogger)
+                $0.logger = .testLogger(capturingLogger)
             } operation: {
                 // MUT
                 try await Ingestion.ingest(client: app.client, database: app.db, mode: .limit(10))


### PR DESCRIPTION
This is actually a required change in order to run tests concurrently successfully.

Trying to pull this change forward with a few fixes that hopefully allow it to work on CI as well now.

Superseedes #3672

To do:

- [x] ad hoc deploy to dev
- [x] check logs are ok