### PR TITLE
Add run 16 results

### DIFF
--- a/Resources/ChartData/rfs6-errors.json
+++ b/Resources/ChartData/rfs6-errors.json
@@ -81,6 +81,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.1 (16B40)",
         "value" : 42140
+      },
+      {
+        "date" : "2025-05-07",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.1 Xcode 16.3 (16E140)",
+        "value" : 55579
       }
     ]
   },
@@ -166,6 +172,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.1 (16B40)",
         "value" : 1298
+      },
+      {
+        "date" : "2025-05-07",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.1 Xcode 16.3 (16E140)",
+        "value" : 4377
       }
     ]
   },
@@ -251,6 +263,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.1 (16B40)",
         "value" : 317
+      },
+      {
+        "date" : "2025-05-07",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.1 Xcode 16.3 (16E140)",
+        "value" : 540
       }
     ]
   }

--- a/Resources/ChartData/rfs6-events.json
+++ b/Resources/ChartData/rfs6-events.json
@@ -38,5 +38,9 @@
     {
         "date": "2024-11-22",
         "value": "Added more Swift build flags"
+    },
+    {
+        "date": "2025-03-31",
+        "value": "Xcode"
     }
 ]

--- a/Resources/ChartData/rfs6-packages.json
+++ b/Resources/ChartData/rfs6-packages.json
@@ -81,6 +81,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.1 (16B40)",
         "value" : 1620
+      },
+      {
+        "date" : "2025-05-07",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.1 Xcode 16.3 (16E140)",
+        "value" : 2027
       }
     ]
   },
@@ -166,6 +172,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.1 (16B40)",
         "value" : 26
+      },
+      {
+        "date" : "2025-05-07",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.1 Xcode 16.3 (16E140)",
+        "value" : 54
       }
     ]
   },
@@ -251,6 +263,12 @@
         "toolchainId" : "com.apple.dt.Xcode",
         "toolchainLabel" : "Swift 6.0 Xcode 16.1 (16B40)",
         "value" : 14
+      },
+      {
+        "date" : "2025-05-07",
+        "toolchainId" : "com.apple.dt.Xcode",
+        "toolchainLabel" : "Swift 6.1 Xcode 16.3 (16E140)",
+        "value" : 31
       }
     ]
   }


### PR DESCRIPTION
I'm not quite sure what to make of the results. It looks like 6.1 fixes at least some of the false positives and the total number of packages with zero warnings has gone up noticeably. However, the total number of errors is also still going up quite noticeably 🤷‍♂️

![CleanShot 2025-05-07 at 09 22 22@2x](https://github.com/user-attachments/assets/a642cd16-3934-4ad8-ae22-9f088211c233)

Unrelated to the values, the graph seems to have stopped showing the month labels on the x axis. Also, I think we should try and suppress the lighter grey vertical month grid lines. There are a lot of vertical lines and I think the event ones should have more prominence.