### PR TITLE
Added logging to determine critical error source

### DIFF
--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -90,14 +90,14 @@ struct TriggerBuildsCommand: AsyncCommand {
         do {
             try await triggerBuilds(on: context.application.db, mode: mode)
         } catch {
-            logger.critical("\(error)")
+            logger.critical("triggerBuilds.run: \(error)")
         }
 
         do {
             try await AppMetrics.push(client: context.application.client,
                                       jobName: "trigger-builds")
         } catch {
-            logger.warning("\(error)")
+            logger.warning("triggerBuilds.run: \(error)")
         }
     }
 
@@ -235,7 +235,12 @@ func triggerBuilds(on database: Database,
                 let triggeredJobCount = triggers.reduce(0) { $0 + $1.buildPairs.count }
                 await newJobs.withValue { $0 += triggeredJobCount }
 
-                try await triggerBuildsUnchecked(on: database, triggers: triggers)
+                do {
+                    try await triggerBuildsUnchecked(on: database, triggers: triggers)
+                } catch {
+                    logger.error("triggerBuildsUnchecked failed: \(error)")
+                    throw error
+                }
             }
         }
     }

--- a/Sources/App/Commands/TriggerBuilds.swift
+++ b/Sources/App/Commands/TriggerBuilds.swift
@@ -201,6 +201,8 @@ func triggerBuilds(on database: Database,
     // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/4024 for details.
     let runningJobs = (try? await runningJobsTask) ?? 0
 
+    logger.info("Jobs pending: \(pendingJobs), running: \(runningJobs)")
+
     AppMetrics.buildPendingJobsCount?.set(pendingJobs)
     AppMetrics.buildRunningJobsCount?.set(runningJobs)
 

--- a/Sources/App/Core/Gitlab.swift
+++ b/Sources/App/Core/Gitlab.swift
@@ -181,11 +181,17 @@ extension Gitlab.Builder {
                                maxPageCount: Int = 5) async throws -> Int {
         let count = try await fetchJobs(status: status, page: page, pageSize: pageSize).count
         if count == pageSize && page < maxPageCount {
-            let statusCount = try await getStatusCount(status: status,
-                                                       page: page + 1,
-                                                       pageSize: pageSize,
-                                                       maxPageCount: maxPageCount)
-            return count + statusCount
+            do {
+                let statusCount = try await getStatusCount(status: status,
+                                                           page: page + 1,
+                                                           pageSize: pageSize,
+                                                           maxPageCount: maxPageCount)
+                return count + statusCount
+            } catch {
+                @Dependency(\.logger) var logger
+                logger.error("Gitlab.Builder.getStatusCount failed: \(error)")
+                throw error
+            }
         } else {
             return count
         }


### PR DESCRIPTION
There's a mysterious log line we get at the end of a trigger pass:

```
2026-04-13T11:45:28.175627665Z [ INFO ] Triggering builds (limit: 8) ... [component: trigger-builds]
2026-04-13T11:45:30.129019662Z [ CRITICAL ] limit [component: trigger-builds]
```

We still trigger builds but what I've noticed is that we're now having about as many pending jobs as running ones, even though I increased the pending limit to 150:

<img width="998" height="496" alt="CleanShot 2026-04-13 at 13 32 35@2x" src="https://github.com/user-attachments/assets/0daa1f17-f86d-4d2c-b771-14ae3624ea51" />

This could be the case if we processed exactly as many builds as we're scheduling, which isn't likely.

I suspect something is off and it is related to the error message (which is new, I believe).

Related to #4024 