### PR TITLE
Update success rate check

### DIFF
--- a/Sources/App/Commands/Alerting.swift
+++ b/Sources/App/Commands/Alerting.swift
@@ -275,8 +275,7 @@ extension [Alerting.BuildInfo] {
 
     func validateSuccessRateInRange() -> Alerting.Validation {
         let successRate = Double(filter { $0.status == .ok }.count) / Double(count)
-        // Success rate has been around 30% generally
-        if 0.15 <= successRate && successRate <= 0.45 {
+        if 0.15 <= successRate && successRate <= 0.85 {
             return .ok
         } else {
             let percentSuccessRate = (successRate * 1000).rounded() / 10

--- a/Tests/AppTests/AlertingTests.swift
+++ b/Tests/AppTests/AlertingTests.swift
@@ -117,12 +117,12 @@ extension AllTests.AlertingTests {
             #expect(all.validateSuccessRateInRange() == .failed(reasons: ["Global success rate of 14.9% out of bounds"]))
         }
         do {
-            let okCount = 451
+            let okCount = 851
             let failedCount = 1000 - okCount
             let okBuilds = (0..<okCount).map { _ in Alerting.BuildInfo.mock(status: .ok) }
             let failedBuilds = (0..<failedCount).map { _ in Alerting.BuildInfo.mock(status: .failed) }
             let all = okBuilds + failedBuilds
-            #expect(all.validateSuccessRateInRange() == .failed(reasons: ["Global success rate of 45.1% out of bounds"]))
+            #expect(all.validateSuccessRateInRange() == .failed(reasons: ["Global success rate of 85.1% out of bounds"]))
         }
     }
 


### PR DESCRIPTION
Since we dropped `triggered` builds from the list of builds we checked, we're now skewing for a higher build success rate and need to widen the window. It's really just to alert us if basically all builds pass or fail (indicative of a config/image problem), so it's intended to be really wide.