### PR TITLE
Bring back `allow: [dependency-type: all]`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,8 @@ updates:
           - "*"
   - package-ecosystem: "swift"
     directory: "/"
+    allow:
+      - dependency-type: all
     commit-message:
       prefix: "Swift:"
     schedule:


### PR DESCRIPTION
Perhaps this is why not all dependency updates are being discovered.