### PR TITLE
Switch to PG 16 + md5 auth

### DIFF
--- a/Tests/AppTests/Helpers/ShellOutCommand+ext.swift
+++ b/Tests/AppTests/Helpers/ShellOutCommand+ext.swift
@@ -22,11 +22,13 @@ extension ShellOutCommand {
             "-e", "POSTGRES_DB=spi_test",
             "-e", "POSTGRES_USER=spi_test",
             "-e", "POSTGRES_PASSWORD=xxx",
+            "-e", "POSTGRES_HOST_AUTH_METHOD=md5",
+            "-e", "POSTGRES_INITDB_ARGS=--auth-host=md5",
             "-e", "PGDATA=/pgdata",
             "--tmpfs", "/pgdata:rw,noexec,nosuid,size=1024m",
             "-p", "\(port):5432",
             "-d",
-            "postgres:13-alpine"
+            "postgres:16-alpine"
         ])
     }
 

--- a/scripts/start-ci-dbs.sh
+++ b/scripts/start-ci-dbs.sh
@@ -12,9 +12,11 @@ for port in {0..7}; do
         -e POSTGRES_DB=spi_test \
         -e POSTGRES_USER=spi_test \
         -e POSTGRES_PASSWORD=xxx \
+        -e POSTGRES_HOST_AUTH_METHOD=md5 \
+        -e POSTGRES_INITDB_ARGS="--auth-host=md5" \
         -e PGDATA=/pgdata \
         --tmpfs /pgdata:rw,noexec,nosuid,size=1024m \
         --network spi_test \
         -d \
-        postgres:13-alpine
+        postgres:16-alpine
 done


### PR DESCRIPTION
It's been quite the journey, details here: https://github.com/vapor/postgres-nio/issues/506#issuecomment-2884267060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated PostgreSQL version used in testing and CI environments from 13-alpine to 16-alpine.
  - Improved database authentication settings for test containers by enabling MD5 password authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->