### PR TITLE
Compatibility matrix redesign for new platforms

### DIFF
--- a/FrontEnd/main.scss
+++ b/FrontEnd/main.scss
@@ -22,6 +22,7 @@ $mobile-breakpoint: 740px;
 @import 'styles/breadcrumbs';
 @import 'styles/build_logs';
 @import 'styles/build_monitor';
+@import 'styles/build_results';
 @import 'styles/copyable_input';
 @import 'styles/error';
 @import 'styles/github_highlighting';

--- a/FrontEnd/styles/build_results.scss
+++ b/FrontEnd/styles/build_results.scss
@@ -1,0 +1,154 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// -------------------------------------------------------------------------
+// Build results page, showing all builds for a package.
+// -------------------------------------------------------------------------
+
+.build-results {
+    margin: 0;
+    padding: 0;
+
+    li {
+        margin: 5px 0;
+
+        @media screen and (max-width: $mobile-breakpoint) {
+            margin: 20px 0;
+        }
+    }
+
+    .row {
+        display: grid;
+        grid-template-columns: 3fr 7fr;
+
+        .row-labels {
+            display: flex;
+            grid-row: 2;
+            flex-direction: column;
+            justify-content: center;
+
+            p {
+                margin: 0;
+            }
+        }
+
+        .column-labels {
+            display: flex;
+            grid-column: 2;
+            flex-direction: row;
+        }
+
+        .results {
+            display: flex;
+            grid-column: 2;
+            flex-direction: row;
+        }
+
+        &:not(:first-child) {
+            .row-labels {
+                grid-row: unset;
+            }
+
+            .column-labels {
+                display: none;
+            }
+        }
+
+        @media (max-width: $mobile-breakpoint) {
+            grid-template-columns: 1fr;
+
+            .row-labels,
+            .column-labels,
+            .results {
+                grid-column: unset;
+                grid-row: unset;
+            }
+
+            .column-labels {
+                display: flex;
+            }
+        }
+    }
+
+    .column-labels > div {
+        display: flex;
+        flex-direction: column;
+        flex-basis: 0;
+        flex-grow: 1;
+        align-items: center;
+        justify-content: flex-start;
+        padding: 5px 0;
+        font-size: 14px;
+        font-weight: 600;
+
+        small {
+            font-weight: normal;
+        }
+    }
+
+    .results > div {
+        position: relative;
+        display: flex;
+        flex-basis: 0;
+        flex-grow: 1;
+        align-items: center;
+        justify-content: center;
+        height: 35px;
+        margin: 0 3px;
+        background-color: var(--grid-default-background);
+
+        &.succeeded > a,
+        &.failed > a {
+            padding-left: 25px;
+            background-position: left center;
+            background-repeat: no-repeat;
+            background-size: 18px;
+        }
+
+        &.succeeded {
+            background-color: var(--grid-succeeded-background);
+
+            a {
+                background-image: var(--image-build-succeeded);
+            }
+        }
+
+        &.failed {
+            background-color: var(--grid-failed-background);
+
+            a {
+                background-image: var(--image-build-failed);
+            }
+        }
+
+        > .generated-docs {
+            position: absolute;
+            right: 5px;
+            display: inline-block;
+            width: 25px;
+            height: 25px;
+            background-position: center;
+            background-repeat: no-repeat;
+            background-size: 15px;
+            background-color: var(--grid-callout-background);
+            background-image: var(--image-documentation);
+            border-radius: 50%;
+        }
+    }
+
+    .column-labels > div > span {
+        font-size: 16px;
+        background-position: top 4px right;
+    }
+}

--- a/FrontEnd/styles/colors.scss
+++ b/FrontEnd/styles/colors.scss
@@ -96,6 +96,8 @@
     --breadcrumb: var(--light-grey);
     --breadcrumb-header: var(--grey);
 
+    --separator-text: var(--light-grey);
+
     --announcement-background: var(--very-light-grey);
 
     --bordered-button-background: var(--very-very-light-grey);
@@ -249,6 +251,8 @@
         --header-gradient-end: rgb(255 255 255 / 3%);
 
         --breadcrumb: var(--dark-grey);
+
+        --separator-text: var(--dark-grey);
 
         --announcement-background: var(--very-dark-grey);
 

--- a/FrontEnd/styles/colors.scss
+++ b/FrontEnd/styles/colors.scss
@@ -128,9 +128,12 @@
     --branch-text: var(--dark-green);
 
     --grid-default-background: var(--very-very-light-grey);
+    --grid-default-text: var(--light-grey);
     --grid-default-border: var(--very-light-grey);
     --grid-compatible-background: var(--light-green);
+    --grid-compatible-text: var(--white);
     --grid-incompatible-background: var(--light-grey);
+    --grid-incompatible-text: var(--grey);
     --grid-succeeded-background: var(--very-light-grey);
     --grid-failed-background: var(--very-light-grey);
     --grid-callout-background: var(--white);

--- a/FrontEnd/styles/layout.scss
+++ b/FrontEnd/styles/layout.scss
@@ -27,11 +27,14 @@ main > .inner {
 
 .two-column {
     display: grid;
-    grid-template-columns: 3fr 1fr;
+    overflow: hidden;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 1fr);
     gap: 60px;
+    min-width: 0;
 
     > :last-child {
         justify-self: end;
+        min-width: 0;
     }
 
     &.even {

--- a/FrontEnd/styles/matrix.scss
+++ b/FrontEnd/styles/matrix.scss
@@ -61,39 +61,38 @@
 
         .results {
             display: grid;
-            grid-template-columns: repeat(var(--items-per-row), 1fr);
+            grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
             gap: 5px;
 
-            .result-label {
+            .result {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                min-height: 30px;
                 font-size: 14px;
                 font-weight: 600;
-                text-align: center;
-            }
-
-            .result {
-                min-height: 30px;
-                background-position: center center;
-                background-repeat: no-repeat;
-                background-size: 20px;
 
                 &.pending,
                 &.unknown {
+                    color: var(--grid-default-text);
                     background-color: var(--grid-default-background);
-                    background-image: var(--image-compatibility-unknown);
                 }
 
                 &.compatible {
+                    color: var(--grid-compatible-text);
                     background-color: var(--grid-compatible-background);
-                    background-image: var(--image-compatible);
                 }
 
                 &.incompatible {
+                    color: var(--grid-incompatible-text);
                     background-color: var(--grid-incompatible-background);
-                    background-image: var(--image-incompatible);
+                }
+
+                small {
+                    font-size: 9px;
                 }
             }
-
-            // TODO: The content of this grid's children need to be flexed for when we have a `small` beta label.
         }
     }
 }

--- a/FrontEnd/styles/matrix.scss
+++ b/FrontEnd/styles/matrix.scss
@@ -18,8 +18,8 @@
 // -------------------------------------------------------------------------
 
 .matrices {
-    display: grid;
-    gap: 20px;
+    display: flex;
+    flex-direction: column;
 
     a {
         color: var(--page-text);
@@ -27,169 +27,73 @@
 }
 
 .matrix {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
     margin: 0;
-    padding: 0;
+    padding: 20px 0;
+    list-style: none;
 
-    li {
-        margin: 5px 0;
-
-        @media screen and (max-width: $mobile-breakpoint) {
-            margin: 20px 0;
-        }
-    }
-
-    .row {
-        display: grid;
-        grid-template-columns: 3fr 7fr;
-
-        .row-labels {
-            display: flex;
-            grid-row: 2;
-            flex-direction: column;
-            justify-content: center;
-
-            p {
-                margin: 0;
-            }
-        }
-
-        .column-labels {
-            display: flex;
-            grid-column: 2;
-            flex-direction: row;
-        }
-
-        .results {
-            display: flex;
-            grid-column: 2;
-            flex-direction: row;
-        }
-
-        // Show the column labels only for the first row on desktop.
-        // Note: This is a *desktop only* media query.
-        @media not all and (max-width: $mobile-breakpoint) {
-            &:not(:first-child) {
-                .row-labels {
-                    grid-row: unset;
-                }
-
-                .column-labels {
-                    display: none;
-                }
-            }
-        }
-
-        @media (max-width: $mobile-breakpoint) {
-            grid-template-columns: 1fr;
-
-            .row-labels,
-            .column-labels,
-            .results {
-                grid-column: unset;
-                grid-row: unset;
-            }
-        }
-    }
-
-    .column-labels > div {
+    .version {
         display: flex;
         flex-direction: column;
-        flex-basis: 0;
-        flex-grow: 1;
-        align-items: center;
-        justify-content: flex-start;
-        padding: 5px 0;
-        font-size: 14px;
-        font-weight: 600;
+        gap: 5px;
 
-        small {
-            font-weight: normal;
+        .label {
+            display: flex;
+            gap: 0.5ch;
+
+            span {
+                overflow: hidden;
+                flex-basis: 0;
+                flex-grow: 1;
+                max-width: fit-content;
+                white-space: nowrap;
+                text-overflow: ellipsis;
+            }
+
+            .separator {
+                font-size: 14px;
+                font-weight: 600;
+                color: var(--separator-text);
+            }
         }
-    }
 
-    .results > div {
-        display: flex;
-        flex-basis: 0;
-        flex-grow: 1;
-        align-items: center;
-        justify-content: center;
-        height: 35px;
-        margin: 0 3px;
-    }
-
-    &.compatibility {
         .results {
-            & > div {
+            display: grid;
+            grid-template-columns: repeat(var(--items-per-row), 1fr);
+            gap: 5px;
+
+            .result-label {
+                font-size: 14px;
+                font-weight: 600;
+                text-align: center;
+            }
+
+            .result {
+                min-height: 30px;
                 background-position: center center;
                 background-repeat: no-repeat;
                 background-size: 20px;
-            }
 
-            & > .pending,
-            & > .unknown {
-                background-color: var(--grid-default-background);
-                background-image: var(--image-compatibility-unknown);
-            }
+                &.pending,
+                &.unknown {
+                    background-color: var(--grid-default-background);
+                    background-image: var(--image-compatibility-unknown);
+                }
 
-            & > .compatible {
-                background-color: var(--grid-compatible-background);
-                background-image: var(--image-compatible);
-            }
+                &.compatible {
+                    background-color: var(--grid-compatible-background);
+                    background-image: var(--image-compatible);
+                }
 
-            & > .incompatible {
-                background-color: var(--grid-incompatible-background);
-                background-image: var(--image-incompatible);
-            }
-        }
-    }
-
-    &.builds {
-        .column-labels > div > span {
-            font-size: 16px;
-            background-position: top 4px right;
-        }
-
-        .results > div {
-            position: relative;
-            background-color: var(--grid-default-background);
-
-            &.succeeded > a,
-            &.failed > a {
-                padding-left: 25px;
-                background-position: left center;
-                background-repeat: no-repeat;
-                background-size: 18px;
-            }
-
-            &.succeeded {
-                background-color: var(--grid-succeeded-background);
-
-                a {
-                    background-image: var(--image-build-succeeded);
+                &.incompatible {
+                    background-color: var(--grid-incompatible-background);
+                    background-image: var(--image-incompatible);
                 }
             }
 
-            &.failed {
-                background-color: var(--grid-failed-background);
-
-                a {
-                    background-image: var(--image-build-failed);
-                }
-            }
-
-            > .generated-docs {
-                position: absolute;
-                right: 5px;
-                display: inline-block;
-                width: 25px;
-                height: 25px;
-                background-position: center;
-                background-repeat: no-repeat;
-                background-size: 15px;
-                background-color: var(--grid-callout-background);
-                background-image: var(--image-documentation);
-                border-radius: 50%;
-            }
+            // TODO: The content of this grid's children need to be flexed for when we have a `small` beta label.
         }
     }
 }

--- a/FrontEnd/styles/matrix.scss
+++ b/FrontEnd/styles/matrix.scss
@@ -45,11 +45,13 @@
 
             span {
                 overflow: hidden;
-                flex-basis: 0;
-                flex-grow: 1;
-                max-width: fit-content;
+                flex-shrink: 0;
                 white-space: nowrap;
                 text-overflow: ellipsis;
+
+                &.longest {
+                    flex-shrink: 1;
+                }
             }
 
             .separator {

--- a/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
@@ -87,7 +87,7 @@ enum BuildIndex {
                                 })
                             ),
                             .ul(
-                                .class("matrix builds"),
+                                .class("build-results"),
                                 .group(model.buildMatrix[swiftVersion].map(\.node))
                             )
                         )

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -608,8 +608,6 @@ extension API.PackageController.GetRoute.Model {
             ),
             .div(
                 .class("results"),
-                .style("--items-per-row: \(cells.count)"),
-                .forEach(cells) { $0.headerNode },
                 .forEach(cells) { $0.cellNode }
             )
         )
@@ -678,18 +676,13 @@ private extension License.Kind {
 
 
 private extension CompatibilityMatrix.BuildResult where T: BuildResultPresentable {
-    var headerNode: Node<HTML.BodyContext> {
-        .div(
-            .class("result-label"),
-            .text(parameter.displayName),
-            .unwrap(parameter.note) { .small(.text("(\($0))")) }
-        )
-    }
-
     var cellNode: Node<HTML.BodyContext> {
         .div(
             .class("result \(status.cssClass)"),
-            .title(title)
+            .title(title),
+            .text(parameter.displayName),
+            .unwrap(parameter.note) { .small(.text("(\($0))")) },
+            .if(status == .unknown, .small(.text("(Pending)")))
         )
     }
 

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -578,8 +578,8 @@ extension API.PackageController.GetRoute.Model {
         return .a(
             .href(SiteURL.package(.value(repositoryOwner), .value(repositoryName), .builds).relativeURL()),
             .ul(
-                .class("matrix compatibility"),
-                .forEach(rows) { compatibilityListItem($0.labelParagraphNode, cells: $0.results.all) }
+                .class("matrix"),
+                .forEach(rows) { compatibilityListItem($0.labelNode, cells: $0.results.all) }
             )
         )
     }
@@ -590,29 +590,26 @@ extension API.PackageController.GetRoute.Model {
         return                         .a(
             .href(SiteURL.package(.value(repositoryOwner), .value(repositoryName), .builds).relativeURL()),
             .ul(
-                .class("matrix compatibility"),
-                .forEach(rows) { compatibilityListItem($0.labelParagraphNode, cells: $0.results.all) }
+                .class("matrix"),
+                .forEach(rows) { compatibilityListItem($0.labelNode, cells: $0.results.all) }
             )
         )
     }
 
     func compatibilityListItem<T: BuildResultPresentable>(
-        _ labelParagraphNode: Node<HTML.BodyContext>,
+        _ labelNode: Node<HTML.BodyContext>,
         cells: [CompatibilityMatrix.BuildResult<T>]
     ) -> Node<HTML.ListContext> {
         return .li(
-            .class("row"),
+            .class("version"),
             .div(
-                .class("row-labels"),
-                labelParagraphNode
-            ),
-            // Matrix CSS should include *both* the column labels, and the column values status boxes in *every* row.
-            .div(
-                .class("column-labels"),
-                .forEach(cells) { $0.headerNode }
+                .class("label"),
+                labelNode
             ),
             .div(
                 .class("results"),
+                .style("--items-per-row: \(cells.count)"),
+                .forEach(cells) { $0.headerNode },
                 .forEach(cells) { $0.cellNode }
             )
         )
@@ -683,6 +680,7 @@ private extension License.Kind {
 private extension CompatibilityMatrix.BuildResult where T: BuildResultPresentable {
     var headerNode: Node<HTML.BodyContext> {
         .div(
+            .class("result-label"),
             .text(parameter.displayName),
             .unwrap(parameter.note) { .small(.text("(\($0))")) }
         )
@@ -690,7 +688,7 @@ private extension CompatibilityMatrix.BuildResult where T: BuildResultPresentabl
 
     var cellNode: Node<HTML.BodyContext> {
         .div(
-            .class("\(status.cssClass)"),
+            .class("result \(status.cssClass)"),
             .title(title)
         )
     }

--- a/Sources/App/Views/PackageController/PackageShow.swift
+++ b/Sources/App/Views/PackageController/PackageShow.swift
@@ -50,13 +50,16 @@ enum PackageShow {
             self.results = namedResult.results
         }
 
-        var labelParagraphNode: Node<HTML.BodyContext> {
+        var labelNode: Node<HTML.BodyContext> {
             guard !references.isEmpty else { return .empty }
-            return .p(
-                .group(
-                    listPhrase(nodes: references.map(\.node))
-                )
-            )
+
+            var versionsAndSeparators = references.flatMap { reference -> [Node<HTML.BodyContext>] in
+                [reference.node, .span(.class("separator"), .text("/"))]
+            }
+            if versionsAndSeparators.isEmpty == false {
+                versionsAndSeparators.removeLast()
+            }
+            return .group(versionsAndSeparators)
         }
     }
 }

--- a/Sources/App/Views/PackageController/PackageShow.swift
+++ b/Sources/App/Views/PackageController/PackageShow.swift
@@ -20,19 +20,19 @@ enum PackageShow {
         var name: String
         var kind: App.Version.Kind
 
-        var node: Node<HTML.BodyContext> {
-            .span(
-                .class(cssClass),
-                .text(name)
-            )
-        }
-
         var cssClass: String {
             switch kind {
                 case .defaultBranch: return "branch"
                 case .preRelease: return "beta"
                 case .release: return "stable"
             }
+        }
+
+        func node(longest: Bool = false) -> Node<HTML.BodyContext> {
+            .span(
+                .class(longest ? "longest \(cssClass)" : cssClass),
+                .text(name)
+            )
         }
     }
 
@@ -53,8 +53,11 @@ enum PackageShow {
         var labelNode: Node<HTML.BodyContext> {
             guard !references.isEmpty else { return .empty }
 
+            let longestReference = references.map(\.name).max(by: { $0.count < $1.count }) ?? ""
+
             var versionsAndSeparators = references.flatMap { reference -> [Node<HTML.BodyContext>] in
-                [reference.node, .span(.class("separator"), .text("/"))]
+                let isLongest = reference.name == longestReference
+                return [reference.node(longest: isLongest), .span(.class("separator"), .text("/"))]
             }
             if versionsAndSeparators.isEmpty == false {
                 versionsAndSeparators.removeLast()

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/BuildIndex_document.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/BuildIndex_document.1.html
@@ -105,7 +105,7 @@
           </p>
           <hr/>
           <h3>Swift 6.1</h3>
-          <ul class="matrix builds">
+          <ul class="build-results">
             <li class="row">
               <div class="row-labels">
                 <strong>iOS</strong>
@@ -352,7 +352,7 @@
           </ul>
           <hr/>
           <h3>Swift 6.0</h3>
-          <ul class="matrix builds">
+          <ul class="build-results">
             <li class="row">
               <div class="row-labels">
                 <strong>iOS</strong>
@@ -548,7 +548,7 @@
           </ul>
           <hr/>
           <h3>Swift 5.10</h3>
-          <ul class="matrix builds">
+          <ul class="build-results">
             <li class="row">
               <div class="row-labels">
                 <strong>iOS</strong>
@@ -741,7 +741,7 @@
           </ul>
           <hr/>
           <h3>Swift 5.9</h3>
-          <ul class="matrix builds">
+          <ul class="build-results">
             <li class="row">
               <div class="row-labels">
                 <strong>iOS</strong>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document.1.html
@@ -188,30 +188,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -222,69 +216,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document.1.html
@@ -181,129 +181,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document.1.html
@@ -184,7 +184,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -199,7 +199,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -214,7 +214,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -243,7 +243,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -264,7 +264,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_app_store_incompatible_license.1.html
@@ -184,129 +184,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_app_store_incompatible_license.1.html
@@ -187,7 +187,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -202,7 +202,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -217,7 +217,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -246,7 +246,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -267,7 +267,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_app_store_incompatible_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_app_store_incompatible_license.1.html
@@ -191,30 +191,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -225,69 +219,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_binary_targets.1.html
@@ -188,7 +188,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -203,7 +203,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -218,7 +218,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -247,7 +247,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -268,7 +268,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_binary_targets.1.html
@@ -192,30 +192,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -226,69 +220,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_binary_targets.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_binary_targets.1.html
@@ -185,129 +185,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_canonicalURL_noImageSnapshots.1.html
@@ -188,30 +188,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -222,69 +216,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_canonicalURL_noImageSnapshots.1.html
@@ -181,129 +181,110 @@
               </div>
               <div class="matrices">
                 <a href="/owner/repo/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/owner/repo/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_canonicalURL_noImageSnapshots.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_canonicalURL_noImageSnapshots.1.html
@@ -184,7 +184,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -199,7 +199,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -214,7 +214,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -243,7 +243,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -264,7 +264,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_customCollection.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_customCollection.1.html
@@ -184,129 +184,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_customCollection.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_customCollection.1.html
@@ -187,7 +187,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -202,7 +202,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -217,7 +217,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -246,7 +246,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -267,7 +267,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_customCollection.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_customCollection.1.html
@@ -191,30 +191,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -225,69 +219,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_emoji_summary.1.html
@@ -188,30 +188,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -222,69 +216,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_emoji_summary.1.html
@@ -181,129 +181,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_emoji_summary.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_emoji_summary.1.html
@@ -184,7 +184,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -199,7 +199,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -214,7 +214,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -243,7 +243,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -264,7 +264,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_few_keywords.1.html
@@ -215,7 +215,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -230,7 +230,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -245,7 +245,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -274,7 +274,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -295,7 +295,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_few_keywords.1.html
@@ -219,30 +219,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -253,69 +247,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_few_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_few_keywords.1.html
@@ -212,129 +212,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_many_keywords.1.html
@@ -394,30 +394,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -428,69 +422,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_many_keywords.1.html
@@ -390,7 +390,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -405,7 +405,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -420,7 +420,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -449,7 +449,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -470,7 +470,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_many_keywords.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_many_keywords.1.html
@@ -387,129 +387,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_authors_activity.1.html
@@ -179,7 +179,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -194,7 +194,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -209,7 +209,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -238,7 +238,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -259,7 +259,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_authors_activity.1.html
@@ -183,30 +183,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -217,69 +211,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_authors_activity.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_authors_activity.1.html
@@ -176,129 +176,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_license.1.html
@@ -184,129 +184,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_license.1.html
@@ -187,7 +187,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -202,7 +202,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -217,7 +217,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -246,7 +246,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -267,7 +267,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_no_license.1.html
@@ -191,30 +191,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -225,69 +219,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_open_source_license.1.html
@@ -186,7 +186,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -201,7 +201,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -216,7 +216,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -245,7 +245,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -266,7 +266,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_open_source_license.1.html
@@ -190,30 +190,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -224,69 +218,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_open_source_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_open_source_license.1.html
@@ -183,129 +183,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_other_license.1.html
@@ -184,129 +184,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_other_license.1.html
@@ -187,7 +187,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -202,7 +202,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -217,7 +217,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -246,7 +246,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -267,7 +267,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_other_license.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_other_license.1.html
@@ -191,30 +191,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -225,69 +219,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_single_row_tables.1.html
@@ -181,59 +181,55 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.5</span>, 
-                          <span class="beta">6.0.0-b1</span>, and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.5</span>
+                        <span class="separator">/</span>
+                        <span class="beta">6.0.0-b1</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.5</span>, 
-                          <span class="beta">6.0.0-b1</span>, and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.5</span>
+                        <span class="separator">/</span>
+                        <span class="beta">6.0.0-b1</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_single_row_tables.1.html
@@ -190,15 +190,11 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -213,23 +209,19 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_single_row_tables.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_single_row_tables.1.html
@@ -186,7 +186,7 @@
                       <div class="label">
                         <span class="stable">5.2.5</span>
                         <span class="separator">/</span>
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -205,7 +205,7 @@
                       <div class="label">
                         <span class="stable">5.2.5</span>
                         <span class="separator">/</span>
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_withPackageFundingLinks.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_withPackageFundingLinks.1.html
@@ -196,30 +196,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -230,69 +224,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_withPackageFundingLinks.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_withPackageFundingLinks.1.html
@@ -189,129 +189,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_withPackageFundingLinks.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_withPackageFundingLinks.1.html
@@ -192,7 +192,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -207,7 +207,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -222,7 +222,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -251,7 +251,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -272,7 +272,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_with_documentation_link.1.html
@@ -188,30 +188,24 @@
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result unknown" title="No build information available for Swift 6.0">6.0
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 4">
-                        <div class="result-label">6.1</div>
-                        <div class="result-label">6.0</div>
-                        <div class="result-label">5.10</div>
-                        <div class="result-label">5.9</div>
-                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10">5.10</div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9">5.9</div>
                       </div>
                     </li>
                   </ul>
@@ -222,69 +216,69 @@
                       <div class="label">
                         <span class="stable">5.2.3</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result unknown" title="No build information available for macOS"></div>
-                        <div class="result unknown" title="No build information available for visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result unknown" title="No build information available for tvOS"></div>
-                        <div class="result unknown" title="No build information available for Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Linux">Linux
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result unknown" title="No build information available for watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                     <li class="version">
                       <div class="label">
                         <span class="branch">main</span>
                       </div>
-                      <div class="results" style="--items-per-row: 8">
-                        <div class="result-label">iOS</div>
-                        <div class="result-label">macOS</div>
-                        <div class="result-label">visionOS</div>
-                        <div class="result-label">watchOS</div>
-                        <div class="result-label">tvOS</div>
-                        <div class="result-label">Linux</div>
-                        <div class="result-label">Wasm</div>
-                        <div class="result-label">Android</div>
-                        <div class="result compatible" title="Built successfully with iOS"></div>
-                        <div class="result compatible" title="Built successfully with macOS"></div>
-                        <div class="result compatible" title="Built successfully with visionOS"></div>
-                        <div class="result compatible" title="Built successfully with watchOS"></div>
-                        <div class="result compatible" title="Built successfully with tvOS"></div>
-                        <div class="result compatible" title="Built successfully with Linux"></div>
-                        <div class="result unknown" title="No build information available for WebAssembly"></div>
-                        <div class="result unknown" title="No build information available for Android"></div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm
+                          <small>(Pending)</small>
+                        </div>
+                        <div class="result unknown" title="No build information available for Android">Android
+                          <small>(Pending)</small>
+                        </div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_with_documentation_link.1.html
@@ -181,129 +181,110 @@
               </div>
               <div class="matrices">
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span> and 
-                          <span class="branch">main</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="unknown" title="No build information available for Swift 6.0"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result unknown" title="No build information available for Swift 6.0"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>6.1</div>
-                        <div>6.0</div>
-                        <div>5.10</div>
-                        <div>5.9</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with Swift 6.1"></div>
-                        <div class="compatible" title="Built successfully with Swift 6.0"></div>
-                        <div class="compatible" title="Built successfully with Swift 5.10"></div>
-                        <div class="incompatible" title="Build failed with Swift 5.9"></div>
+                      <div class="results" style="--items-per-row: 4">
+                        <div class="result-label">6.1</div>
+                        <div class="result-label">6.0</div>
+                        <div class="result-label">5.10</div>
+                        <div class="result-label">5.9</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1"></div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0"></div>
+                        <div class="result compatible" title="Built successfully with Swift 5.10"></div>
+                        <div class="result incompatible" title="Build failed with Swift 5.9"></div>
                       </div>
                     </li>
                   </ul>
                 </a>
                 <a href="/Alamo/Alamofire/builds">
-                  <ul class="matrix compatibility">
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="stable">5.2.3</span>
-                        </p>
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.3</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="unknown" title="No build information available for macOS"></div>
-                        <div class="unknown" title="No build information available for visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="unknown" title="No build information available for tvOS"></div>
-                        <div class="unknown" title="No build information available for Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result unknown" title="No build information available for macOS"></div>
+                        <div class="result unknown" title="No build information available for visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result unknown" title="No build information available for tvOS"></div>
+                        <div class="result unknown" title="No build information available for Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="beta">6.0.0-b1</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="beta">6.0.0-b1</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="unknown" title="No build information available for watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result unknown" title="No build information available for watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
-                    <li class="row">
-                      <div class="row-labels">
-                        <p>
-                          <span class="branch">main</span>
-                        </p>
+                    <li class="version">
+                      <div class="label">
+                        <span class="branch">main</span>
                       </div>
-                      <div class="column-labels">
-                        <div>iOS</div>
-                        <div>macOS</div>
-                        <div>visionOS</div>
-                        <div>watchOS</div>
-                        <div>tvOS</div>
-                        <div>Linux</div>
-                        <div>Wasm</div>
-                        <div>Android</div>
-                      </div>
-                      <div class="results">
-                        <div class="compatible" title="Built successfully with iOS"></div>
-                        <div class="compatible" title="Built successfully with macOS"></div>
-                        <div class="compatible" title="Built successfully with visionOS"></div>
-                        <div class="compatible" title="Built successfully with watchOS"></div>
-                        <div class="compatible" title="Built successfully with tvOS"></div>
-                        <div class="compatible" title="Built successfully with Linux"></div>
-                        <div class="unknown" title="No build information available for WebAssembly"></div>
-                        <div class="unknown" title="No build information available for Android"></div>
+                      <div class="results" style="--items-per-row: 8">
+                        <div class="result-label">iOS</div>
+                        <div class="result-label">macOS</div>
+                        <div class="result-label">visionOS</div>
+                        <div class="result-label">watchOS</div>
+                        <div class="result-label">tvOS</div>
+                        <div class="result-label">Linux</div>
+                        <div class="result-label">Wasm</div>
+                        <div class="result-label">Android</div>
+                        <div class="result compatible" title="Built successfully with iOS"></div>
+                        <div class="result compatible" title="Built successfully with macOS"></div>
+                        <div class="result compatible" title="Built successfully with visionOS"></div>
+                        <div class="result compatible" title="Built successfully with watchOS"></div>
+                        <div class="result compatible" title="Built successfully with tvOS"></div>
+                        <div class="result compatible" title="Built successfully with Linux"></div>
+                        <div class="result unknown" title="No build information available for WebAssembly"></div>
+                        <div class="result unknown" title="No build information available for Android"></div>
                       </div>
                     </li>
                   </ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_with_documentation_link.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_with_documentation_link.1.html
@@ -184,7 +184,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                         <span class="separator">/</span>
                         <span class="branch">main</span>
                       </div>
@@ -199,7 +199,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
@@ -214,7 +214,7 @@
                   <ul class="matrix">
                     <li class="version">
                       <div class="label">
-                        <span class="stable">5.2.3</span>
+                        <span class="longest stable">5.2.3</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -243,7 +243,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="beta">6.0.0-b1</span>
+                        <span class="longest beta">6.0.0-b1</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>
@@ -264,7 +264,7 @@
                     </li>
                     <li class="version">
                       <div class="label">
-                        <span class="branch">main</span>
+                        <span class="longest branch">main</span>
                       </div>
                       <div class="results">
                         <div class="result compatible" title="Built successfully with iOS">iOS</div>


### PR DESCRIPTION
There are a few options with the matrix redesign. I wanted to combine the header with the compatibility information and have moved the platform and Swift version names inside the cells, coloured with the existing colours:

![Screenshot 2025-05-22 at 17 43 55@2x](https://github.com/user-attachments/assets/397f9f0e-9041-4737-932e-9959a19d6311)

Unfortunately, it’s not very clear the difference between a pending/unknown state and a failed state for someone who is unfamiliar with the site. We could do something like this:

![Screenshot 2025-05-22 at 18 01 10@2x](https://github.com/user-attachments/assets/b9b863ab-f9c1-4393-9eb8-a3857b428acf)

Alternatively, there is a version in `f2945ee05e91d19fd2d004cee9d32d7bbb4d51ad` that keeps the headers separated, and looks like this:

![Screenshot 2025-05-22 at 18 14 11@2x](https://github.com/user-attachments/assets/329a7975-1b18-45b3-888e-d127f6f40483)

Unfortunately, that takes up significantly more vertical space, especially when compatibility does not match between versions. While it’s nice and clear, it pushes the README way too far down.

![Screenshot 2025-05-22 at 18 13 17@2x](https://github.com/user-attachments/assets/290b354f-4383-41b1-9d40-4a9b7b00bebc)

### Other Improvements

This redesign also changes how we label the versions above the matrices. They’re now separated with a “/” instead of a sentence and it copes with extremely long tag names by truncating the _longest_ tag when they don’t fit on one line:

![Screenshot 2025-05-22 at 19 38 16@2x](https://github.com/user-attachments/assets/1d792caf-0aca-488e-8317-6cefbcbf91e0)

