### PR TITLE
Add Wasm and Android platforms

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "864e3bec45f77c29f638c44a5fcf674990c65b9c5fbc26d8e01ac626f6142536",
+  "originHash" : "90afa6033b3948dd2483c4119540067594218f6ae758fa47f1d16bbb615d8373",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftPackageIndex/SPIManifest.git",
       "state" : {
-        "branch" : "release-2.0",
-        "revision" : "2df1290febc1fd1ee164bde3d5dcacaa82a52978"
+        "revision" : "aace30e17abaa35713022ecc1cf426292b57f980",
+        "version" : "1.9.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c2a3dc302e76c540d06ab4501e4d518278f4c507599b8d925a73be6e0d838533",
+  "originHash" : "864e3bec45f77c29f638c44a5fcf674990c65b9c5fbc26d8e01ac626f6142536",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -249,8 +249,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SwiftPackageIndex/SPIManifest.git",
       "state" : {
-        "revision" : "df8dfd0295c5ec9840c2987f8adec20381243109",
-        "version" : "1.8.2"
+        "branch" : "release-2.0",
+        "revision" : "2df1290febc1fd1ee164bde3d5dcacaa82a52978"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftPackageIndex/Plot.git", branch: "main"),
         .package(url: "https://github.com/SwiftPackageIndex/CanonicalPackageURL.git", from: "1.0.0"),
         .package(url: "https://github.com/SwiftPackageIndex/DependencyResolution.git", from: "1.1.2"),
-        .package(url: "https://github.com/SwiftPackageIndex/SPIManifest.git", from: "1.2.0"),
+        .package(url: "https://github.com/SwiftPackageIndex/SPIManifest.git", branch: "release-2.0"),
         .package(url: "https://github.com/SwiftPackageIndex/SemanticVersion.git", from: "0.3.0"),
         .package(url: "https://github.com/SwiftPackageIndex/ShellOut.git", from: "3.1.4"),
         .package(url: "https://github.com/swiftlang/swift-package-manager.git", branch: "release/6.1"),

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
         .package(url: "https://github.com/SwiftPackageIndex/Plot.git", branch: "main"),
         .package(url: "https://github.com/SwiftPackageIndex/CanonicalPackageURL.git", from: "1.0.0"),
         .package(url: "https://github.com/SwiftPackageIndex/DependencyResolution.git", from: "1.1.2"),
-        .package(url: "https://github.com/SwiftPackageIndex/SPIManifest.git", branch: "release-2.0"),
+        .package(url: "https://github.com/SwiftPackageIndex/SPIManifest.git", from: "1.9.0"),
         .package(url: "https://github.com/SwiftPackageIndex/SemanticVersion.git", from: "0.3.0"),
         .package(url: "https://github.com/SwiftPackageIndex/ShellOut.git", from: "3.1.4"),
         .package(url: "https://github.com/swiftlang/swift-package-manager.git", branch: "release/6.1"),

--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -383,11 +383,17 @@ struct BuildPair {
     static let all = Build.Platform.allActive.flatMap { platform in
         SwiftVersion.allActive.compactMap { swiftVersion in
             switch platform {
+                case .android:
+                    // Android is supported from Swift version 6.1+
+                    return swiftVersion >= .v6_1 ? BuildPair(platform, swiftVersion) : nil
                 case .iOS, .linux, .macosSpm, .macosXcodebuild, .tvOS, .watchOS:
                     return BuildPair(platform, swiftVersion)
                 case .visionOS:
                     // visionOS is only available for Swift versions 5.9+
                     return swiftVersion >= .v5_9 ? BuildPair(platform, swiftVersion) : nil
+                case .wasm:
+                    // Android is supported from Swift version 6.1+
+                    return swiftVersion >= .v6_1 ? BuildPair(platform, swiftVersion) : nil
             }
         }
     }

--- a/Sources/App/Controllers/CompatibilityMatrix.swift
+++ b/Sources/App/Controllers/CompatibilityMatrix.swift
@@ -36,6 +36,8 @@ extension CompatibilityMatrix {
         case watchOS
         case tvOS
         case linux
+        case wasm
+        case android
 
         static func <(lhs: Self, rhs: Self) -> Bool { allCases.firstIndex(of: lhs)! < allCases.firstIndex(of: rhs)! }
     }

--- a/Sources/App/Controllers/PackageController+ShowRoute.swift
+++ b/Sources/App/Controllers/PackageController+ShowRoute.swift
@@ -51,12 +51,16 @@ extension Array where Element == PackageController.BuildsRoute.BuildInfo {
 extension Build.Platform {
     func isCompatible(with other: CompatibilityMatrix.Platform) -> Bool {
         switch self {
+            case .android:
+                return other == .android
             case .iOS:
                 return other == .iOS
             case .macosSpm, .macosXcodebuild:
                 return other == .macOS
             case .tvOS:
                 return other == .tvOS
+            case .wasm:
+                return other == .wasm
             case .watchOS:
                 return other == .watchOS
             case .visionOS:

--- a/Sources/App/Core/Extensions/Badge.swift
+++ b/Sources/App/Core/Extensions/Badge.swift
@@ -124,6 +124,10 @@ extension Badge {
                                 return .init(left: 4, right: "watchOS")
                             case .linux:
                                 return .init(left: 5, right: "Linux")
+                            case .wasm:
+                                return .init(left: 6, right: "Wasm")
+                            case .android:
+                                return .init(left: 7, right: "Android")
                         }
                     }
                 )

--- a/Sources/App/Core/Extensions/BuildPair+ext.swift
+++ b/Sources/App/Core/Extensions/BuildPair+ext.swift
@@ -32,6 +32,10 @@ extension BuildPair {
                 return .visionOS
             case .watchOS:
                 return .watchOS
+            case .wasm:
+                return .wasm
+            case .android:
+                return .android
         }
     }
 

--- a/Sources/App/Core/PackageCollection+generate.swift
+++ b/Sources/App/Core/PackageCollection+generate.swift
@@ -296,7 +296,7 @@ extension Array where Element == PackageCollection.Compatibility {
 private extension PackageCollection.Platform {
     init(platform: Build.Platform) {
         switch platform {
-            case .iOS, .tvOS, .visionOS, .watchOS, .linux:
+            case .android, .iOS, .tvOS, .visionOS, .watchOS, .linux, .wasm:
                 self.init(name: platform.rawValue)
             case .macosSpm, .macosXcodebuild:
                 self.init(name: "macos")

--- a/Sources/App/Core/SearchFilter/Filters/PlatformSearchFilter.swift
+++ b/Sources/App/Core/SearchFilter/Filters/PlatformSearchFilter.swift
@@ -57,6 +57,8 @@ struct PlatformSearchFilter: SearchFilterProtocol {
 private extension Package.PlatformCompatibility {
     var displayDescription: String {
         switch self {
+            case .android:
+                return "Android"
             case .iOS:
                 return "iOS"
             case .macOS:
@@ -67,6 +69,8 @@ private extension Package.PlatformCompatibility {
                 return "tvOS"
             case .visionOS:
                 return "visionOS"
+            case .wasm:
+                return "Wasm"
             case .watchOS:
                 return "watchOS"
         }

--- a/Sources/App/Models/Build+Platform.swift
+++ b/Sources/App/Models/Build+Platform.swift
@@ -17,49 +17,59 @@ import SPIManifest
 
 extension Build {
     enum Platform: String, Codable, Equatable, CaseIterable {
+        case android
         case iOS                = "ios"
         case linux
         case macosSpm           = "macos-spm"
         case macosXcodebuild    = "macos-xcodebuild"
         case tvOS               = "tvos"
         case visionOS           = "visionos"
+        case wasm
         case watchOS            = "watchos"
 
         var name: String {
             switch self {
+                case .android:
+                    return "Android"
                 case .iOS:
                     return "iOS"
+                case .linux:
+                    return "Linux"
                 case .macosSpm:
                     return "macOS - SPM"
                 case .macosXcodebuild:
                     return "macOS - xcodebuild"
                 case .tvOS:
                     return "tvOS"
+                case .wasm:
+                    return "Wasm"
                 case .watchOS:
                     return "watchOS"
                 case .visionOS:
                     return "visionOS"
-                case .linux:
-                    return "Linux"
             }
         }
 
         var displayName: String {
             switch self {
+                case .android:
+                    return "Android"
                 case .iOS:
                     return "iOS"
+                case .linux:
+                    return "Linux"
                 case .macosSpm:
                     return "macOS (SPM)"
                 case .macosXcodebuild:
                     return "macOS (Xcode)"
                 case .tvOS:
                     return "tvOS"
+                case .wasm:
+                    return "Wasm"
                 case .watchOS:
                     return "watchOS"
                 case .visionOS:
                     return "visionOS"
-                case .linux:
-                    return "Linux"
             }
         }
 
@@ -67,7 +77,7 @@ extension Build {
         static var allActive: [Self] {
             // The order of this array defines the platform order on the BuildIndex page. Keep this aliged with the
             // order in GetRoute.Model.PlatformResults (which is the order in the build matrix on the PackageShow page).
-            let active: [Self] = [.iOS, .macosSpm, .macosXcodebuild, .visionOS, .tvOS, .watchOS, .linux]
+            let active: [Self] = [.iOS, .macosSpm, .macosXcodebuild, .visionOS, .tvOS, .watchOS, .linux, .wasm, .android]
             assert(active.count == allCases.count, "mismatch in Build.Platform and active platform count")
             return active
         }
@@ -78,6 +88,8 @@ extension Build {
         /// - Parameter spiManifestPlatform: SPIManifest platform
         private init(_ spiManifestPlatform: SPIManifest.Platform) {
             switch spiManifestPlatform {
+                case .android:
+                    self = .android
                 case .iOS:
                     self = .iOS
                 case .linux:
@@ -90,6 +102,8 @@ extension Build {
                     self = .tvOS
                 case .visionOS:
                     self = .visionOS
+                case .wasm:
+                    self = .wasm
                 case .watchOS:
                     self = .watchOS
             }

--- a/Sources/App/Models/Package.swift
+++ b/Sources/App/Models/Package.swift
@@ -103,11 +103,13 @@ extension Package: Hashable {
 
 extension Package {
     enum PlatformCompatibility: String, Codable {
+        case android
         case iOS      = "ios"
         case macOS    = "macos"
         case linux
         case tvOS     = "tvos"
         case visionOS = "visionos"
+        case wasm
         case watchOS  = "watchos"
     }
 }

--- a/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildShow+Model.swift
@@ -107,7 +107,7 @@ extension BuildShow {
                      (.visionOS, let swift),
                      (.watchOS, let swift):
                     return swift.xcodeVersion
-                case (.macosSpm, _), (.linux, _):
+                case (.android, _), (.macosSpm, _), (.linux, _), (.wasm, _):
                     return nil
             }
         }

--- a/Sources/App/Views/PackageController/CompatibilityMatrix.Platform+BuildResultPresentable.swift
+++ b/Sources/App/Views/PackageController/CompatibilityMatrix.Platform+BuildResultPresentable.swift
@@ -16,6 +16,8 @@
 extension CompatibilityMatrix.Platform: BuildResultPresentable {
     var displayName: String {
         switch self {
+            case .android:
+                return "Android"
             case .iOS:
                 return "iOS"
             case .linux:
@@ -26,6 +28,8 @@ extension CompatibilityMatrix.Platform: BuildResultPresentable {
                 return "tvOS"
             case .visionOS:
                 return "visionOS"
+            case .wasm:
+                return "Wasm"
             case .watchOS:
                 return "watchOS"
         }
@@ -33,8 +37,10 @@ extension CompatibilityMatrix.Platform: BuildResultPresentable {
 
     var longDisplayName: String {
         switch self {
-            case .macOS, .iOS, .linux, .tvOS, .visionOS, .watchOS:
+            case .android, .macOS, .iOS, .linux, .tvOS, .visionOS, .watchOS:
                 return displayName
+            case .wasm:
+                return "WebAssembly"
         }
     }
 

--- a/Tests/AppTests/BuildIndexModelTests.swift
+++ b/Tests/AppTests/BuildIndexModelTests.swift
@@ -96,7 +96,7 @@ extension AllTests.BuildIndexModelTests {
         let matrix = model.buildMatrix
 
         // validate
-        #expect(matrix.values.keys.count == 28)
+        #expect(matrix.values.keys.count == 30)
         #expect(
             matrix.values[.init(swiftVersion: .v3, platform: .iOS)]?.map(\.column.label) == ["1.2.3", "2.0.0-b1", "main"]
         )
@@ -141,7 +141,7 @@ extension AllTests.BuildIndexModelTests {
         let matrix = model.buildMatrix
 
         // validate
-        #expect(matrix.values.keys.count == 28)
+        #expect(matrix.values.keys.count == 30)
         #expect(
             matrix.values[.init(swiftVersion: .v3, platform: .iOS)]?.map(\.column.label) == ["1.2.3", "main"]
         )

--- a/Tests/AppTests/PackageTests.swift
+++ b/Tests/AppTests/PackageTests.swift
@@ -472,7 +472,7 @@ extension AllTests.PackageTests {
             let p1 = try #require(
                 try await Package.query(on: app.db).filter(by: "1".url).first()
             )
-            #expect(p1.platformCompatibility == [.iOS, .macOS, .linux, .tvOS, .visionOS, .watchOS])
+            #expect(p1.platformCompatibility == [.android, .iOS, .macOS, .linux, .tvOS, .visionOS, .wasm, .watchOS])
             let p2 = try #require(
                 try await Package.query(on: app.db).filter(by: "2".url).first()
             )

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/BuildIndex_document.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/BuildIndex_document.1.html
@@ -11,9 +11,9 @@
     <title>foobar &ndash; Build Results &ndash; Swift Package Index</title>
     <meta name="twitter:title" content="foobar &ndash; Build Results &ndash; Swift Package Index"/>
     <meta property="og:title" content="foobar &ndash; Build Results &ndash; Swift Package Index"/>
-    <meta name="description" content="The latest compatibility build results for foobar, showing compatibility across 7 platforms with 4 versions of Swift."/>
-    <meta name="twitter:description" content="The latest compatibility build results for foobar, showing compatibility across 7 platforms with 4 versions of Swift."/>
-    <meta property="og:description" content="The latest compatibility build results for foobar, showing compatibility across 7 platforms with 4 versions of Swift."/>
+    <meta name="description" content="The latest compatibility build results for foobar, showing compatibility across 9 platforms with 4 versions of Swift."/>
+    <meta name="twitter:description" content="The latest compatibility build results for foobar, showing compatibility across 9 platforms with 4 versions of Swift."/>
+    <meta property="og:description" content="The latest compatibility build results for foobar, showing compatibility across 9 platforms with 4 versions of Swift."/>
     <meta name="twitter:card" content="summary"/>
     <meta name="twitter:image" content="http://localhost:8080/images/logo.png"/>
     <meta property="og:image" content="http://localhost:8080/images/logo.png"/>
@@ -271,6 +271,60 @@
             <li class="row">
               <div class="row-labels">
                 <strong>Linux</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>Wasm</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>Android</strong>
               </div>
               <div class="column-labels">
                 <div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document.1.html
@@ -238,6 +238,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -246,6 +248,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -261,6 +265,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -269,6 +275,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -284,6 +292,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -292,6 +302,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_app_store_incompatible_license.1.html
@@ -241,6 +241,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -249,6 +251,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -264,6 +268,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -272,6 +278,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -287,6 +295,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -295,6 +305,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_binary_targets.1.html
@@ -242,6 +242,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -250,6 +252,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -265,6 +269,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -273,6 +279,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -288,6 +296,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -296,6 +306,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_canonicalURL_noImageSnapshots.1.html
@@ -238,6 +238,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -246,6 +248,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -261,6 +265,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -269,6 +275,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -284,6 +292,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -292,6 +302,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_customCollection.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_customCollection.1.html
@@ -241,6 +241,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -249,6 +251,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -264,6 +268,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -272,6 +278,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -287,6 +295,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -295,6 +305,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_emoji_summary.1.html
@@ -238,6 +238,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -246,6 +248,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -261,6 +265,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -269,6 +275,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -284,6 +292,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -292,6 +302,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_few_keywords.1.html
@@ -269,6 +269,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -277,6 +279,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -292,6 +296,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -300,6 +306,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -315,6 +323,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -323,6 +333,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_many_keywords.1.html
@@ -444,6 +444,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -452,6 +454,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -467,6 +471,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -475,6 +481,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -490,6 +498,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -498,6 +508,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_authors_activity.1.html
@@ -233,6 +233,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -241,6 +243,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -256,6 +260,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -264,6 +270,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -279,6 +287,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -287,6 +297,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_license.1.html
@@ -241,6 +241,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -249,6 +251,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -264,6 +268,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -272,6 +278,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -287,6 +295,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -295,6 +305,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_open_source_license.1.html
@@ -240,6 +240,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -248,6 +250,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -263,6 +267,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -271,6 +277,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -286,6 +294,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -294,6 +304,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_other_license.1.html
@@ -241,6 +241,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -249,6 +251,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -264,6 +268,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -272,6 +278,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -287,6 +295,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -295,6 +305,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_single_row_tables.1.html
@@ -222,6 +222,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -230,6 +232,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_withPackageFundingLinks.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_withPackageFundingLinks.1.html
@@ -246,6 +246,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -254,6 +256,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -269,6 +273,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -277,6 +283,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -292,6 +300,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -300,6 +310,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_with_documentation_link.1.html
@@ -238,6 +238,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -246,6 +248,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="unknown" title="No build information available for tvOS"></div>
                         <div class="unknown" title="No build information available for Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -261,6 +265,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -269,6 +275,8 @@
                         <div class="unknown" title="No build information available for watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                     <li class="row">
@@ -284,6 +292,8 @@
                         <div>watchOS</div>
                         <div>tvOS</div>
                         <div>Linux</div>
+                        <div>Wasm</div>
+                        <div>Android</div>
                       </div>
                       <div class="results">
                         <div class="compatible" title="Built successfully with iOS"></div>
@@ -292,6 +302,8 @@
                         <div class="compatible" title="Built successfully with watchOS"></div>
                         <div class="compatible" title="Built successfully with tvOS"></div>
                         <div class="compatible" title="Built successfully with Linux"></div>
+                        <div class="unknown" title="No build information available for WebAssembly"></div>
+                        <div class="unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>


### PR DESCRIPTION
To do

- [x] merge and tag SPIManifest 1.9.0
- [x] adopt SPIManifest 1.9.0 in Package.swift
- [x] verify and deploy builder with new platforms
  - [x] wasm
  - [x] android
- [ ] optionally disable display of new platforms until matrix is polished
- [x] reset `BUILD_TRIGGER_DOWNSCALING` to 0.01

![CleanShot 2025-05-20 at 16 16 59@2x](https://github.com/user-attachments/assets/529c31f4-9058-4079-b2a7-cd96ec8c54af)

We need to deploy this to dev in order to finalise the builder changes, because they need to report back to the API in order to pass the tests.

We can ad hoc deploy from this branch without merging to allow the builder tests to pass.

I've set the `BUILD_TRIGGER_DOWNSCALING` for dev to 0 in order to avoid triggering any of the new platform builds while it is running on dev.