### PR TITLE
Reduce critical error rate

### DIFF
--- a/Sources/App/Commands/Common.swift
+++ b/Sources/App/Commands/Common.swift
@@ -48,7 +48,7 @@ extension Analyze {
             switch errorRate {
                 case 0:
                     logger.info("Updating \(total) packages for stage 'analysis'")
-                case 0..<20:
+                case 0..<25:
                     logger.info("Updating \(total) packages for stage 'analysis' (errors: \(errors))")
                 default:
                     logger.critical("updatePackages: unusually high error rate: \(errors)/\(total) = \(errorRate)%")


### PR DESCRIPTION
We have a couple of packages which trigger [analysis errors beyond our control](https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/4043). They trigger the following warning whenever they are being analysed:

```
[ CRITICAL ] updatePackages: unusually high error rate: 1/5 = 20.0% [component: analyze]
```

The reason this warning exists is to make sure we don't end up with most of the analysis queue blocked by packages that can't be analysed.

Raising the limit slightly will allow for single packages failing without triggering a critical warning.

At the same time, we should see if we can let packages with known errors, or rather errors we know that aren't ours, pass analysis, so they don't come around early. What's happening right now is that they are analysed quite frequently, because they're not marked done and put to the end of the queue until next regular analysis.

To do:

- [ ] check if/how we can complete analysis on known problematic packages