### PR TITLE
Updated snapshot for `dump package` output

### DIFF
--- a/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.macos.json
+++ b/Tests/AppTests/__Snapshots__/AnalyzerTests/dumpPackage_format.macos.json
@@ -1,7 +1,6 @@
 {
   "cLanguageStandard" : null,
   "cxxLanguageStandard" : null,
-  "defaultLocalization" : null,
   "dependencies" : [
     {
       "sourceControl" : [
@@ -215,10 +214,7 @@
     }
   ],
   "toolsVersion" : {
-    "_version" : "5.9.0",
-    "experimentalFeatures" : [
-
-    ]
+    "_version" : "5.9.0"
   },
   "traits" : [
 


### PR DESCRIPTION
It seems odd that this has changed at this point but I am getting consistent results locally.

I wondered if it might not have changed on Linux but the tests run without errors on CI, too, so at the very least this should let us run consistently on both platforms.