### PR TITLE
Move dependabot to different time of day

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,7 +33,7 @@ updates:
       prefix: "Swift:"
     schedule:
       interval: "daily"
-      time: "02:00"
+      time: "08:00"
     groups:
       swift-dependencies:
         patterns:


### PR DESCRIPTION
Don't really know what else to try but since it ran fine last week when I changed the config file in the morning, perhaps this might help.