### PR TITLE
Ready for Swift 6 Chart fixes for extended data

### DIFF
--- a/FrontEnd/scripts/controllers/vega_chart_controller.js
+++ b/FrontEnd/scripts/controllers/vega_chart_controller.js
@@ -320,7 +320,7 @@ class ReadyForSwift6Chart {
                         y: { scale: 'yscale', signal: 'minYScale' },
                         y2: { scale: 'yscale', signal: 'maxYScale' },
                         fill: { value: '#000000' },
-                        opacity: { value: 0.3 },
+                        opacity: { value: 0.1 },
                         tooltip: {
                             signal: 'datum.value',
                         },

--- a/FrontEnd/scripts/controllers/vega_chart_controller.js
+++ b/FrontEnd/scripts/controllers/vega_chart_controller.js
@@ -89,7 +89,6 @@ export class VegaChartController extends Controller {
 
             const labelTextElement = document.createTextNode(dataSet.name)
             labelElement.appendChild(labelTextElement)
-            labelElement.replaceChild
         })
         return formElement
     }

--- a/FrontEnd/scripts/controllers/vega_chart_controller.js
+++ b/FrontEnd/scripts/controllers/vega_chart_controller.js
@@ -235,7 +235,7 @@ class ReadyForSwift6Chart {
             )
         }
 
-        const dates = data.flatMap((dataSet) => dataSet.values.map((element) => element.date))
+        const dates = data.flatMap((dataSet) => dataSet.values.map((element) => new Date(element.date)))
         const minDate = dates.reduce((min, date) => (date < min ? date : min), dates[0])
         const maxDate = dates.reduce((max, date) => (date > max ? date : max), dates[0])
 
@@ -243,7 +243,10 @@ class ReadyForSwift6Chart {
             {
                 name: 'xscale',
                 type: 'time',
-                domain: [{ signal: `datetime("${minDate}")` }, { signal: `datetime("${maxDate}")` }],
+                domain: [
+                    { signal: `datetime(${minDate.getFullYear()}, ${minDate.getMonth()}, ${minDate.getDate()})` },
+                    { signal: `datetime(${maxDate.getFullYear()}, ${maxDate.getMonth()}, ${maxDate.getDate()})` },
+                ],
                 range: 'width',
             },
             {

--- a/FrontEnd/scripts/controllers/vega_chart_controller.js
+++ b/FrontEnd/scripts/controllers/vega_chart_controller.js
@@ -257,7 +257,6 @@ class ReadyForSwift6Chart {
             {
                 orient: 'bottom',
                 scale: 'xscale',
-                grid: true,
                 labelAngle: { value: -45 },
                 labelAlign: { value: 'right' },
             },

--- a/FrontEnd/scripts/controllers/vega_chart_controller.js
+++ b/FrontEnd/scripts/controllers/vega_chart_controller.js
@@ -235,18 +235,11 @@ class ReadyForSwift6Chart {
             )
         }
 
-        const dates = data.flatMap((dataSet) => dataSet.values.map((element) => new Date(element.date)))
-        const minDate = dates.reduce((min, date) => (date < min ? date : min), dates[0])
-        const maxDate = dates.reduce((max, date) => (date > max ? date : max), dates[0])
-
         return [
             {
                 name: 'xscale',
                 type: 'time',
-                domain: [
-                    { signal: `datetime(${minDate.getFullYear()}, ${minDate.getMonth()}, ${minDate.getDate()})` },
-                    { signal: `datetime(${maxDate.getFullYear()}, ${maxDate.getMonth()}, ${maxDate.getDate()})` },
-                ],
+                domain: { fields: data.map((d) => ({ data: d.id, field: 'date' })) },
                 range: 'width',
             },
             {

--- a/FrontEnd/scripts/controllers/vega_chart_controller.js
+++ b/FrontEnd/scripts/controllers/vega_chart_controller.js
@@ -235,11 +235,15 @@ class ReadyForSwift6Chart {
             )
         }
 
+        const dates = data.flatMap((dataSet) => dataSet.values.map((element) => element.date))
+        const minDate = dates.reduce((min, date) => (date < min ? date : min), dates[0])
+        const maxDate = dates.reduce((max, date) => (date > max ? date : max), dates[0])
+
         return [
             {
                 name: 'xscale',
                 type: 'time',
-                domain: [{ signal: 'datetime("2024-05-01")' }, { signal: 'datetime("2024-12-31")' }],
+                domain: [{ signal: `datetime("${minDate}")` }, { signal: `datetime("${maxDate}")` }],
                 range: 'width',
             },
             {

--- a/Resources/ChartData/rfs6-events.json
+++ b/Resources/ChartData/rfs6-events.json
@@ -1,39 +1,39 @@
 [
     {
         "date": "2024-06-10",
-        "value": "Xcode 16 beta 1 released at WWDC '24"
+        "value": "Xcode 16 beta 1 released at WWDC '24 (Swift 6.0)"
     },
     {
         "date": "2024-06-25",
-        "value": "Xcode 16 beta 2 released"
+        "value": "Xcode 16 beta 2 released (Swift 6.0)"
     },
     {
         "date": "2024-07-08",
-        "value": "Xcode 16 beta 3 released"
+        "value": "Xcode 16 beta 3 released (Swift 6.0)"
     },
     {
         "date": "2024-07-23",
-        "value": "Xcode 16 beta 4 released"
+        "value": "Xcode 16 beta 4 released (Swift 6.0)"
     },
     {
         "date": "2024-08-06",
-        "value": "Xcode 16 beta 5 released"
+        "value": "Xcode 16 beta 5 released (Swift 6.0)"
     },
     {
         "date": "2024-08-20",
-        "value": "Xcode 16 beta 6 released"
+        "value": "Xcode 16 beta 6 released (Swift 6.0)"
     },
     {
         "date": "2024-09-09",
-        "value": "Xcode 16 RC released"
+        "value": "Xcode 16 RC released (Swift 6.0)"
     },
     {
         "date": "2024-09-16",
-        "value": "Xcode 16 released"
+        "value": "Xcode 16 released (Swift 6.0)"
     },
     {
         "date": "2024-10-28",
-        "value": "Xcode 16.1 released"
+        "value": "Xcode 16.1 released (Swift 6.0)"
     },
     {
         "date": "2024-11-22",
@@ -41,6 +41,6 @@
     },
     {
         "date": "2025-03-31",
-        "value": "Xcode 16.3 released"
+        "value": "Xcode 16.3 released (Swift 6.1)"
     }
 ]

--- a/Resources/ChartData/rfs6-events.json
+++ b/Resources/ChartData/rfs6-events.json
@@ -41,6 +41,6 @@
     },
     {
         "date": "2025-03-31",
-        "value": "Xcode"
+        "value": "Xcode 16.3 released"
     }
 ]


### PR DESCRIPTION
- [x] X axis now scales based on the min/max dates rather than going to the end of the year
- [x] Removed gridlines that were conflicting with event lines
- [x] Corrected the Xcode 16.3 event label
- [x] Added the Swift version to all event labels now the chart covers multiple Swift versions

![Screenshot 2025-05-08 at 14 50 19@2x](https://github.com/user-attachments/assets/01252cab-6ca8-4ca0-819a-7be75a5803f8)

![Screenshot 2025-05-08 at 14 50 09@2x](https://github.com/user-attachments/assets/12b95cb8-08a6-44a3-8c50-3bf10c0e8968)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - The chart's time axis now automatically adjusts to the range of available data, improving flexibility.
  - X-axis grid lines have been removed for a cleaner chart appearance.
  - Event highlight transparency has been increased for better visual clarity.

- **Data Updates**
  - Xcode release events now display the corresponding Swift version in their descriptions for improved context.
  - Future Xcode release descriptions have been clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->