### PR TITLE
Add a VS Code `problemMatcher` to correctly parse ESBuild output

### DIFF
--- a/.vscode/tasks.json.template
+++ b/.vscode/tasks.json.template
@@ -5,6 +5,25 @@
             "label": "Serve Front End",
             "type": "shell",
             "command": "npm install && npm run serve",
+            "isBackground": true,
+            "problemMatcher": {
+                // The begin/end markers (logged by `esbuild.mjs`) flip the task between
+                // "building" and "watching" so the task isn't shown as permanently busy.
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "Build started",
+                    "endsPattern": "Build finished"
+                },
+                "fileLocation": "relative",
+                // Error reporting is intentionally disabled, but VS Code still requires
+                // a valid pattern, so the regex is a no-op that never matches.
+                "pattern": {
+                    "regexp": "()()(?!)",
+                    "kind": "file",
+                    "file": 1,
+                    "message": 2
+                }
+            },
             "presentation": {
                 "reveal": "always",
                 "panel": "new"

--- a/FrontEnd/esbuild.mjs
+++ b/FrontEnd/esbuild.mjs
@@ -15,6 +15,17 @@
 import * as esbuild from 'esbuild'
 import { sassPlugin } from 'esbuild-sass-plugin'
 
+const isWatching = process.argv.includes('--watch')
+
+// Log each rebuild while in watch mode
+const watchLogPlugin = {
+    name: 'watch-log',
+    setup(build) {
+        build.onStart(() => console.log('Build started'))
+        build.onEnd(() => console.log('Build finished'))
+    },
+}
+
 try {
     const context = await esbuild.context({
         entryPoints: [
@@ -28,12 +39,12 @@ try {
         bundle: true,
         sourcemap: true,
         minify: true,
-        plugins: [sassPlugin()],
+        plugins: isWatching ? [sassPlugin(), watchLogPlugin] : [sassPlugin()],
         external: ['/images/*'],
         platform: 'browser',
     })
 
-    if (process.argv.includes('--watch')) {
+    if (isWatching) {
         // Watch forever!
         await context.watch()
         await new Promise(() => {})
@@ -41,6 +52,7 @@ try {
         await context.rebuild()
         await context.dispose()
     }
-} catch {
+} catch (error) {
+    console.error(error)
     process.exit(1)
 }


### PR DESCRIPTION
This used to work fine, but recently the Serve Front End task constantly shows in an orange colour in VS Code as it thinks it is a never ending task when watching. This change to the script adds text we can parse for in tasks.json and a template in case anyone else wants to use it.