### PR TITLE
Redirect bare reference URLs to documentation

### DIFF
--- a/Sources/App/routes+documentation.swift
+++ b/Sources/App/routes+documentation.swift
@@ -32,6 +32,9 @@ func docRoutes(_ app: Application) throws {
     app.get(":owner", ":repository", ":reference", "documentation") { req -> Response in
         req.redirect(to: SiteURL.relativeURL(for: try await req.getDocRedirect(), fragment: .documentation))
     }
+    app.get(":owner", ":repository", ":reference") { req -> Response in
+        req.redirect(to: SiteURL.relativeURL(for: try await req.getDocRedirect(), fragment: .documentation))
+    }
 
     // Stable URLs with reference (real reference or ~)
     app.get(":owner", ":repository", ":reference", "documentation", ":archive") {

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -576,6 +576,12 @@ extension AllTests.PackageController_routesTests {
                 #expect(res.status == .seeOther)
                 #expect(res.headers.location == "/owner/package/1.0.0/tutorials/foo")
             }
+
+            // Test bare reference redirect (no /documentation suffix)
+            try await app.testing().test(.GET, "/owner/package/main") { res async in
+                #expect(res.status == .seeOther)
+                #expect(res.headers.location == "/owner/package/main/documentation/target")
+            }
         }
     }
 


### PR DESCRIPTION
With this change, we redirect `/:owner/:repository/:reference` to the documentation page for that reference (e.g., `/DePasqualeOrg/swift-mcp/main` → `/DePasqualeOrg/swift-mcp/main/documentation/mcp`).

Users might reasonably try to access documentation at a bare reference URL like `/owner/repo/main`, which currently 404s. This redirect improves discoverability by guiding them to the right place.

This uses the same `getDocRedirect()` logic as the existing `/:owner/:repository/:reference/documentation` redirect route. If no documentation exists for the given reference, the request 404s as before.

Relates to #3944.