### PR TITLE
Add 0BSD (Zero-Clause BSD) license support

### DIFF
--- a/Sources/App/Models/License.swift
+++ b/Sources/App/Models/License.swift
@@ -15,6 +15,7 @@
 enum License: String, Codable, Equatable, CaseIterable {
 
     // This is not an exhaustive list, but includes most commonly used license types
+    case bsd_0_clause = "0bsd"
     case afl_3_0 = "afl-3.0"
     case apache_2_0 = "apache-2.0"
     case artistic_2_0 = "artistic-2.0"
@@ -53,6 +54,7 @@ enum License: String, Codable, Equatable, CaseIterable {
 
     var fullName: String {
         switch self {
+            case .bsd_0_clause: return "BSD Zero Clause License"
             case .afl_3_0: return "Academic Free License v3.0"
             case .apache_2_0: return "Apache License 2.0"
             case .artistic_2_0: return "Artistic License 2.0"
@@ -92,6 +94,7 @@ enum License: String, Codable, Equatable, CaseIterable {
 
     var shortName: String {
         switch self {
+            case .bsd_0_clause: return "0BSD"
             case .afl_3_0: return "AFL 3.0"
             case .apache_2_0: return "Apache 2.0"
             case .artistic_2_0: return "Artistic 2.0"

--- a/Tests/AppTests/LicenseTests.swift
+++ b/Tests/AppTests/LicenseTests.swift
@@ -22,6 +22,7 @@ extension AllTests.LicenseTests {
     @Test func init_from_dto() throws {
         #expect(License(from: Github.Metadata.LicenseInfo(key: "mit")) == .mit)
         #expect(License(from: Github.Metadata.LicenseInfo(key: "agpl-3.0")) == .agpl_3_0)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "0bsd")) == .bsd_0_clause)
         #expect(License(from: Github.Metadata.LicenseInfo(key: "other")) == .other)
         #expect(License(from: .none) == .none)
     }


### PR DESCRIPTION
## Summary
- Adds `0bsd` to the `License` enum so packages with the BSD Zero Clause License are correctly recognized
- Without this, GitHub reports `"0bsd"` as the license key but SPI falls through to `.other`, showing the license as unknown/orange

Fixes #3956

## Changes
- `License.swift`: Add `bsd_0_clause` case with raw value `"0bsd"`, full name "BSD Zero Clause License", short name "0BSD"
- `LicenseTests.swift`: Add test for `0bsd` key mapping

The license is permissive and falls under the existing `default` → `.compatibleWithAppStore` classification, so no change needed to `licenseKind`.

## Test plan
- [x] Added test case for `0bsd` DTO key mapping
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)