### PR TITLE
Pin footer to bottom of viewport on short-content pages

### DIFF
--- a/FrontEnd/styles/base.scss
+++ b/FrontEnd/styles/base.scss
@@ -21,6 +21,9 @@
 }
 
 body {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
     font-family:
         -apple-system, BlinkMacSystemFont, 'SF Hello', 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif,
         'Apple Color Emoji', 'Segoe UI Emoji';

--- a/FrontEnd/styles/layout.scss
+++ b/FrontEnd/styles/layout.scss
@@ -21,8 +21,12 @@
     margin: 0 auto;
 }
 
-main > .inner {
-    padding: 20px 10px;
+main {
+    flex-grow: 1;
+
+    > .inner {
+        padding: 20px 10px;
+    }
 }
 
 .two-column {


### PR DESCRIPTION
On pages with little content (e.g. the 404 page), the footer floats in the middle of the viewport instead of staying at the bottom.

This change uses a flexbox sticky footer pattern: `body` becomes a flex column with `min-height: 100vh`, and `main` gets `flex-grow: 1` to fill the remaining space.

## Changes

- `FrontEnd/styles/base.scss`: Add `display: flex`, `flex-direction: column`, and `min-height: 100vh` to `body`
- `FrontEnd/styles/layout.scss`: Add `flex-grow: 1` to `main`

## Before

<img width="921" height="718" alt="before" src="https://github.com/user-attachments/assets/959fe4ed-168c-415e-9051-2ddd31bf1fc2" />

## After

<img width="921" height="718" alt="after" src="https://github.com/user-attachments/assets/c41fefb7-b2d5-481b-b2e3-037c3183c5ce" />
