### PR TITLE
Use file_copy strategy when creating databases

### DIFF
--- a/Tests/AppTests/Helpers/DatabasePool.swift
+++ b/Tests/AppTests/Helpers/DatabasePool.swift
@@ -209,7 +209,7 @@ extension DatabasePool.Database {
             try await _withDatabase("postgres", details: connectionDetails, timeout: .seconds(10)) {  // Connect to `postgres` db in order to reset the test db
                 let databaseName = Environment.get("DATABASE_NAME")!
                 try await $0.query(PostgresQuery(unsafeSQL: "DROP DATABASE IF EXISTS \(databaseName) WITH (FORCE)"))
-                try await $0.query(PostgresQuery(unsafeSQL: "CREATE DATABASE \(databaseName)"))
+                try await $0.query(PostgresQuery(unsafeSQL: "CREATE DATABASE \(databaseName) STRATEGY = file_copy"))
             }
 
             do {  // Use autoMigrate to spin up the schema
@@ -231,7 +231,7 @@ extension DatabasePool.Database {
         do {
             try await _withDatabase("postgres", details: connectionDetails, timeout: .seconds(10)) { client in
                 try await client.query(PostgresQuery(unsafeSQL: "DROP DATABASE IF EXISTS \(snapshot) WITH (FORCE)"))
-                try await client.query(PostgresQuery(unsafeSQL: "CREATE DATABASE \(snapshot) TEMPLATE \(original)"))
+                try await client.query(PostgresQuery(unsafeSQL: "CREATE DATABASE \(snapshot) TEMPLATE \(original) STRATEGY = file_copy"))
             }
         } catch {
             print("Create snapshot failed with error: ", String(reflecting: error))
@@ -246,7 +246,7 @@ extension DatabasePool.Database {
         do {
             try await _withDatabase("postgres", details: details, timeout: .seconds(10)) { client in
                 try await client.query(PostgresQuery(unsafeSQL: "DROP DATABASE IF EXISTS \(original) WITH (FORCE)"))
-                try await client.query(PostgresQuery(unsafeSQL: "CREATE DATABASE \(original) TEMPLATE \(snapshot)"))
+                try await client.query(PostgresQuery(unsafeSQL: "CREATE DATABASE \(original) TEMPLATE \(snapshot) STRATEGY = file_copy"))
             }
         } catch {
             print("Restore snapshot failed with error: ", String(reflecting: error))


### PR DESCRIPTION
The difference is tiny given how fast our tests are running now but we might as well put it in, if anything more as a safeguard against future regressions should the default strategy change to something slower again.

```
Series: Default Strategy
Suite AllTests passed after 5.081 seconds
Suite AllTests passed after 5.274 seconds
Suite AllTests passed after 5.306 seconds
Suite AllTests passed after 5.224 seconds
Suite AllTests passed after 6.343 seconds
Suite AllTests passed after 5.450 seconds
Series: file_copy Strategy
Suite AllTests passed after 4.729 seconds
Suite AllTests passed after 4.755 seconds
Suite AllTests passed after 4.739 seconds
Suite AllTests passed after 4.772 seconds
Suite AllTests passed after 4.866 seconds
Suite AllTests passed after 4.855 seconds
```

![out](https://github.com/user-attachments/assets/027d44ab-9971-4b52-8d00-9c812b322f96)
