### PR TITLE
Speed up GH build pipeline

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
+FROM registry.gitlab.com/finestructure/spi-base:1.2.2
 
 # Install SPM build dependencies
 RUN apt-get update && apt-get install -y curl git make unzip \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.gitlab.com/finestructure/spi-base:1.2.0
+FROM registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
 
 # Install SPM build dependencies
 RUN apt-get update && apt-get install -y curl git make unzip \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,10 +51,8 @@ jobs:
           key: "spi-debug-build-${{ runner.os }}-${{ github.event.after }}"
           restore-keys: "spi-debug-build-${{ runner.os }}-"
 
-      - name: Run tests
-        run: cp .env.testing.template .env.testing && make test
-        env:
-          COLLECTION_SIGNING_PRIVATE_KEY: ${{ secrets.COLLECTION_SIGNING_PRIVATE_KEY }}
+      - name: Build tests
+        run: cp .env.testing.template .env.testing && make build-tests
 
       - name: Cache .build
         if: steps.restore-cache.outputs.cache-hit != 'true'
@@ -62,6 +60,11 @@ jobs:
         with:
           path: .build
           key: "spi-debug-build-${{ runner.os }}-${{ github.event.after }}"
+
+      - name: Run tests
+        run: cp .env.testing.template .env.testing && make run-tests
+        env:
+          COLLECTION_SIGNING_PRIVATE_KEY: ${{ secrets.COLLECTION_SIGNING_PRIVATE_KEY }}
           
     services:
       spi_test_0:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,15 +34,35 @@ jobs:
     steps:
       - name: GH Runner bug workaround
         run: sysctl -w vm.mmap_rnd_bits=28
+
       - name: Checkout code
         uses: actions/checkout@v4
         with: { 'fetch-depth': 0 }
-      - name: Install unzip
-        run: apt-get update && apt-get install -y unzip
+
+      - name: Install unzip (for tests) and zstd (for faster caching)
+        run: apt-get update && apt-get install -y unzip zstd
+
+      - name: Restore .build
+        if: ${{ !(github.run_attempt > 1) }} # Because maybe the cache is causing issues
+        id: "restore-cache"
+        uses: actions/cache/restore@v4
+        with:
+          path: .build
+          key: "spi-debug-build-${{ runner.os }}-${{ github.event.after }}"
+          restore-keys: "spi-debug-build-${{ runner.os }}-"
+
       - name: Run tests
         run: cp .env.testing.template .env.testing && make test
         env:
           COLLECTION_SIGNING_PRIVATE_KEY: ${{ secrets.COLLECTION_SIGNING_PRIVATE_KEY }}
+
+      - name: Cache .build
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .build
+          key: "spi-debug-build-${{ runner.os }}-${{ github.event.after }}"
+          
     services:
       spi_test_0:
         image: postgres:16-alpine
@@ -172,7 +192,7 @@ jobs:
         with:
           path: .build
           key: "spi-release-build-${{ runner.os }}-${{ github.event.after }}"
-          
+
       - name: Test release
         run: |
           $(swift build --show-bin-path -c release)/Run serve --port 8080 --hostname 0.0.0.0 &

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
+      image: registry.gitlab.com/finestructure/spi-base:1.2.2
       options: --privileged
     steps:
       - name: GH Runner bug workaround
@@ -157,7 +157,7 @@ jobs:
     name: Release build
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
+      image: registry.gitlab.com/finestructure/spi-base:1.2.2
       options: --privileged
     steps:
       - name: GH Runner bug workaround

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,15 +142,39 @@ jobs:
     steps:
       - name: GH Runner bug workaround
         run: sysctl -w vm.mmap_rnd_bits=28
+
       - name: Checkout code
         uses: actions/checkout@v4
         with: { 'fetch-depth': 0 }
-      - name: Test release
+
+      - name: Install zstd (for faster caching)
+        run: apt-get update && apt-get install -y zstd
+
+      - name: Restore .build
+        if: ${{ !(github.run_attempt > 1) }} # Because maybe the cache is causing issues
+        id: "restore-cache"
+        uses: actions/cache/restore@v4
+        with:
+          path: .build
+          key: "spi-release-build-${{ runner.os }}-${{ github.event.after }}"
+          restore-keys: "spi-release-build-${{ runner.os }}-"
+
+      - name: Build release
         run: |
           # Since we're only pinging the version api endpoint, no database is needed and
           # we can just copy the development template to ensure the db env variables are set.
           cp .env.development.template .env.development
           swift build -c release --static-swift-stdlib -Xlinker -ljemalloc --enable-experimental-prebuilts
+
+      - name: Cache .build
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .build
+          key: "spi-release-build-${{ runner.os }}-${{ github.event.after }}"
+          
+      - name: Test release
+        run: |
           $(swift build --show-bin-path -c release)/Run serve --port 8080 --hostname 0.0.0.0 &
           sleep 10
           echo Probing api/version...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1.2.0
+      image: registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
       options: --privileged
     steps:
       - name: GH Runner bug workaround
@@ -137,7 +137,7 @@ jobs:
     name: Release build
     runs-on: ubuntu-latest
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1.2.0
+      image: registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
       options: --privileged
     steps:
       - name: GH Runner bug workaround

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,7 +150,7 @@ jobs:
           # Since we're only pinging the version api endpoint, no database is needed and
           # we can just copy the development template to ensure the db env variables are set.
           cp .env.development.template .env.development
-          swift build -c release --static-swift-stdlib -Xlinker -ljemalloc
+          swift build -c release --static-swift-stdlib -Xlinker -ljemalloc --enable-experimental-prebuilts
           $(swift build --show-bin-path -c release)/Run serve --port 8080 --hostname 0.0.0.0 &
           sleep 10
           echo Probing api/version...

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: registry.gitlab.com/finestructure/spi-base:1.2.0
+      image: registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -33,8 +33,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with: { 'fetch-depth': 0 }
-      - name: Install unzip
-        run: apt-get update && apt-get install -y unzip
+
+      - name: Install unzip (for tests) and zstd (for faster caching)
+        run: apt-get update && apt-get install -y unzip zstd
+
+      - name: Restore .build
+        if: ${{ !(github.run_attempt > 1) }} # Because maybe the cache is causing issues
+        id: "restore-cache"
+        uses: actions/cache/restore@v4
+        with:
+          path: .build
+          key: "spi-query-performance-build-${{ runner.os }}-${{ github.event.after }}"
+          restore-keys: "spi-query-performance-build-${{ runner.os }}-"
+
+      - name: Build tests
+        run: cp .env.testing.template .env.testing && make build-tests
+
+      - name: Cache .build
+        if: steps.restore-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: .build
+          key: "spi-query-performance-build-${{ runner.os }}-${{ github.event.after }}"
+        
       - name: Run tests
         run: |
           echo "
@@ -45,4 +66,4 @@ jobs:
           DATABASE_USE_TLS=true
           DATABASE_USERNAME=spi_dev
           " >> .env.staging
-          make test-query-performance
+          make run-query-performance-tests

--- a/.github/workflows/query-performance.yml
+++ b/.github/workflows/query-performance.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     container:
-      image: registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
+      image: registry.gitlab.com/finestructure/spi-base:1.2.2
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # ================================
 # Build image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:1.2.0 as build
+FROM registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc as build
 
 # Set up a build area
 WORKDIR /build
@@ -61,7 +61,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:1.2.0
+FROM registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
 
 # NB sas 2022-09-23: We're not using a dedicated `vapor` user to run the executable, because it
 # makes managing the data in the checkouts volume difficult. See

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@
 # ================================
 # Build image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc as build
+FROM registry.gitlab.com/finestructure/spi-base:1.2.2 as build
 
 # Set up a build area
 WORKDIR /build
@@ -62,7 +62,7 @@ RUN [ -d /build/Resources ] && { mv /build/Resources ./Resources && chmod -R a-w
 # ================================
 # Run image
 # ================================
-FROM registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc
+FROM registry.gitlab.com/finestructure/spi-base:1.2.2
 
 # NB sas 2022-09-23: We're not using a dedicated `vapor` user to run the executable, because it
 # makes managing the data in the checkouts volume difficult. See

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY . .
 # Build everything, with optimizations, with static linking, and using jemalloc
 # N.B.: The static version of jemalloc is incompatible with the static Swift runtime.
 RUN swift build -c release \
+                --enable-experimental-prebuilts \
                 --static-swift-stdlib \
                 -Xlinker -ljemalloc
 

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -238,7 +238,7 @@ The trickiest part of this is to ensure the test or app container can connect to
 So, in order to run the tests in a Linux container run:
 
 ```
-docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc swift test
+docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:1.2.2 swift test
 ```
 
 Make sure you use the most recent `spi-base` image. You can find the latest image name in the `test-docker` target, which also provides a convenient way to run all all tests in a docker container.

--- a/LOCAL_DEVELOPMENT_SETUP.md
+++ b/LOCAL_DEVELOPMENT_SETUP.md
@@ -238,7 +238,7 @@ The trickiest part of this is to ensure the test or app container can connect to
 So, in order to run the tests in a Linux container run:
 
 ```
-docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:1.2.0 swift test
+docker run --rm -v "$PWD":/host -w /host --add-host=host.docker.internal:host-gateway registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc swift test
 ```
 
 Make sure you use the most recent `spi-base` image. You can find the latest image name in the `test-docker` target, which also provides a convenient way to run all all tests in a docker container.

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ else
 endif
 
 build:
-	swift build --disable-automatic-resolution
+	swift build --disable-automatic-resolution --enable-experimental-prebuilts
+
 
 run:
 	swift run
@@ -36,12 +37,14 @@ run:
 test: xcbeautify
 	set -o pipefail \
 	&& swift test --disable-automatic-resolution \
+	--enable-experimental-prebuilts \
 	2>&1 | ./xcbeautify --renderer github-actions
 
 test-query-performance: xcbeautify
 	set -o pipefail \
 	&& env RUN_QUERY_PERFORMANCE_TESTS=true \
 	   swift test --disable-automatic-resolution \
+	   --enable-experimental-prebuilts \
 	   --filter QueryPerformanceTests \
 	2>&1 | tee test.log
 	grep "ℹ️" test.log

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,24 @@ endif
 build:
 	swift build --disable-automatic-resolution --enable-experimental-prebuilts
 
-
 run:
 	swift run
 
-test: xcbeautify
+build-tests: xcbeautify
 	set -o pipefail \
-	&& swift test --disable-automatic-resolution \
+	&& swift build --build-tests \
+	--disable-automatic-resolution \
 	--enable-experimental-prebuilts \
 	2>&1 | xcbeautify --renderer github-actions
+
+run-tests: xcbeautify
+	set -o pipefail \
+	&& swift test --skip-build \
+	--disable-automatic-resolution \
+	--enable-experimental-prebuilts \
+	2>&1 | xcbeautify --renderer github-actions
+
+test: build-tests run-tests
 
 test-query-performance: xcbeautify
 	set -o pipefail \

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test: xcbeautify
 	set -o pipefail \
 	&& swift test --disable-automatic-resolution \
 	--enable-experimental-prebuilts \
-	2>&1 | ./xcbeautify --renderer github-actions
+	2>&1 | xcbeautify --renderer github-actions
 
 test-query-performance: xcbeautify
 	set -o pipefail \
@@ -56,10 +56,7 @@ test-fast:
 	swift test --disable-automatic-resolution
 
 xcbeautify:
-	rm -rf .build/checkouts/xcbeautify
-	git clone https://github.com/cpisciotta/xcbeautify.git .build/checkouts/xcbeautify
-	cd .build/checkouts/xcbeautify && git checkout 2.25.1 && make build
-	binpath=`cd .build/checkouts/xcbeautify && swift build -c release --show-bin-path` && ln -sf $$binpath/xcbeautify
+	command -v xcbeautify
 
 docker-build: version
 	docker build -t $(DOCKER_IMAGE):$(VERSION) .

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ test-docker:
 	@# run tests inside a docker container
 	docker run --rm -v "$(PWD)":/host -w /host \
 	  --add-host=host.docker.internal:host-gateway \
-	  registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc \
+	  registry.gitlab.com/finestructure/spi-base:1.2.2 \
 	  make test
 
 test-e2e: db-reset reconcile ingest analyze

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,15 @@ run-tests: xcbeautify
 
 test: build-tests run-tests
 
+build-query-performance-tests:
+	set -o pipefail \
+	&& env RUN_QUERY_PERFORMANCE_TESTS=true \
+	   swift build --build-tests \
+	   --disable-automatic-resolution \
+	   --enable-experimental-prebuilts \
+	   --filter QueryPerformanceTests \
+	2>&1 | xcbeautify --renderer github-actions
+
 run-query-performance-tests:
 	set -o pipefail \
 	&& env RUN_QUERY_PERFORMANCE_TESTS=true \
@@ -58,9 +67,9 @@ run-query-performance-tests:
 	   --filter QueryPerformanceTests \
 	2>&1 | tee test.log
 	grep "ℹ️" test.log
-	grep -v "\] Compiling" test.log | ./xcbeautify --renderer github-actions
+	grep -v "\] Compiling" test.log | xcbeautify --renderer github-actions
 
-test-query-performance: build-tests run-query-performance-tests
+test-query-performance: build-query-performance-tests run-query-performance-tests
 
 test-fast:
 	@echo Skipping image snapshot tests

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-docker:
 	@# run tests inside a docker container
 	docker run --rm -v "$(PWD)":/host -w /host \
 	  --add-host=host.docker.internal:host-gateway \
-	  registry.gitlab.com/finestructure/spi-base:1.2.0 \
+	  registry.gitlab.com/finestructure/spi-base:224946a41aedd5106245666d7261a5218ceac0fc \
 	  make test
 
 test-e2e: db-reset reconcile ingest analyze

--- a/Makefile
+++ b/Makefile
@@ -49,15 +49,18 @@ run-tests: xcbeautify
 
 test: build-tests run-tests
 
-test-query-performance: xcbeautify
+run-query-performance-tests:
 	set -o pipefail \
 	&& env RUN_QUERY_PERFORMANCE_TESTS=true \
-	   swift test --disable-automatic-resolution \
+	   swift test --skip-build \
+	   --disable-automatic-resolution \
 	   --enable-experimental-prebuilts \
 	   --filter QueryPerformanceTests \
 	2>&1 | tee test.log
 	grep "ℹ️" test.log
 	grep -v "\] Compiling" test.log | ./xcbeautify --renderer github-actions
+
+test-query-performance: build-tests run-query-performance-tests
 
 test-fast:
 	@echo Skipping image snapshot tests

--- a/Tests/AppTests/QueryPerformanceTests.swift
+++ b/Tests/AppTests/QueryPerformanceTests.swift
@@ -180,7 +180,7 @@ struct QueryPerformanceTests {
                   JOIN versions v ON v.package_id = p.id
                 WHERE v.reference ->> 'branch' = r.default_branch
                 """)
-            try await assertQueryPerformance(query, expectedCost: 150_000, variation: 5000)
+            try await assertQueryPerformance(query, expectedCost: 160_000, variation: 5000)
         }
     }
 


### PR DESCRIPTION
Unfortunately, we can't benefit from this new flag that uses pre-built SwiftSyntax libraries at the moment.

Due to our dependence on SwiftPM's branch release/6.1, we depend on SwiftSyntax release/6.1, which does not have a prebuilt library and we end up building it ourselves, as before 😞