### PR TITLE
Mitigate gitlab 500s part 6

### DIFF
--- a/Sources/App/Core/Constants.swift
+++ b/Sources/App/Core/Constants.swift
@@ -49,4 +49,8 @@ enum Constants {
 
     // package
     static let maxKeywordPackageCollectionCount = 300
+
+    // HTTP client
+    // 2026-04-14 sas: For details, see: https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/4024#issuecomment-4237684071
+    static let httpDecompressionSizeLimit = 1_000_000
 }

--- a/Sources/App/Core/Dependencies/BuildSystemClient.swift
+++ b/Sources/App/Core/Dependencies/BuildSystemClient.swift
@@ -35,8 +35,8 @@ extension BuildSystemClient: DependencyKey {
             getStatusCount: { status in
                 try await Gitlab.Builder.getStatusCount(status: status,
                                                         page: 1,
-                                                        pageSize: 20,
-                                                        maxPageCount: 10)
+                                                        pageSize: 100,
+                                                        maxPageCount: 5)
             },
             triggerBuild: { buildId, cloneURL, isDocBuild, platform, ref, swiftVersion, versionID in
                 try await Gitlab.Builder.triggerBuild(buildId: buildId,

--- a/Sources/App/Core/Dependencies/HTTPClient.swift
+++ b/Sources/App/Core/Dependencies/HTTPClient.swift
@@ -37,14 +37,14 @@ extension HTTPClient: DependencyKey {
         .init(
             get: { url, headers in
                 let req = try Request(url: url, method: .GET, headers: headers)
-                return try await Vapor.HTTPClient.shared.execute(request: req).get()
+                return try await shared.execute(request: req).get()
             },
             post: { url, headers, body in
                 let req = try Request(url: url, method: .POST, headers: headers, body: body.map({.data($0)}))
-                return try await Vapor.HTTPClient.shared.execute(request: req).get()
+                return try await shared.execute(request: req).get()
             },
             fetchDocumentation: { url in
-                try await Vapor.HTTPClient.shared.get(url: url.string).get()
+                try await shared.get(url: url.string).get()
             },
             fetchHTTPStatusCode: { url in
                 var config = Vapor.HTTPClient.Configuration()
@@ -71,6 +71,8 @@ extension HTTPClient: DependencyKey {
     func post(url: String, body: Data?) async throws -> Response {
         try await post(url: url, headers: .init(), body: body)
     }
+
+    private static var shared: Vapor.HTTPClient { globallySharedHTTPClient }
 }
 
 
@@ -85,6 +87,21 @@ extension DependencyValues {
         set { self[HTTPClient.self] = newValue }
     }
 }
+
+
+private let globallySharedHTTPClient: Vapor.HTTPClient = {
+    var conf = Vapor.HTTPClient.Configuration.singletonConfiguration
+    // 2026-04-14 sas: Increasing limit from default `.enabled(limit: .ratio(25))`, which caused requests to fail in the past.
+    // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/4024#issuecomment-4237684071
+    conf.decompression = .enabled(limit: .size(Constants.httpDecompressionSizeLimit))
+
+    let httpClient = Vapor.HTTPClient(
+        eventLoopGroup: Vapor.HTTPClient.defaultEventLoopGroup,
+        configuration: conf,
+        backgroundActivityLogger: .noop
+    )
+    return httpClient
+}()
 
 
 #if DEBUG

--- a/Sources/App/Core/Dependencies/HTTPClient.swift
+++ b/Sources/App/Core/Dependencies/HTTPClient.swift
@@ -41,10 +41,10 @@ extension HTTPClient: DependencyKey {
             },
             post: { url, headers, body in
                 let req = try Request(url: url, method: .POST, headers: headers, body: body.map({.data($0)}))
-                return try await shared.execute(request: req).get()
+                return try await Vapor.HTTPClient.shared.execute(request: req).get()
             },
             fetchDocumentation: { url in
-                try await shared.get(url: url.string).get()
+                try await Vapor.HTTPClient.shared.get(url: url.string).get()
             },
             fetchHTTPStatusCode: { url in
                 var config = Vapor.HTTPClient.Configuration()

--- a/Sources/App/Core/Dependencies/LoggerClient.swift
+++ b/Sources/App/Core/Dependencies/LoggerClient.swift
@@ -40,12 +40,12 @@ extension DependencyValues {
 }
 
 
-#if DEBUG
 extension Logger {
     static var noop: Self { .init(label: "noop") { _ in SwiftLogNoOpLogHandler() } }
 
+#if DEBUG
     static func testLogger(_ handler: LogHandler) -> Self {
         .init(label: "test", factory: { _ in handler })
     }
-}
 #endif
+}


### PR DESCRIPTION
This reverts the pageSize decrease I pushed yesterday in favour of changing the decompression size limit for the HTTP client.

TBD what the new size should be. I'm not sure if 1MB isn't too low given this also affects documentation.

Alternatively we could _not_ apply this change to the documentation requests but I wonder if it was affected by hitting the `limit` error as well but we just didn't see it.