### PR TITLE
Fix layout shift in website header

### DIFF
--- a/Sources/App/Views/PublicPage.swift
+++ b/Sources/App/Views/PublicPage.swift
@@ -306,6 +306,8 @@ class PublicPage {
                     .h1(
                         .img(
                             .alt("The Swift Package Index logo."),
+                            .attribute(named: "width", value: "64"),
+                            .attribute(named: "height", value: "64"),
                             .src(SiteURL.images("logo.svg").relativeURL())
                         ),
                         "Swift Package Index"


### PR DESCRIPTION
I've fixed the layout shift in the website header by adding dimensions to the logo image. I confirmed this works when running the website locally.