### PR TITLE
Build with Swift 6.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/finestructure/spi-base:1.1.1
+FROM registry.gitlab.com/finestructure/spi-base:1.2.0
 
 # Install SPM build dependencies
 RUN apt-get update && apt-get install -y curl git make unzip \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1.1.1
+      image: registry.gitlab.com/finestructure/spi-base:1.2.0
       options: --privileged
     services:
       postgres:
@@ -64,7 +64,7 @@ jobs:
     name: Release build
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1.1.1
+      image: registry.gitlab.com/finestructure/spi-base:1.2.0
       options: --privileged
     steps:
       - name: GH Runner bug workaround

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1.1.1
+      image: registry.gitlab.com/finestructure/spi-base:1.2.0
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # ================================
 # Build image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:1.1.1 as build
+FROM registry.gitlab.com/finestructure/spi-base:1.2.0 as build
 
 # Set up a build area
 WORKDIR /build
@@ -61,7 +61,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:1.1.1
+FROM registry.gitlab.com/finestructure/spi-base:1.2.0
 
 # NB sas 2022-09-23: We're not using a dedicated `vapor` user to run the executable, because it
 # makes managing the data in the checkouts volume difficult. See

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -236,7 +236,7 @@ The trickiest part of this is to ensure the test or app container can connect to
 So, in order to run the tests in a Linux container run:
 
 ```
-docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:1.1.1 swift test
+docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:1.2.0 swift test
 ```
 
 Make sure you use the most recent `spi-base` image. You can find the latest image name in the `test-docker` target, which also provides a convenient way to run all all tests in a docker container.

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-docker:
 	@# run tests inside a docker container
 	docker run --rm -v "$(PWD)":/host -w /host \
 	  --add-host=host.docker.internal:host-gateway \
-	  registry.gitlab.com/finestructure/spi-base:1.1.1 \
+	  registry.gitlab.com/finestructure/spi-base:1.2.0 \
 	  make test
 
 test-e2e: db-reset reconcile ingest analyze

--- a/Tests/AppTests/AllTests.swift
+++ b/Tests/AppTests/AllTests.swift
@@ -15,12 +15,14 @@
 @testable import App
 
 import Dependencies
+import SnapshotTesting
 import Testing
 
 
 @Suite(
     .dependency(\.date.now, .t0),
-    .dependency(\.metricsSystem, .mock)
+    .dependency(\.metricsSystem, .mock),
+    .snapshots(record: .failed)
 ) struct AllTests { }
 
 

--- a/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.linux.json
+++ b/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.linux.json
@@ -21,7 +21,12 @@
                 "upperBound" : "510.0.0"
               }
             ]
-          }
+          },
+          "traits" : [
+            {
+              "name" : "default"
+            }
+          ]
         }
       ]
     }
@@ -204,5 +209,8 @@
   ],
   "toolsVersion" : {
     "_version" : "5.9.0"
-  }
+  },
+  "traits" : [
+
+  ]
 }

--- a/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.macos.json
+++ b/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.macos.json
@@ -21,7 +21,12 @@
                 "upperBound" : "510.0.0"
               }
             ]
-          }
+          },
+          "traits" : [
+            {
+              "name" : "default"
+            }
+          ]
         }
       ]
     }
@@ -210,5 +215,8 @@
   ],
   "toolsVersion" : {
     "_version" : "5.9.0"
-  }
+  },
+  "traits" : [
+
+  ]
 }


### PR DESCRIPTION
This just switches the building and running of spi-server to 6.1.

I'm pulling this forward, because it's needed for parallel testing (and also the Xcode 16.3 update).