### PR TITLE
Revert "Merge pull request #3750 from SwiftPackageIndex/swift-6.1"

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/finestructure/spi-base:1.2.0
+FROM registry.gitlab.com/finestructure/spi-base:1.1.1
 
 # Install SPM build dependencies
 RUN apt-get update && apt-get install -y curl git make unzip \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1.2.0
+      image: registry.gitlab.com/finestructure/spi-base:1.1.1
       options: --privileged
     services:
       postgres:
@@ -64,7 +64,7 @@ jobs:
     name: Release build
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1.2.0
+      image: registry.gitlab.com/finestructure/spi-base:1.1.1
       options: --privileged
     steps:
       - name: GH Runner bug workaround

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1.2.0
+      image: registry.gitlab.com/finestructure/spi-base:1.1.1
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # ================================
 # Build image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:1.2.0 as build
+FROM registry.gitlab.com/finestructure/spi-base:1.1.1 as build
 
 # Set up a build area
 WORKDIR /build
@@ -61,7 +61,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:1.2.0
+FROM registry.gitlab.com/finestructure/spi-base:1.1.1
 
 # NB sas 2022-09-23: We're not using a dedicated `vapor` user to run the executable, because it
 # makes managing the data in the checkouts volume difficult. See

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -236,7 +236,7 @@ The trickiest part of this is to ensure the test or app container can connect to
 So, in order to run the tests in a Linux container run:
 
 ```
-docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:1.2.0 swift test
+docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:1.1.1 swift test
 ```
 
 Make sure you use the most recent `spi-base` image. You can find the latest image name in the `test-docker` target, which also provides a convenient way to run all all tests in a docker container.

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-docker:
 	@# run tests inside a docker container
 	docker run --rm -v "$(PWD)":/host -w /host \
 	  --add-host=host.docker.internal:host-gateway \
-	  registry.gitlab.com/finestructure/spi-base:1.2.0 \
+	  registry.gitlab.com/finestructure/spi-base:1.1.1 \
 	  make test
 
 test-e2e: db-reset reconcile ingest analyze

--- a/Tests/AppTests/AllTests.swift
+++ b/Tests/AppTests/AllTests.swift
@@ -15,14 +15,12 @@
 @testable import App
 
 import Dependencies
-import SnapshotTesting
 import Testing
 
 
 @Suite(
     .dependency(\.date.now, .t0),
-    .dependency(\.metricsSystem, .mock),
-    .snapshots(record: .failed)
+    .dependency(\.metricsSystem, .mock)
 ) struct AllTests { }
 
 

--- a/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.linux.json
+++ b/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.linux.json
@@ -21,12 +21,7 @@
                 "upperBound" : "510.0.0"
               }
             ]
-          },
-          "traits" : [
-            {
-              "name" : "default"
-            }
-          ]
+          }
         }
       ]
     }
@@ -209,8 +204,5 @@
   ],
   "toolsVersion" : {
     "_version" : "5.9.0"
-  },
-  "traits" : [
-
-  ]
+  }
 }

--- a/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.macos.json
+++ b/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.macos.json
@@ -21,12 +21,7 @@
                 "upperBound" : "510.0.0"
               }
             ]
-          },
-          "traits" : [
-            {
-              "name" : "default"
-            }
-          ]
+          }
         }
       ]
     }
@@ -215,8 +210,5 @@
   ],
   "toolsVersion" : {
     "_version" : "5.9.0"
-  },
-  "traits" : [
-
-  ]
+  }
 }


### PR DESCRIPTION
This reverts commit ff657240143a5cf610c0cc4f1be495918d45afa9, reversing changes made to eb22c4489f4b81f4b5a8e1a990877da86de1bab9.

Something is definitely wrong with the 2.117.0 docker image. It deploys and is running according to `docker service ps` but it's not completing the deployment process nor is it accepting connections.