### PR TITLE
Base data race safety reporting on latest Swift version

### DIFF
--- a/Sources/App/Controllers/API/API+PackageController+BuildInfo.swift
+++ b/Sources/App/Controllers/API/API+PackageController+BuildInfo.swift
@@ -90,7 +90,7 @@ extension API.PackageController {
 
         static func swift6Readiness(builds: [PackageController.BuildsRoute.BuildInfo]) -> Swift6Readiness {
             var readiness = Swift6Readiness()
-            for build in builds where build.swiftVersion == .v6_0 {
+            for build in builds where build.swiftVersion == .latest {
                 readiness.errorCounts[build.platform] = build.buildErrors?.numSwift6Errors
             }
             return readiness


### PR DESCRIPTION
Fixes #3794 

GRDB now correctly reports 9 errors:

![CleanShot 2025-05-12 at 11 06 34@2x](https://github.com/user-attachments/assets/dcda8717-cd79-4ca7-8629-3f87220c2aae)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated build filtering to use the latest Swift version when displaying build readiness information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->