### PR TITLE
Reset text color for all paragraphs in an alert box

### DIFF
--- a/FrontEnd/styles/_readme.scss
+++ b/FrontEnd/styles/_readme.scss
@@ -110,7 +110,7 @@
         font-weight: 500;
     }
 
-    .markdown-alert p:nth-child(2) {
+    .markdown-alert p:not(.markdown-alert-title) {
         color: var(--page-text);
     }
 


### PR DESCRIPTION
On https://swiftpackageindex.com/realm/SwiftLint you can find one note box that looks like

<img width="853" height="316" alt="Screenshot 2026-05-25 at 13 05 34" src="https://github.com/user-attachments/assets/2155fab8-6009-4845-9d8e-cc8f30ce5478" />

where the second and third paragraph should not be in blue.

The change makes sure, that only the title receives the highlight color.