### PR TITLE
Mitigate gitlab 500s part 2

### DIFF
--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -197,9 +197,9 @@ func triggerBuilds(on database: Database,
     async let pendingJobsTask = getStatusCount(.pending)
     async let runningJobsTask = getStatusCount(.running)
     let pendingJobs = try await pendingJobsTask
-    // 2026-04-10 sas: default running job count to (current) maximum to mitigate 500s from Gitlab API.
+    // 2026-04-10 sas: default running job count to 0 to mitigate 500s from Gitlab API.
     // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/4024 for details.
-    let runningJobs = (try? await runningJobsTask) ?? 20
+    let runningJobs = (try? await runningJobsTask) ?? 0
 
     AppMetrics.buildPendingJobsCount?.set(pendingJobs)
     AppMetrics.buildRunningJobsCount?.set(runningJobs)

--- a/Sources/App/Core/Gitlab.swift
+++ b/Sources/App/Core/Gitlab.swift
@@ -152,19 +152,18 @@ extension Gitlab.Builder {
     }
 
     // periphery:ignore
-    struct Pipeline: Decodable {
+    struct Job: Decodable {
         var id: Int
-        var status: Status
     }
 
-    // https://docs.gitlab.com/ee/api/pipelines.html
-    static func fetchPipelines(status: Status,
-                               page: Int,
-                               pageSize: Int = 20) async throws -> [Pipeline] {
+    // https://docs.gitlab.com/ee/api/jobs.html
+    static func fetchJobs(status: Status,
+                          page: Int,
+                          pageSize: Int = 20) async throws -> [Job] {
         @Dependency(\.environment) var environment
         @Dependency(\.httpClient) var httpClient
         guard let apiToken = environment.gitlabApiToken() else { throw Gitlab.Error.missingToken }
-        let url = "\(projectURL)/pipelines?status=\(status)&page=\(page)&per_page=\(pageSize)"
+        let url = "\(projectURL)/jobs?scope=\(status)&page=\(page)&per_page=\(pageSize)"
 
         let response = try await httpClient.get(url: url, headers: .bearer(apiToken))
 
@@ -173,14 +172,14 @@ extension Gitlab.Builder {
         }
         guard let body = response.body else { throw Gitlab.Error.noBody }
 
-        return try Gitlab.decoder.decode([Pipeline].self, from: body)
+        return try Gitlab.decoder.decode([Job].self, from: body)
     }
 
     static func getStatusCount(status: Status,
                                page: Int = 1,
                                pageSize: Int = 20,
                                maxPageCount: Int = 5) async throws -> Int {
-        let count = try await fetchPipelines(status: status, page: page, pageSize: pageSize).count
+        let count = try await fetchJobs(status: status, page: page, pageSize: pageSize).count
         if count == pageSize && page < maxPageCount {
             let statusCount = try await getStatusCount(status: status,
                                                        page: page + 1,

--- a/Tests/AppTests/GitlabBuilderTests.swift
+++ b/Tests/AppTests/GitlabBuilderTests.swift
@@ -133,7 +133,7 @@ extension AllTests.GitlabBuilderTests {
             $0.environment.gitlabApiToken = { "api token" }
             $0.httpClient.get = { @Sendable url, _ in
                 #expect(
-                    url == "https://gitlab.com/api/v4/projects/19564054/pipelines?status=pending&page=\(page.value)&per_page=20"
+                    url == "https://gitlab.com/api/v4/projects/19564054/jobs?scope=pending&page=\(page.value)&per_page=20"
                 )
                 let pending = #"{"id": 1, "status": "pending"}"#
                 defer { page.increment() }

--- a/restfiles/gitlab-jobs.restfile
+++ b/restfiles/gitlab-jobs.restfile
@@ -1,0 +1,30 @@
+# Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variables:
+  api_url: https://gitlab.com/api/v4
+  project_id: 19564054
+
+requests:
+  jobs:
+    url: ${api_url}/projects/${project_id}/jobs
+    query:
+      scope: running
+      page: 1
+      per_page: 20
+    headers:
+      Authorization: Bearer ${API_TOKEN}
+    validation:
+      status: 200
+    log: json


### PR DESCRIPTION
Switch to `/jobs` API

See #4024 for details.