### PR TITLE
Allow the hiding of compatibility information for the latest version of Swift

### DIFF
--- a/FrontEnd/styles/_matrix.scss
+++ b/FrontEnd/styles/_matrix.scss
@@ -36,6 +36,12 @@
     padding: 20px 0;
     list-style: none;
 
+    &.hide-latest-swift-version {
+        .results .result:first-child {
+            display: none;
+        }
+    }
+
     .version {
         display: flex;
         flex-direction: column;

--- a/Sources/App/Core/Dependencies/EnvironmentClient.swift
+++ b/Sources/App/Core/Dependencies/EnvironmentClient.swift
@@ -219,6 +219,7 @@ extension EnvironmentClient: TestDependencyKey {
         mock.appVersion = { "test" }
         mock.current = { .development }
         mock.deployment = { nil }
+        mock.hideLatestSwiftVersionBuildData = { false }
         mock.hideStagingBanner = { false }
         mock.siteURL = { "http://localhost:8080" }
         mock.shouldFail = { @Sendable _ in false }

--- a/Sources/App/Core/Dependencies/EnvironmentClient.swift
+++ b/Sources/App/Core/Dependencies/EnvironmentClient.swift
@@ -58,6 +58,7 @@ struct EnvironmentClient {
     var gitlabPipelineLimit: @Sendable () -> Int = { XCTFail("gitlabPipelineLimit"); return 100 }
     var gitlabPipelineToken: @Sendable () -> String?
     var gitlabProjectId: @Sendable () -> Int = { XCTFail("gitlabProjectId"); return 19564054 }
+    var hideLatestSwiftVersionBuildData: @Sendable () -> Bool = { XCTFail("hideLatestSwiftVersionBuildData"); return false }
     var hideStagingBanner: @Sendable () -> Bool = { XCTFail("hideStagingBanner"); return Constants.defaultHideStagingBanner }
     var loadSPIManifest: @Sendable (String) -> SPIManifest.Manifest?
     var maintenanceMessage: @Sendable () -> String?
@@ -155,6 +156,9 @@ extension EnvironmentClient: DependencyKey {
             },
             gitlabPipelineToken: { Environment.get("GITLAB_PIPELINE_TOKEN") },
             gitlabProjectId: { Environment.get("GITLAB_PROJECT_ID").flatMap(Int.init) ?? 19564054 },
+            hideLatestSwiftVersionBuildData: {
+                Environment.get("HIDE_LATEST_SWIFT_VERSION_BUILD_DATA").flatMap(\.asBool) ?? false
+            },
             hideStagingBanner: {
                 Environment.get("HIDE_STAGING_BANNER").flatMap(\.asBool)
                     ?? Constants.defaultHideStagingBanner

--- a/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
+++ b/Sources/App/Views/PackageController/Builds/BuildIndex+View.swift
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import Dependencies
 import Plot
 
 
@@ -49,7 +50,13 @@ enum BuildIndex {
         }
 
         override func content() -> Node<HTML.BodyContext> {
-            .div(
+            @Dependency(\.environment) var environment
+
+            let swiftVersions = environment.hideLatestSwiftVersionBuildData()
+                ? SwiftVersion.allActive.reversed().filter { $0 != .latest }
+                : SwiftVersion.allActive.reversed()
+
+            return .div(
                 .h2("Build Results"),
                 .p(
                     .strong("\(model.completedBuildCount)"),
@@ -73,7 +80,7 @@ enum BuildIndex {
                     ),
                     "."
                 ),
-                .forEach(SwiftVersion.allActive.reversed()) { swiftVersion in
+                .forEach(swiftVersions) { swiftVersion in
                         .group(
                             .hr(),
                             .h3(

--- a/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
+++ b/Sources/App/Views/PackageController/GetRoute.Model+ext.swift
@@ -543,11 +543,14 @@ extension API.PackageController.GetRoute.Model {
 
     func swiftVersionCompatibilityList() -> Node<HTML.BodyContext> {
         guard let buildInfo = swiftVersionBuildInfo else { return .empty }
+        @Dependency(\.environment) var environment
+
         let rows = Self.groupBuildInfo(buildInfo)
+        let matrixClass = environment.hideLatestSwiftVersionBuildData() ? "matrix hide-latest-swift-version" : "matrix"
         return .a(
             .href(SiteURL.package(.value(repositoryOwner), .value(repositoryName), .builds).relativeURL()),
             .ul(
-                .class("matrix"),
+                .class(matrixClass),
                 .forEach(rows) { compatibilityListItem($0.labelNode, cells: $0.results.all) }
             )
         )

--- a/Tests/AppTests/SwiftVersionTests.swift
+++ b/Tests/AppTests/SwiftVersionTests.swift
@@ -55,4 +55,10 @@ extension AllTests.SwiftVersionTests {
         #expect(SwiftVersion.latest.major == 6)
     }
 
+    @Test func compatibilityMatrixOrdersLatestVersionFirst() throws {
+        // _matrix.scss sometimes hides the latest Swift version via `:first-child`, so it must render first.
+        let compatibility = CompatibilityMatrix.SwiftVersionCompatibility()
+        #expect(compatibility.all.first?.parameter == SwiftVersion.latest)
+    }
+
 }

--- a/Tests/AppTests/WebpageSnapshotTests.swift
+++ b/Tests/AppTests/WebpageSnapshotTests.swift
@@ -242,6 +242,29 @@ extension AllTests.WebpageSnapshotTests {
         assertSnapshot(of: page, as: .html)
     }
 
+    @Test func PackageShow_document_hideLatestSwiftVersion() throws {
+        // Test that the latest Swift version's cell is hidden via CSS (not removed from the HTML)
+        // in the compatibility matrix when HIDE_LATEST_SWIFT_VERSION_BUILD_DATA is set.
+        var model = API.PackageController.GetRoute.Model.mock
+        let compatible = CompatibilityMatrix.SwiftVersionCompatibility(results: [.v1: .compatible,
+                                                                                 .v2: .compatible,
+                                                                                 .v3: .compatible,
+                                                                                 .v4: .compatible])
+        model.swiftVersionBuildInfo = .init(
+            stable: .init(referenceName: "5.2.5", results: compatible),
+            beta: .init(referenceName: "6.0.0-b1", results: compatible),
+            latest: .init(referenceName: "main", results: compatible)
+        )
+
+        withDependencies {
+            $0.environment.hideLatestSwiftVersionBuildData = { true }
+        } operation: {
+            let page = { PackageShow.View(path: "", model: model, packageSchema: .mock).document() }
+
+            assertSnapshot(of: page, as: .html)
+        }
+    }
+
     @Test func PackageShow_document_canonicalURL_noImageSnapshots() throws {
         // In production, the owner and repository name in the view model are fetched from
         // the database and have canonical capitalisation.
@@ -334,6 +357,18 @@ extension AllTests.WebpageSnapshotTests {
         let page = { BuildIndex.View(path: "", model: .mock).document() }
 
         assertSnapshot(of: page, as: .html)
+    }
+
+    @Test func BuildIndex_document_hideLatestSwiftVersion() throws {
+        // Test that the latest Swift version's whole section is skipped from rendering
+        // when HIDE_LATEST_SWIFT_VERSION_BUILD_DATA is set.
+        withDependencies {
+            $0.environment.hideLatestSwiftVersionBuildData = { true }
+        } operation: {
+            let page = { BuildIndex.View(path: "", model: .mock).document() }
+
+            assertSnapshot(of: page, as: .html)
+        }
     }
 
     @Test func BuildShow_document() throws {

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/BuildIndex_document_hideLatestSwiftVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/BuildIndex_document_hideLatestSwiftVersion.1.html
@@ -69,7 +69,6 @@
         </nav>
       </div>
     </header>
-    <p class="announcement">Swift Package Index will be temporarily unavailable on Tuesday, 23rd of June for scheduled maintenance.</p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/BuildIndex_document_hideLatestSwiftVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/BuildIndex_document_hideLatestSwiftVersion.1.html
@@ -1,0 +1,840 @@
+<!DOCTYPE html>
+<html lang="en"><!--Version: test--><!--DB Id: db-id-->
+  <head>
+    <meta name="robots" content="noindex"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="UTF-8"/>
+    <meta name="turbo-refresh-method" content="replace"/>
+    <meta property="og:site_name" content="The Swift Package Index"/>
+    <link rel="canonical" href="http://localhost:8080/"/>
+    <meta name="twitter:url" content="http://localhost:8080/"/>
+    <meta property="og:url" content="http://localhost:8080/"/>
+    <title>foobar &ndash; Build Results &ndash; Swift Package Index</title>
+    <meta name="twitter:title" content="foobar &ndash; Build Results &ndash; Swift Package Index"/>
+    <meta property="og:title" content="foobar &ndash; Build Results &ndash; Swift Package Index"/>
+    <meta name="description" content="The latest compatibility build results for foobar, showing compatibility across 9 platforms with 4 versions of Swift."/>
+    <meta name="twitter:description" content="The latest compatibility build results for foobar, showing compatibility across 9 platforms with 4 versions of Swift."/>
+    <meta property="og:description" content="The latest compatibility build results for foobar, showing compatibility across 9 platforms with 4 versions of Swift."/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:image" content="http://localhost:8080/images/logo.png"/>
+    <meta property="og:image" content="http://localhost:8080/images/logo.png"/>
+    <link rel="shortcut icon" href="/images/logo-tiny.png" type="image/png"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index Blog" href="http://localhost:8080/blog/feed.xml"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added Packages" href="http://localhost:8080/packages.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Package Releases" href="http://localhost:8080/releases.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Package Releases" href="http://localhost:8080/releases.rss?major=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Package Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Package Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
+    <link rel="stylesheet" href="/shared.css?test" data-turbo-track="reload"/>
+    <link rel="stylesheet" href="/main.css?test" data-turbo-track="reload"/>
+    <script src="/shared.js?test" data-turbo-track="reload" defer></script>
+    <script src="/main.js?test" data-turbo-track="reload" defer></script><script>var s_account = 'awdswiftpackageindexcom'</script>
+<script src="https://developer.apple.com/assets/metrics/scripts/analytics.js"></script>
+<script>
+    s.pageName = AC && AC.Tracking && AC.Tracking.pageName()
+
+    /************* DO NOT ALTER ANYTHING BELOW THIS LINE ! **************/
+    var s_code = s.t()
+    if (s_code) document.write(s_code)
+</script>
+  </head>
+  <body>
+    <header>
+      <div class="inner">
+        <a href="/">
+          <h1>
+            <img alt="The Swift Package Index logo." width="64" height="64" src="/images/logo.svg"/>Swift Package Index
+          </h1>
+        </a>
+        <nav>
+          <ul>
+            <li>
+              <a href="/add-a-package">Add a Package</a>
+            </li>
+            <li>
+              <a href="/blog">Blog</a>
+            </li>
+            <li>
+              <a href="/faq">FAQ</a>
+            </li>
+            <li class="search">
+              <form action="/search">
+                <input id="query" name="query" type="search" placeholder="Search" spellcheck="false" autocomplete="off" data-gramm="false" data-focus="false"/>
+                <button type="submit">
+                  <div title="Search"></div>
+                </button>
+              </form>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <p class="announcement">Swift Package Index will be temporarily unavailable on Tuesday, 23rd of June for scheduled maintenance.</p>
+    <nav class="breadcrumbs">
+      <div class="inner">
+        <ul>
+          <li>
+            <a href="/">
+              <span>Home</span>
+            </a>
+          </li>
+          <li>
+            <a href="/foo">
+              <span>Foo</span>
+            </a>
+          </li>
+          <li>
+            <a href="/foo/foobar">
+              <span>foobar</span>
+            </a>
+          </li>
+          <li>
+            <span>Build Results</span>
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <main>
+      <div class="inner">
+        <div>
+          <h2>Build Results</h2>
+          <p>
+            <strong>43</strong> completed builds for 
+            <a href="/foo/foobar">foobar</a>.
+          </p>
+          <p>If you are the author of this package and see unexpected build failures, please check the 
+            <a href="/docs/builds">build system documentation</a> to see how we derive build parameters. If you still see surprising results, please 
+            <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/new/choose">raise an issue</a>.
+          </p>
+          <hr/>
+          <h3>Swift 6.2</h3>
+          <ul class="build-results">
+            <li class="row">
+              <div class="row-labels">
+                <strong>iOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                  <span class="generated-docs" title="If successful, this build generated package documentation."></span>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                  <span class="generated-docs" title="If successful, this build generated package documentation."></span>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                  <span class="generated-docs" title="If successful, this build generated package documentation."></span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>macOS (SPM)</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="failed">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
+                </div>
+                <div class="failed">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
+                </div>
+                <div class="failed">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>macOS (Xcode)</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Queued</span>
+                </div>
+                <div>
+                  <span>Queued</span>
+                </div>
+                <div>
+                  <span>Queued</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>visionOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>tvOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Timed Out</span>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>watchOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Errored</span>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>Linux</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>Wasm</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>Android</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+              </div>
+            </li>
+          </ul>
+          <hr/>
+          <h3>Swift 6.1</h3>
+          <ul class="build-results">
+            <li class="row">
+              <div class="row-labels">
+                <strong>iOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>macOS (SPM)</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="failed">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
+                </div>
+                <div class="failed">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
+                </div>
+                <div class="failed">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>macOS (Xcode)</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Queued</span>
+                </div>
+                <div>
+                  <span>Queued</span>
+                </div>
+                <div>
+                  <span>Queued</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>visionOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>tvOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>watchOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>Linux</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>Wasm</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>Android</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+              </div>
+            </li>
+          </ul>
+          <hr/>
+          <h3>Swift 6.0</h3>
+          <ul class="build-results">
+            <li class="row">
+              <div class="row-labels">
+                <strong>iOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>macOS (SPM)</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="failed">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
+                </div>
+                <div class="failed">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
+                </div>
+                <div class="failed">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Failed</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>macOS (Xcode)</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Queued</span>
+                </div>
+                <div>
+                  <span>Queued</span>
+                </div>
+                <div>
+                  <span>Queued</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>visionOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+                <div>
+                  <span>Pending</span>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>tvOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>watchOS</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+            <li class="row">
+              <div class="row-labels">
+                <strong>Linux</strong>
+              </div>
+              <div class="column-labels">
+                <div>
+                  <span class="stable">1.2.3</span>
+                </div>
+                <div>
+                  <span class="branch">main</span>
+                </div>
+                <div>
+                  <span class="beta">2.0.0-b1</span>
+                </div>
+              </div>
+              <div class="results">
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+                <div class="succeeded">
+                  <a href="/builds/2F16F873-1EBF-4987-B4CE-A9F22269D13A">Succeeded</a>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </main>
+    <footer>
+      <div class="inner">
+        <nav>
+          <ul>
+            <li>
+              <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a>
+            </li>
+            <li>
+              <a href="https://www.apple.com/privacy/privacy-policy/">Privacy</a>
+            </li>
+            <li>
+              <a href="https://swiftpackageindex.statuspage.io">System Status</a>
+            </li>
+            <li>
+              <a href="/build-monitor">Build System Monitor</a>
+            </li>
+            <li>
+              <a href="https://mas.to/@SwiftPackageUpdates">Mastodon</a>
+            </li>
+            <li>
+              <a href="/ready-for-swift-6">Ready for Swift 6</a>
+            </li>
+          </ul>
+          <small>Copyright © 2026 SPI Operations Limited. All rights reserved. Swift Package Index and the Swift Package Index logo are trademarks of SPI Operations Limited. Swift and the Swift logo are trademarks of Apple Inc.</small>
+          <small>The Swift Package Index is operated by SPI Operations Limited (
+            <a href="mailto:contact@swiftpackageindex.com">contact@swiftpackageindex.com</a>), a company registered in England and Wales with company number 13466692, with its registered office at 280 Bishopsgate, London, EC2M 4AG.
+          </small>
+          <a rel="me" href="https://mas.to/@SwiftPackageIndex"></a>
+          <a rel="me" href="https://mas.to/@SwiftPackageUpdates"></a>
+        </nav>
+      </div>
+    </footer>
+    <spi-debug-panel class="hidden">
+      <table>
+        <tbody></tbody>
+      </table>
+    </spi-debug-panel>
+  </body>
+</html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_hideLatestSwiftVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_hideLatestSwiftVersion.1.html
@@ -1,0 +1,391 @@
+<!DOCTYPE html>
+<html lang="en"><!--Version: test--><!--DB Id: db-id-->
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="UTF-8"/>
+    <meta name="turbo-refresh-method" content="replace"/>
+    <meta property="og:site_name" content="The Swift Package Index"/>
+    <link rel="canonical" href="http://localhost:8080/Alamo/Alamofire"/>
+    <meta name="twitter:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <meta property="og:url" content="http://localhost:8080/Alamo/Alamofire"/>
+    <title>Alamofire &ndash; Swift Package Index</title>
+    <meta name="twitter:title" content="Alamofire &ndash; Swift Package Index"/>
+    <meta property="og:title" content="Alamofire &ndash; Swift Package Index"/>
+    <meta name="description" content="Alamofire by Alamofire on the Swift Package Index – Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. V…"/>
+    <meta name="twitter:description" content="Alamofire by Alamofire on the Swift Package Index – Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. V…"/>
+    <meta property="og:description" content="Alamofire by Alamofire on the Swift Package Index – Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. V…"/>
+    <meta name="twitter:card" content="summary"/>
+    <meta name="twitter:image" content="http://localhost:8080/images/logo.png"/>
+    <meta property="og:image" content="http://localhost:8080/images/logo.png"/>
+    <link rel="shortcut icon" href="/images/logo-tiny.png" type="image/png"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index Blog" href="http://localhost:8080/blog/feed.xml"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recently Added Packages" href="http://localhost:8080/packages.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Package Releases" href="http://localhost:8080/releases.rss"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major Package Releases" href="http://localhost:8080/releases.rss?major=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Major & Minor Package Releases" href="http://localhost:8080/releases.rss?major=true&minor=true"/>
+    <link rel="alternate" type="application/rss+xml" title="Swift Package Index – Recent Package Pre-Releases" href="http://localhost:8080/releases.rss?pre=true"/>
+    <link rel="stylesheet" href="/shared.css?test" data-turbo-track="reload"/>
+    <link rel="stylesheet" href="/main.css?test" data-turbo-track="reload"/>
+    <script src="/shared.js?test" data-turbo-track="reload" defer></script>
+    <script src="/main.js?test" data-turbo-track="reload" defer></script><script>var s_account = 'awdswiftpackageindexcom'</script>
+<script src="https://developer.apple.com/assets/metrics/scripts/analytics.js"></script>
+<script>
+    s.pageName = AC && AC.Tracking && AC.Tracking.pageName()
+
+    /************* DO NOT ALTER ANYTHING BELOW THIS LINE ! **************/
+    var s_code = s.t()
+    if (s_code) document.write(s_code)
+</script>
+  </head>
+  <body class="package"><!--CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE-->
+    <header>
+      <div class="inner">
+        <a href="/">
+          <h1>
+            <img alt="The Swift Package Index logo." width="64" height="64" src="/images/logo.svg"/>Swift Package Index
+          </h1>
+        </a>
+        <nav>
+          <ul>
+            <li>
+              <a href="/add-a-package">Add a Package</a>
+            </li>
+            <li>
+              <a href="/blog">Blog</a>
+            </li>
+            <li>
+              <a href="/faq">FAQ</a>
+            </li>
+            <li class="search">
+              <form action="/search">
+                <input id="query" name="query" type="search" placeholder="Search" spellcheck="false" autocomplete="off" data-gramm="false" data-focus="false"/>
+                <button type="submit">
+                  <div title="Search"></div>
+                </button>
+              </form>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </header>
+    <p class="announcement">Swift Package Index will be temporarily unavailable on Tuesday, 23rd of June for scheduled maintenance.</p>
+    <nav class="breadcrumbs">
+      <div class="inner">
+        <ul>
+          <li>
+            <a href="/">
+              <span>Home</span>
+            </a>
+          </li>
+          <li>
+            <a href="/Alamo">
+              <span>Alamofire</span>
+            </a>
+          </li>
+          <li>
+            <span>Alamofire</span>
+          </li>
+        </ul>
+      </div>
+    </nav>
+    <main>
+      <div class="inner">
+        <div class="two-column v-end">
+          <div class="package-title">
+            <h2>Alamofire</h2>
+            <small>
+              <a href="https://github.com/Alamo">Alamo</a>
+              <span>/</span>
+              <a href="https://github.com/Alamo/Alamofire">Alamofire</a>
+            </small>
+          </div>
+          <div data-controller="modal-panel">
+            <button data-modal-panel-target="button" data-action="click->modal-panel#show">Use this Package</button>
+            <section class="use-this-package" data-modal-panel-target="panel">
+              <button class="close" data-action="click->modal-panel#hide">&times;</button>
+              <h4>When working with an Xcode project:</h4>
+              <form class="copyable-input">
+                <input type="text" data-button-name="Copy" data-event-name="Copy Xcodeproj Package URL Button" value="https://github.com/Alamofire/Swift-Alamofire.git" readonly/>
+              </form>
+              <h4>When working with a Swift Package Manager manifest:</h4>
+              <p>Select a package version:</p>
+              <div class="version">
+                <p>
+                  <span class="stable">5.2.0</span>
+                </p>
+                <form class="copyable-input">
+                  <input type="text" data-button-name="Copy" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Swift-Alamofire.git&quot;, from: &quot;5.2.0&quot;)" readonly/>
+                </form>
+              </div>
+              <div class="version">
+                <p>
+                  <span class="beta">5.3.0-beta.1</span>
+                </p>
+                <form class="copyable-input">
+                  <input type="text" data-button-name="Copy" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Swift-Alamofire.git&quot;, from: &quot;5.3.0-beta.1&quot;)" readonly/>
+                </form>
+              </div>
+              <div class="version">
+                <p>
+                  <span class="branch">main</span>
+                </p>
+                <form class="copyable-input">
+                  <input type="text" data-button-name="Copy" data-event-name="Copy SPM Manifest Code Snippet Button" value=".package(url: &quot;https://github.com/Alamofire/Swift-Alamofire.git&quot;, branch: &quot;main&quot;)" readonly/>
+                </form>
+              </div>
+              <div data-controller="use-this-package-panel">
+                <p>
+                  <label for="products">Select a product:</label>
+                  <select data-use-this-package-panel-target="select" data-action="input->use-this-package-panel#updateProductSnippet" name="products" id="products">
+                    <option data-package="swift-alamofire" data-product="lib1" data-type="library" value="lib1" label="lib1"/>
+                    <option data-package="swift-alamofire" data-product="lib2" data-type="library" value="lib2" label="lib2"/>
+                    <option data-package="swift-alamofire" data-product="lib3" data-type="library" value="lib3" label="lib3"/>
+                  </select>
+                </p>
+                <form class="copyable-input">
+                  <input type="text" data-use-this-package-panel-target="snippet" data-button-name="Copy" data-event-name="Copy SPM Manifest Product Code Snippet Button" readonly/>
+                </form>
+              </div>
+            </section>
+          </div>
+        </div>
+        <hr class="tight"/>
+        <p class="summary">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque quis porttitor erat. Vivamus porttitor mi odio, quis imperdiet velit blandit id. Vivamus vehicula urna eget ipsum laoreet, sed porttitor sapien malesuada. Mauris faucibus tellus at augue vehicula, vitae aliquet felis ullamcorper. Praesent vitae leo rhoncus, egestas elit id, porttitor lacus. Cras ac bibendum mauris. Praesent luctus quis nulla sit amet tempus. Ut pharetra non augue sed pellentesque.</p>
+        <article class="details two-column">
+          <section>
+            <section>
+              <ul class="main-metadata">
+                <li class="authors">Written by Author One, Author Two, Author Three, and 5 other contributors.</li>
+                <li class="history">In development for 2 months, with 
+                  <a href="https://github.com/Alamofire/Alamofire/commits/main">1,433 commits</a> and 
+                  <a href="https://github.com/Alamofire/Alamofire/releases">79 releases</a>.
+                </li>
+                <li class="activity">There are 
+                  <a href="https://github.com/Alamofire/Alamofire/issues">27 open issues</a> and 
+                  <a href="https://github.com/Alamofire/Alamofire/pulls">5 open pull requests</a>. The last issue was closed 5 days ago and the last pull request was merged/closed 6 days ago.
+                </li>
+                <li class="dependencies">
+                  <div>This package depends on 2 other packages.</div>
+                  <small>Including all transitive and test dependencies.</small>
+                </li>
+                <li class="license"> licensed</li>
+                <li class="stars">17 stars</li>
+                <li class="libraries">3 libraries</li>
+                <li class="executables">1 executable</li>
+                <li class="plugins">No plugins</li>
+                <li class="macros">2 macros</li>
+              </ul>
+            </section>
+            <hr class="minor"/>
+            <section class="main-compatibility">
+              <div class="title">
+                <h3>Compatibility</h3>
+                <a href="/Alamo/Alamofire/builds">Full Build Results</a>
+              </div>
+              <div class="matrices">
+                <a href="/Alamo/Alamofire/builds">
+                  <ul class="matrix hide-latest-swift-version">
+                    <li class="version">
+                      <div class="label">
+                        <span class="stable">5.2.5</span>
+                        <span class="separator">/</span>
+                        <span class="longest beta">6.0.0-b1</span>
+                        <span class="separator">/</span>
+                        <span class="branch">main</span>
+                      </div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with Swift 6.3">6.3</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.2">6.2</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.1">6.1</div>
+                        <div class="result compatible" title="Built successfully with Swift 6.0">6.0</div>
+                      </div>
+                    </li>
+                  </ul>
+                </a>
+                <a href="/Alamo/Alamofire/builds">
+                  <ul class="matrix">
+                    <li class="version">
+                      <div class="label">
+                        <span class="longest stable">5.2.3</span>
+                      </div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result unknown" title="No build information available for macOS">macOS</div>
+                        <div class="result unknown" title="No build information available for visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS</div>
+                        <div class="result unknown" title="No build information available for tvOS">tvOS</div>
+                        <div class="result unknown" title="No build information available for Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm</div>
+                        <div class="result unknown" title="No build information available for Android">Android</div>
+                      </div>
+                    </li>
+                    <li class="version">
+                      <div class="label">
+                        <span class="longest beta">6.0.0-b1</span>
+                      </div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result unknown" title="No build information available for watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm</div>
+                        <div class="result unknown" title="No build information available for Android">Android</div>
+                      </div>
+                    </li>
+                    <li class="version">
+                      <div class="label">
+                        <span class="longest branch">main</span>
+                      </div>
+                      <div class="results">
+                        <div class="result compatible" title="Built successfully with iOS">iOS</div>
+                        <div class="result compatible" title="Built successfully with macOS">macOS</div>
+                        <div class="result compatible" title="Built successfully with visionOS">visionOS</div>
+                        <div class="result compatible" title="Built successfully with watchOS">watchOS</div>
+                        <div class="result compatible" title="Built successfully with tvOS">tvOS</div>
+                        <div class="result compatible" title="Built successfully with Linux">Linux</div>
+                        <div class="result unknown" title="No build information available for WebAssembly">Wasm</div>
+                        <div class="result unknown" title="No build information available for Android">Android</div>
+                      </div>
+                    </li>
+                  </ul>
+                </a>
+              </div>
+            </section>
+          </section>
+          <section>
+            <section class="sidebar-links">
+              <ul>
+                <li>
+                  <a class="github" href="https://github.com/Alamo/Alamofire">View on GitHub</a>
+                </li>
+              </ul>
+            </section>
+            <hr class="minor"/>
+            <section class="sidebar-versions" aria-label="Versions">
+              <ul>
+                <li class="stable">
+                  <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.2.0">
+                    <span class="stable">5.2.0</span>
+                  </a>
+                  <strong>Latest Release</strong>
+                  <small>Released 12 days ago</small>
+                </li>
+                <li class="beta">
+                  <a href="https://github.com/Alamofire/Alamofire/releases/tag/5.3.0-beta.1">
+                    <span class="beta">5.3.0-beta.1</span>
+                  </a>
+                  <strong>Latest Beta Release</strong>
+                  <small>Released 4 days ago</small>
+                </li>
+                <li class="branch">
+                  <a href="https://github.com/Alamofire/Alamofire">
+                    <span class="branch">main</span>
+                  </a>
+                  <strong>Default Branch</strong>
+                  <small>Modified 12 minutes ago</small>
+                </li>
+              </ul>
+            </section>
+            <hr class="minor"/>
+            <section class="sidebar-package-authors">
+              <small>
+                <strong>Do you maintain this package?</strong> Get shields.io compatibility badges and learn how to control our build system. 
+                <a href="/Alamo/Alamofire/information-for-package-maintainers">Learn more</a>.
+              </small>
+            </section>
+          </section>
+        </article>
+        <section data-controller="tab-bar">
+          <nav>
+            <ul class="tab-list">
+              <li id="readme" data-tab-bar-target="tab" data-action="click->tab-bar#updateTab">README</li>
+              <li id="releases" data-tab-bar-target="tab" data-action="click->tab-bar#updateTab">Release Notes</li>
+            </ul>
+          </nav>
+          <section data-tab-bar-target="content">
+            <turbo-frame id="readme_content" src="/Alamo/Alamofire/readme" data-controller="readme" data-action="turbo:frame-load->readme#frameLoaded">
+              <div>
+                <div class="spinner">
+                  <div class="rect1"></div>
+                  <div class="rect2"></div>
+                  <div class="rect3"></div>
+                  <div class="rect4"></div>
+                  <div class="rect5"></div>
+                </div>
+              </div>
+            </turbo-frame>
+          </section>
+          <section data-tab-bar-target="content">
+            <turbo-frame id="releases_content" src="/Alamo/Alamofire/releases">
+              <div>
+                <div class="spinner">
+                  <div class="rect1"></div>
+                  <div class="rect2"></div>
+                  <div class="rect3"></div>
+                  <div class="rect4"></div>
+                  <div class="rect5"></div>
+                </div>
+              </div>
+            </turbo-frame>
+          </section>
+          <noscript>JavaScript must be enabled for the tab bar to be functional.</noscript>
+        </section>
+        <section>
+          <hr/>
+          <p>
+            <time datetime="2001-01-01">Last updated on 1 Jan 2001</time>
+          </p>
+        </section>
+      </div>
+    </main>
+    <footer>
+      <div class="inner">
+        <nav>
+          <ul>
+            <li>
+              <a href="https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server">GitHub</a>
+            </li>
+            <li>
+              <a href="https://www.apple.com/privacy/privacy-policy/">Privacy</a>
+            </li>
+            <li>
+              <a href="https://swiftpackageindex.statuspage.io">System Status</a>
+            </li>
+            <li>
+              <a href="/build-monitor">Build System Monitor</a>
+            </li>
+            <li>
+              <a href="https://mas.to/@SwiftPackageUpdates">Mastodon</a>
+            </li>
+            <li>
+              <a href="/ready-for-swift-6">Ready for Swift 6</a>
+            </li>
+          </ul>
+          <small>Copyright © 2026 SPI Operations Limited. All rights reserved. Swift Package Index and the Swift Package Index logo are trademarks of SPI Operations Limited. Swift and the Swift logo are trademarks of Apple Inc.</small>
+          <small>The Swift Package Index is operated by SPI Operations Limited (
+            <a href="mailto:contact@swiftpackageindex.com">contact@swiftpackageindex.com</a>), a company registered in England and Wales with company number 13466692, with its registered office at 280 Bishopsgate, London, EC2M 4AG.
+          </small>
+          <a rel="me" href="https://mas.to/@SwiftPackageIndex"></a>
+          <a rel="me" href="https://mas.to/@SwiftPackageUpdates"></a>
+        </nav>
+      </div>
+    </footer>
+    <script type="application/ld+json">{"@context":"https://schema.org","@type":"SoftwareSourceCode","codeRepository":"https://github.com/Alamofire/Alamofire","dateModified":"2001-01-01T00:00:00Z","datePublished":"1970-01-01T00:00:00Z","description":"This is an amazing package.","identifier":"Owner/Name","keywords":["foo","bar","baz"],"license":"https://github.com/Alamofire/Alamofire/blob/master/LICENSE","name":"Name","programmingLanguage":{"@context":"https://schema.org","@type":"ComputerLanguage","name":"Swift","url":"https://swift.org/"},"sourceOrganization":{"@context":"https://schema.org","@type":"Organization","legalName":"MegaOwner Corporation"},"url":"http://localhost:8080/Owner/Name","version":"5.2.0"}</script>
+    <spi-debug-panel class="hidden">
+      <table>
+        <tbody>
+          <tr server-side>
+            <td>Package ID</td>
+            <td>CAFECAFE-CAFE-CAFE-CAFE-CAFECAFECAFE</td>
+          </tr>
+          <tr server-side>
+            <td>Score</td>
+            <td>10</td>
+          </tr>
+        </tbody>
+      </table>
+    </spi-debug-panel>
+  </body>
+</html>

--- a/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_hideLatestSwiftVersion.1.html
+++ b/Tests/AppTests/__Snapshots__/WebpageSnapshotTests/PackageShow_document_hideLatestSwiftVersion.1.html
@@ -68,7 +68,6 @@
         </nav>
       </div>
     </header>
-    <p class="announcement">Swift Package Index will be temporarily unavailable on Tuesday, 23rd of June for scheduled maintenance.</p>
     <nav class="breadcrumbs">
       <div class="inner">
         <ul>


### PR DESCRIPTION
Regular view:

<img width="616" height="237" alt="Screenshot 2026-07-31 at 18 06 52" src="https://github.com/user-attachments/assets/f62f5eb0-b47d-4696-bcb2-e2645c3b78d1" />

With `HIDE_LATEST_SWIFT_VERSION_BUILD_DATA` set:

<img width="615" height="230" alt="Screenshot 2026-07-31 at 18 09 04" src="https://github.com/user-attachments/assets/a27143b1-54dc-4692-871e-58beee896b14" />

Obviously this will hide 6.4 and not 6.3 once #4112 is merged.