### PR TITLE
Remove cache mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,7 @@ RUN mkdir /staging
 
 # Build everything, with optimizations, with static linking, and using jemalloc
 # N.B.: The static version of jemalloc is incompatible with the static Swift runtime.
-RUN --mount=type=cache,target=/build/.build \
-    swift build -c release \
+RUN swift build -c release \
         --enable-experimental-prebuilts \
         --static-swift-stdlib \
         -Xlinker -ljemalloc


### PR DESCRIPTION
This was still failing (in a different way):

```
ERROR: failed to solve: process "/bin/sh -c cp \"$(swift build --package-path /build -c release --show-bin-path)/Run\" ./" did not complete successfully: exit code: 1
```

https://gitlab.com/finestructure/swiftpackageindex/-/jobs/12584043933

I'm not sure if the cache mount was doing anything useful in our case but we can check that out again later.