### PR TITLE
Set cache headers on package collection requests

### DIFF
--- a/Sources/App/Controllers/API/API+PackageCollectionController.swift
+++ b/Sources/App/Controllers/API/API+PackageCollectionController.swift
@@ -64,8 +64,19 @@ extension API {
 extension SignedCollection: @retroactive RequestDecodable {}
 extension SignedCollection: @retroactive ResponseEncodable {}
 extension SignedCollection: @retroactive AsyncRequestDecodable {}
-extension SignedCollection: @retroactive AsyncResponseEncodable {}
 extension SignedCollection: @retroactive Content {}
+
+extension SignedCollection: @retroactive AsyncResponseEncodable {
+    public func encodeResponse(for request: Request) async throws -> Response {
+        let res = Response(status: .ok)
+        try res.content.encode(self)
+
+        // Set cache control headers to tell Cloudflare not to transform the data, and to cache it for 2 hours.
+        res.headers.replaceOrAdd(name: .cacheControl, value: "public, max-age=7200, s-maxage=7200, no-transform")
+
+        return res
+    }
+}
 
 
 extension API {


### PR DESCRIPTION
Might fix: #3885

My guess as to why this has manifested now is that SwiftPM/Xcode in Swift 6.2 check for a content-length where in earlier versions they did not.

Unfortunately, the content-length response header is being removed by Cloudflare. For proof of this, check these two logs:

```
$ curl -svo /dev/null --http2 --compressed https://swiftpackageindex.com/daveverwer/collection.json 

…
…
…
 
* Request completely sent off
< HTTP/2 200 
< date: Mon, 06 Oct 2025 22:06:31 GMT
< content-type: application/json; charset=utf-8
< server: cloudflare
< vary: accept-encoding
< last-modified: Mon, 06 Oct 2025 22:06:31 GMT
< cache-control: no-store
< cf-cache-status: MISS
< content-encoding: gzip
< cf-ray: 98a87761b9d2b2e5-LHR
< 
{ [1360 bytes data]
* Connection #0 to host swiftpackageindex.com left intact
```

and direct to source, bypassing Cloudflare:

```
$ curl -svo /dev/null --http2 --compressed http://spi-prod.swiftpackageindex.com/daveverwer/collection.json 

…
…
…
 
* Request completely sent off
< HTTP/1.1 200 OK
< content-type: application/json; charset=utf-8
< content-length: 16245
< connection: keep-alive
< date: Mon, 06 Oct 2025 22:07:28 GMT
< 
{ [13830 bytes data]
* Connection #0 to host spi-prod.swiftpackageindex.com left intact
```

This patch sets an explicit cache control header that Cloudflare will interpret and honour to not modify anything coming from the server. Specifically, the `no-transform` header is what will hopefully stop it removing the header.