### PR TITLE
Add missing licenses from choosealicense.com

### DIFF
--- a/Sources/App/Models/License.swift
+++ b/Sources/App/Models/License.swift
@@ -14,37 +14,56 @@
 
 enum License: String, Codable, Equatable, CaseIterable {
 
-    // This is not an exhaustive list, but includes most commonly used license types
+    // License identifiers match GitHub's API keys from choosealicense.com
+    case bsd_0_clause = "0bsd"
     case afl_3_0 = "afl-3.0"
+    case agpl_3_0 = "agpl-3.0"
     case apache_2_0 = "apache-2.0"
     case artistic_2_0 = "artistic-2.0"
+    case blueoak_1_0_0 = "blueoak-1.0.0"
     case bsd_2_clause = "bsd-2-clause"
+    case bsd_2_clause_patent = "bsd-2-clause-patent"
     case bsd_3_clause = "bsd-3-clause"
     case bsd_3_clause_clear = "bsd-3-clause-clear"
+    case bsd_4_clause = "bsd-4-clause"
     case bsl_1_0 = "bsl-1.0"
     case cc
-    case cc0_1_0 = "cc0-1.0"
     case cc_by_4_0 = "cc-by-4.0"
     case cc_by_sa_4_0 = "cc-by-sa-4.0"
-    case wtfpl
+    case cc0_1_0 = "cc0-1.0"
+    case cecill_2_1 = "cecill-2.1"
+    case cern_ohl_p_2_0 = "cern-ohl-p-2.0"
+    case cern_ohl_s_2_0 = "cern-ohl-s-2.0"
+    case cern_ohl_w_2_0 = "cern-ohl-w-2.0"
     case ecl_2_0 = "ecl-2.0"
     case epl_1_0 = "epl-1.0"
+    case epl_2_0 = "epl-2.0"
     case eupl_1_1 = "eupl-1.1"
-    case agpl_3_0 = "agpl-3.0"
+    case eupl_1_2 = "eupl-1.2"
+    case gfdl_1_3 = "gfdl-1.3"
     case gpl
     case gpl_2_0 = "gpl-2.0"
     case gpl_3_0 = "gpl-3.0"
+    case isc
     case lgpl
     case lgpl_2_1 = "lgpl-2.1"
     case lgpl_3_0 = "lgpl-3.0"
-    case isc
-    case ms_pl = "ms-pl"
+    case lppl_1_3c = "lppl-1.3c"
     case mit
+    case mit_0 = "mit-0"
     case mpl_2_0 = "mpl-2.0"
+    case ms_pl = "ms-pl"
+    case ms_rl = "ms-rl"
+    case mulanpsl_2_0 = "mulanpsl-2.0"
+    case ncsa
+    case odbl_1_0 = "odbl-1.0"
+    case ofl_1_1 = "ofl-1.1"
     case osl_3_0 = "osl-3.0"
     case postgresql
-    case ncsa
+    case upl_1_0 = "upl-1.0"
     case unlicense // NB: This is an actual license and *not* a typo of "unlicensed"
+    case vim
+    case wtfpl
     case zlib
 
     // These are special cases, not license types
@@ -53,36 +72,55 @@ enum License: String, Codable, Equatable, CaseIterable {
 
     var fullName: String {
         switch self {
+            case .bsd_0_clause: return "BSD Zero Clause License"
             case .afl_3_0: return "Academic Free License v3.0"
+            case .agpl_3_0: return "GNU Affero General Public License v3.0"
             case .apache_2_0: return "Apache License 2.0"
             case .artistic_2_0: return "Artistic License 2.0"
-            case .bsd_2_clause: return "BSD 2-clause \"Simplified\" license"
-            case .bsd_3_clause: return "BSD 3-clause \"New\" or \"Revised\" license"
-            case .bsd_3_clause_clear: return "BSD 3-clause Clear license"
+            case .blueoak_1_0_0: return "Blue Oak Model License 1.0.0"
+            case .bsd_2_clause: return "BSD 2-Clause \"Simplified\" License"
+            case .bsd_2_clause_patent: return "BSD 2-Clause Plus Patent License"
+            case .bsd_3_clause: return "BSD 3-Clause \"New\" or \"Revised\" License"
+            case .bsd_3_clause_clear: return "BSD 3-Clause Clear License"
+            case .bsd_4_clause: return "BSD 4-Clause \"Original\" License"
             case .bsl_1_0: return "Boost Software License 1.0"
             case .cc: return "Creative Commons License"
-            case .cc0_1_0: return "Creative Commons Zero v1.0 Universal"
             case .cc_by_4_0: return "Creative Commons Attribution 4.0"
             case .cc_by_sa_4_0: return "Creative Commons Attribution Share Alike 4.0"
-            case .wtfpl: return "Do What The F**k You Want To Public License"
+            case .cc0_1_0: return "Creative Commons Zero v1.0 Universal"
+            case .cecill_2_1: return "CeCILL Free Software License Agreement v2.1"
+            case .cern_ohl_p_2_0: return "CERN Open Hardware Licence Version 2 - Permissive"
+            case .cern_ohl_s_2_0: return "CERN Open Hardware Licence Version 2 - Strongly Reciprocal"
+            case .cern_ohl_w_2_0: return "CERN Open Hardware Licence Version 2 - Weakly Reciprocal"
             case .ecl_2_0: return "Educational Community License v2.0"
             case .epl_1_0: return "Eclipse Public License 1.0"
+            case .epl_2_0: return "Eclipse Public License 2.0"
             case .eupl_1_1: return "European Union Public License 1.1"
-            case .agpl_3_0: return "GNU Affero General Public License v3.0"
+            case .eupl_1_2: return "European Union Public License 1.2"
+            case .gfdl_1_3: return "GNU Free Documentation License v1.3"
             case .gpl: return "GNU General Public License family"
             case .gpl_2_0: return "GNU General Public License v2.0"
             case .gpl_3_0: return "GNU General Public License v3.0"
+            case .isc: return "ISC License"
             case .lgpl: return "GNU Lesser General Public License family"
             case .lgpl_2_1: return "GNU Lesser General Public License v2.1"
             case .lgpl_3_0: return "GNU Lesser General Public License v3.0"
-            case .isc: return "ISC License"
-            case .ms_pl: return "Microsoft Public License"
+            case .lppl_1_3c: return "LaTeX Project Public License v1.3c"
             case .mit: return "MIT License"
+            case .mit_0: return "MIT No Attribution License"
             case .mpl_2_0: return "Mozilla Public License 2.0"
+            case .ms_pl: return "Microsoft Public License"
+            case .ms_rl: return "Microsoft Reciprocal License"
+            case .mulanpsl_2_0: return "Mulan Permissive Software License, Version 2"
+            case .ncsa: return "University of Illinois/NCSA Open Source License"
+            case .odbl_1_0: return "Open Data Commons Open Database License v1.0"
+            case .ofl_1_1: return "SIL Open Font License 1.1"
             case .osl_3_0: return "Open Software License 3.0"
             case .postgresql: return "PostgreSQL License"
-            case .ncsa: return "University of Illinois/NCSA Open Source License"
+            case .upl_1_0: return "Universal Permissive License v1.0"
             case .unlicense: return "The Unlicense"
+            case .vim: return "Vim License"
+            case .wtfpl: return "Do What The F**k You Want To Public License"
             case .zlib: return "zLib License"
 
             case .other: return "Unknown or Unrecognised License"
@@ -92,36 +130,55 @@ enum License: String, Codable, Equatable, CaseIterable {
 
     var shortName: String {
         switch self {
+            case .bsd_0_clause: return "0BSD"
             case .afl_3_0: return "AFL 3.0"
+            case .agpl_3_0: return "AGPL 3.0"
             case .apache_2_0: return "Apache 2.0"
             case .artistic_2_0: return "Artistic 2.0"
+            case .blueoak_1_0_0: return "BlueOak 1.0.0"
             case .bsd_2_clause: return "BSD 2-Clause"
+            case .bsd_2_clause_patent: return "BSD 2-Clause Patent"
             case .bsd_3_clause: return "BSD 3-Clause"
             case .bsd_3_clause_clear: return "BSD 3-Clause Clear"
+            case .bsd_4_clause: return "BSD 4-Clause"
             case .bsl_1_0: return "Boost 1.0"
             case .cc: return "CC"
-            case .cc0_1_0: return "CC Zero 1.0"
             case .cc_by_4_0: return "CC Attribution 4.0"
             case .cc_by_sa_4_0: return "CC Attribution SA 4.0"
-            case .wtfpl: return "DWTFYWTPL"
+            case .cc0_1_0: return "CC Zero 1.0"
+            case .cecill_2_1: return "CeCILL 2.1"
+            case .cern_ohl_p_2_0: return "CERN OHL-P 2.0"
+            case .cern_ohl_s_2_0: return "CERN OHL-S 2.0"
+            case .cern_ohl_w_2_0: return "CERN OHL-W 2.0"
             case .ecl_2_0: return "ECL 2.0"
             case .epl_1_0: return "EPL 1.0"
+            case .epl_2_0: return "EPL 2.0"
             case .eupl_1_1: return "EUPL 1.1"
-            case .agpl_3_0: return "AGPL 3.0"
+            case .eupl_1_2: return "EUPL 1.2"
+            case .gfdl_1_3: return "GFDL 1.3"
             case .gpl: return "GPL"
             case .gpl_2_0: return "GPL 2.0"
             case .gpl_3_0: return "GPL 3.0"
+            case .isc: return "ISC"
             case .lgpl: return "LGPL"
             case .lgpl_2_1: return "LGPL 2.1"
             case .lgpl_3_0: return "LGPL 3.0"
-            case .isc: return "ISC"
-            case .ms_pl: return "MSPL"
+            case .lppl_1_3c: return "LPPL 1.3c"
             case .mit: return "MIT"
+            case .mit_0: return "MIT-0"
             case .mpl_2_0: return "MPL 2.0"
+            case .ms_pl: return "MSPL"
+            case .ms_rl: return "MSRL"
+            case .mulanpsl_2_0: return "MulanPSL 2.0"
+            case .ncsa: return "NCSA"
+            case .odbl_1_0: return "ODbL 1.0"
+            case .ofl_1_1: return "OFL 1.1"
             case .osl_3_0: return "OSL 3.0"
             case .postgresql: return "PostgreSQL"
-            case .ncsa: return "NCSA"
+            case .upl_1_0: return "UPL 1.0"
             case .unlicense: return "The Unlicense"
+            case .vim: return "Vim"
+            case .wtfpl: return "DWTFYWTPL"
             case .zlib: return "zLib"
 
             case .other: return "Unknown license"
@@ -136,12 +193,21 @@ enum License: String, Codable, Equatable, CaseIterable {
             case .none:
                 return .none
             case .agpl_3_0,
+                 .cecill_2_1,
+                 .cern_ohl_s_2_0,
+                 .cern_ohl_w_2_0,
+                 .eupl_1_1,
+                 .eupl_1_2,
+                 .gfdl_1_3,
                  .gpl,
                  .gpl_2_0,
                  .gpl_3_0,
                  .lgpl,
                  .lgpl_2_1,
-                 .lgpl_3_0: return .incompatibleWithAppStore
+                 .lgpl_3_0,
+                 .lppl_1_3c,
+                 .ms_rl,
+                 .osl_3_0: return .incompatibleWithAppStore
             default: return .compatibleWithAppStore
         }
     }

--- a/Tests/AppTests/LicenseTests.swift
+++ b/Tests/AppTests/LicenseTests.swift
@@ -22,6 +22,22 @@ extension AllTests.LicenseTests {
     @Test func init_from_dto() throws {
         #expect(License(from: Github.Metadata.LicenseInfo(key: "mit")) == .mit)
         #expect(License(from: Github.Metadata.LicenseInfo(key: "agpl-3.0")) == .agpl_3_0)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "0bsd")) == .bsd_0_clause)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "blueoak-1.0.0")) == .blueoak_1_0_0)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "bsd-2-clause-patent")) == .bsd_2_clause_patent)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "cecill-2.1")) == .cecill_2_1)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "cern-ohl-s-2.0")) == .cern_ohl_s_2_0)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "epl-2.0")) == .epl_2_0)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "eupl-1.2")) == .eupl_1_2)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "gfdl-1.3")) == .gfdl_1_3)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "lppl-1.3c")) == .lppl_1_3c)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "mit-0")) == .mit_0)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "ms-rl")) == .ms_rl)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "mulanpsl-2.0")) == .mulanpsl_2_0)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "odbl-1.0")) == .odbl_1_0)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "ofl-1.1")) == .ofl_1_1)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "upl-1.0")) == .upl_1_0)
+        #expect(License(from: Github.Metadata.LicenseInfo(key: "vim")) == .vim)
         #expect(License(from: Github.Metadata.LicenseInfo(key: "other")) == .other)
         #expect(License(from: .none) == .none)
     }
@@ -46,8 +62,29 @@ extension AllTests.LicenseTests {
     }
 
     @Test func isCompatibleWithAppStore() throws {
+        // Compatible
         #expect(License.mit.licenseKind == .compatibleWithAppStore)
+        #expect(License.mit_0.licenseKind == .compatibleWithAppStore)
+        #expect(License.apache_2_0.licenseKind == .compatibleWithAppStore)
+        #expect(License.blueoak_1_0_0.licenseKind == .compatibleWithAppStore)
+        #expect(License.bsd_2_clause_patent.licenseKind == .compatibleWithAppStore)
+        #expect(License.epl_2_0.licenseKind == .compatibleWithAppStore)
+        #expect(License.cern_ohl_p_2_0.licenseKind == .compatibleWithAppStore)
+        #expect(License.upl_1_0.licenseKind == .compatibleWithAppStore)
+        // Incompatible
         #expect(License.agpl_3_0.licenseKind == .incompatibleWithAppStore)
+        #expect(License.cecill_2_1.licenseKind == .incompatibleWithAppStore)
+        #expect(License.cern_ohl_s_2_0.licenseKind == .incompatibleWithAppStore)
+        #expect(License.cern_ohl_w_2_0.licenseKind == .incompatibleWithAppStore)
+        #expect(License.eupl_1_1.licenseKind == .incompatibleWithAppStore)
+        #expect(License.eupl_1_2.licenseKind == .incompatibleWithAppStore)
+        #expect(License.gfdl_1_3.licenseKind == .incompatibleWithAppStore)
+        #expect(License.gpl_2_0.licenseKind == .incompatibleWithAppStore)
+        #expect(License.lgpl_3_0.licenseKind == .incompatibleWithAppStore)
+        #expect(License.lppl_1_3c.licenseKind == .incompatibleWithAppStore)
+        #expect(License.ms_rl.licenseKind == .incompatibleWithAppStore)
+        #expect(License.osl_3_0.licenseKind == .incompatibleWithAppStore)
+        // Special
         #expect(License.other.licenseKind == .other)
         #expect(License.none.licenseKind == .none)
     }

--- a/Tests/AppTests/SearchFilterTests.swift
+++ b/Tests/AppTests/SearchFilterTests.swift
@@ -189,7 +189,7 @@ extension AllTests.SearchFilterTests {
                                                                    value: "compatible"))
             #expect(filter.key == .license)
             #expect(filter.predicate == .init(operator: .in,
-                                              bindableValue: .array(["afl-3.0", "apache-2.0", "artistic-2.0", "bsd-2-clause", "bsd-3-clause", "bsd-3-clause-clear", "bsl-1.0", "cc", "cc0-1.0", "cc-by-4.0", "cc-by-sa-4.0", "wtfpl", "ecl-2.0", "epl-1.0", "eupl-1.1", "isc", "ms-pl", "mit", "mpl-2.0", "osl-3.0", "postgresql", "ncsa", "unlicense", "zlib"]),
+                                              bindableValue: .array(["0bsd", "afl-3.0", "apache-2.0", "artistic-2.0", "blueoak-1.0.0", "bsd-2-clause", "bsd-2-clause-patent", "bsd-3-clause", "bsd-3-clause-clear", "bsd-4-clause", "bsl-1.0", "cc", "cc-by-4.0", "cc-by-sa-4.0", "cc0-1.0", "cern-ohl-p-2.0", "ecl-2.0", "epl-1.0", "epl-2.0", "isc", "mit", "mit-0", "mpl-2.0", "ms-pl", "mulanpsl-2.0", "ncsa", "odbl-1.0", "ofl-1.1", "postgresql", "upl-1.0", "unlicense", "vim", "wtfpl", "zlib"]),
                                               displayValue: "compatible with the App Store"))
 
             // test view representation
@@ -198,7 +198,7 @@ extension AllTests.SearchFilterTests {
             // test sql representation
             #expect(app.db.renderSQL(filter.leftHandSide) == #""license""#)
             #expect(app.db.renderSQL(filter.sqlOperator) == "IN")
-            #expect(app.db.binds(filter.rightHandSide) == ["afl-3.0", "apache-2.0", "artistic-2.0", "bsd-2-clause", "bsd-3-clause", "bsd-3-clause-clear", "bsl-1.0", "cc", "cc0-1.0", "cc-by-4.0", "cc-by-sa-4.0", "wtfpl", "ecl-2.0", "epl-1.0", "eupl-1.1", "isc", "ms-pl", "mit", "mpl-2.0", "osl-3.0", "postgresql", "ncsa", "unlicense", "zlib"])
+            #expect(app.db.binds(filter.rightHandSide) == ["0bsd", "afl-3.0", "apache-2.0", "artistic-2.0", "blueoak-1.0.0", "bsd-2-clause", "bsd-2-clause-patent", "bsd-3-clause", "bsd-3-clause-clear", "bsd-4-clause", "bsl-1.0", "cc", "cc-by-4.0", "cc-by-sa-4.0", "cc0-1.0", "cern-ohl-p-2.0", "ecl-2.0", "epl-1.0", "epl-2.0", "isc", "mit", "mit-0", "mpl-2.0", "ms-pl", "mulanpsl-2.0", "ncsa", "odbl-1.0", "ofl-1.1", "postgresql", "upl-1.0", "unlicense", "vim", "wtfpl", "zlib"])
         }
     }
 
@@ -235,7 +235,7 @@ extension AllTests.SearchFilterTests {
         #expect(
             try LicenseSearchFilter(
                 expression: .init(operator: .is,
-                                  value: "Compatible")).bindableValue == ["afl-3.0", "apache-2.0", "artistic-2.0", "bsd-2-clause", "bsd-3-clause", "bsd-3-clause-clear", "bsl-1.0", "cc", "cc0-1.0", "cc-by-4.0", "cc-by-sa-4.0", "wtfpl", "ecl-2.0", "epl-1.0", "eupl-1.1", "isc", "ms-pl", "mit", "mpl-2.0", "osl-3.0", "postgresql", "ncsa", "unlicense", "zlib"]
+                                  value: "Compatible")).bindableValue == ["0bsd", "afl-3.0", "apache-2.0", "artistic-2.0", "blueoak-1.0.0", "bsd-2-clause", "bsd-2-clause-patent", "bsd-3-clause", "bsd-3-clause-clear", "bsd-4-clause", "bsl-1.0", "cc", "cc-by-4.0", "cc-by-sa-4.0", "cc0-1.0", "cern-ohl-p-2.0", "ecl-2.0", "epl-1.0", "epl-2.0", "isc", "mit", "mit-0", "mpl-2.0", "ms-pl", "mulanpsl-2.0", "ncsa", "odbl-1.0", "ofl-1.1", "postgresql", "upl-1.0", "unlicense", "vim", "wtfpl", "zlib"]
         )
     }
 
@@ -245,7 +245,7 @@ extension AllTests.SearchFilterTests {
                                                                    value: "incompatible"))
             #expect(filter.key == .license)
             #expect(filter.predicate == .init(operator: .in,
-                                              bindableValue: .array(["agpl-3.0", "gpl", "gpl-2.0", "gpl-3.0", "lgpl", "lgpl-2.1", "lgpl-3.0"]),
+                                              bindableValue: .array(["agpl-3.0", "cecill-2.1", "cern-ohl-s-2.0", "cern-ohl-w-2.0", "eupl-1.1", "eupl-1.2", "gfdl-1.3", "gpl", "gpl-2.0", "gpl-3.0", "lgpl", "lgpl-2.1", "lgpl-3.0", "lppl-1.3c", "ms-rl", "osl-3.0"]),
                                               displayValue: "incompatible with the App Store"))
 
             // test view representation
@@ -254,7 +254,7 @@ extension AllTests.SearchFilterTests {
             // test sql representation
             #expect(app.db.renderSQL(filter.leftHandSide) == #""license""#)
             #expect(app.db.renderSQL(filter.sqlOperator) == "IN")
-            #expect(app.db.binds(filter.rightHandSide) == ["agpl-3.0", "gpl", "gpl-2.0", "gpl-3.0", "lgpl", "lgpl-2.1", "lgpl-3.0"])
+            #expect(app.db.binds(filter.rightHandSide) == ["agpl-3.0", "cecill-2.1", "cern-ohl-s-2.0", "cern-ohl-w-2.0", "eupl-1.1", "eupl-1.2", "gfdl-1.3", "gpl", "gpl-2.0", "gpl-3.0", "lgpl", "lgpl-2.1", "lgpl-3.0", "lppl-1.3c", "ms-rl", "osl-3.0"])
         }
     }
 


### PR DESCRIPTION
Supercedes #3979
Supercedes #3957
Fixes #3956

Updates all detected licenses that can be returned from GitHub's license checking code (from choosealicense.com).