### PR TITLE
Show helpful links on reference route

### DIFF
--- a/Sources/App/Views/ReferenceIndex.swift
+++ b/Sources/App/Views/ReferenceIndex.swift
@@ -1,0 +1,62 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Plot
+
+
+enum ReferenceIndex {
+
+    struct Model {
+        var owner: String
+        var repository: String
+        var reference: String
+        var packageURL: String
+        var documentationURL: String?
+    }
+
+    final class View: PublicPage {
+        let model: Model
+
+        init(path: String, model: Model) {
+            self.model = model
+            super.init(path: path)
+        }
+
+        override func allowIndexing() -> Bool { false }
+
+        override func pageTitle() -> String? {
+            "\(model.owner)/\(model.repository) – \(model.reference)"
+        }
+
+        override func breadcrumbs() -> [Breadcrumb] {
+            [
+                Breadcrumb(title: "Home", url: SiteURL.home.relativeURL()),
+                Breadcrumb(title: "\(model.owner)/\(model.repository)", url: model.packageURL),
+                Breadcrumb(title: model.reference)
+            ]
+        }
+
+        override func content() -> Node<HTML.BodyContext> {
+            .section(
+                .ul(
+                    .unwrap(model.documentationURL) { url in
+                        .li(.a(.href(url), "Documentation"))
+                    },
+                    .li(.a(.href(model.packageURL), "Package page"))
+                )
+            )
+        }
+    }
+
+}

--- a/Sources/App/routes+documentation.swift
+++ b/Sources/App/routes+documentation.swift
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import Dependencies
+import Plot
 import Vapor
 
 
@@ -31,6 +32,33 @@ func docRoutes(_ app: Application) throws {
     }
     app.get(":owner", ":repository", ":reference", "documentation") { req -> Response in
         req.redirect(to: SiteURL.relativeURL(for: try await req.getDocRedirect(), fragment: .documentation))
+    }
+    app.get(":owner", ":repository", ":reference") { req -> HTML in
+        guard let owner = req.parameters.get("owner"),
+              let repository = req.parameters.get("repository"),
+              let reference = req.parameters.get("reference")
+        else { throw Abort(.badRequest) }
+
+        // Verify the package exists (throws 404 if not)
+        _ = try await Joined<Package, Repository>.query(on: req.db, owner: owner, repository: repository)
+
+        let docTarget = try await DocumentationTarget.query(
+            on: req.db, owner: owner, repository: repository,
+            docVersion: .reference(reference)
+        )
+        let documentationURL = docTarget.map {
+            SiteURL.relativeURL(owner: owner, repository: repository,
+                                documentation: $0, fragment: .documentation)
+        }
+        let packageURL = SiteURL.package(.value(owner), .value(repository), nil).relativeURL()
+        let model = ReferenceIndex.Model(
+            owner: owner,
+            repository: repository,
+            reference: reference,
+            packageURL: packageURL,
+            documentationURL: documentationURL
+        )
+        return ReferenceIndex.View(path: req.url.path, model: model).document()
     }
 
     // Stable URLs with reference (real reference or ~)

--- a/Tests/AppTests/PackageController+routesTests.swift
+++ b/Tests/AppTests/PackageController+routesTests.swift
@@ -862,6 +862,90 @@ extension AllTests.PackageController_routesTests {
         }
     }
 
+    @Test func referenceIndex_withDocumentation() async throws {
+        try await withSPIApp { app in
+            // setup
+            let pkg = try await savePackage(on: app.db, "1")
+            try await Repository(package: pkg, name: "package", owner: "owner")
+                .save(on: app.db)
+            try await Version(package: pkg,
+                              commit: "0123456789",
+                              commitDate: .t0,
+                              docArchives: [.init(name: "target", title: "Target")],
+                              latest: .defaultBranch,
+                              packageName: "pkg",
+                              reference: .branch("main"))
+            .save(on: app.db)
+
+            // MUT
+            try await app.testing().test(.GET, "/owner/package/main") { res async in
+                #expect(res.status == .ok)
+                let body = res.body.asString()
+                #expect(body.contains("href=\"/owner/package/main/documentation/target\""))
+                #expect(body.contains("href=\"/owner/package\""))
+            }
+        }
+    }
+
+    @Test func referenceIndex_withoutDocumentation() async throws {
+        try await withSPIApp { app in
+            // setup
+            let pkg = try await savePackage(on: app.db, "1")
+            try await Repository(package: pkg, name: "package", owner: "owner")
+                .save(on: app.db)
+            try await Version(package: pkg,
+                              commit: "0123456789",
+                              commitDate: .t0,
+                              docArchives: [],
+                              latest: .defaultBranch,
+                              packageName: "pkg",
+                              reference: .branch("main"))
+            .save(on: app.db)
+
+            // MUT
+            try await app.testing().test(.GET, "/owner/package/main") { res async in
+                #expect(res.status == .ok)
+                let body = res.body.asString()
+                #expect(!body.contains("documentation"))
+                #expect(body.contains("href=\"/owner/package\""))
+            }
+        }
+    }
+
+    @Test func referenceIndex_tagReference() async throws {
+        try await withSPIApp { app in
+            // setup
+            let pkg = try await savePackage(on: app.db, "1")
+            try await Repository(package: pkg, name: "package", owner: "owner")
+                .save(on: app.db)
+            try await Version(package: pkg,
+                              commit: "0123456789",
+                              commitDate: .t0,
+                              docArchives: [.init(name: "target", title: "Target")],
+                              latest: .release,
+                              packageName: "pkg",
+                              reference: .tag(1, 0, 0))
+            .save(on: app.db)
+
+            // MUT
+            try await app.testing().test(.GET, "/owner/package/1.0.0") { res async in
+                #expect(res.status == .ok)
+                let body = res.body.asString()
+                #expect(body.contains("href=\"/owner/package/1.0.0/documentation/target\""))
+                #expect(body.contains("href=\"/owner/package\""))
+            }
+        }
+    }
+
+    @Test func referenceIndex_nonExistentPackage() async throws {
+        try await withSPIApp { app in
+            // MUT - no setup, the package doesn't exist
+            try await app.testing().test(.GET, "/nonexistent/package/main") { res async in
+                #expect(res.status == .notFound)
+            }
+        }
+    }
+
     @Test func documentationRoot_notFound() async throws {
         try await withDependencies {
             $0.environment.dbId = { nil }


### PR DESCRIPTION
This PR is meant to improve on the solution to the problem outlined in [#3975](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/pull/3975).

While that PR replaced the 404 error message on the `:reference` route with a redirect, this one displays helpful links to the documentation route for the reference (if it exists) and a link to the parent route (package page). This is more helpful than showing an error message on this route, while also leaving the door open to other potential uses in the future.

Pages on intermediate routes of valid URLs should ideally not show an error, since users could reasonably navigate to these routes, expecting to see content there.

The page is marked as `noindex` to prevent search engine indexing, and returns a 404 for non-existent packages.

See also #3944.