### PR TITLE
Align Swift dependabot section with SPIManifest's

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -28,8 +27,6 @@ updates:
           - "*"
   - package-ecosystem: "swift"
     directory: "/"
-    allow:
-      - dependency-type: all
     commit-message:
       prefix: "Swift:"
     schedule:


### PR DESCRIPTION
SPIManifest's dependabot is working while the one in this repo doesn't. There are very few differences and none of them looks problematic.