### PR TITLE
Add debug logging around new version analysis

### DIFF
--- a/Sources/App/Commands/Analyze.swift
+++ b/Sources/App/Commands/Analyze.swift
@@ -199,6 +199,7 @@ extension Analyze {
                     try await applyVersionDelta(on: tx, delta: versionDelta)
 
                     let newVersions = versionDelta.toAdd
+                    logger.debug("newVersions: \(newVersions.map { $0.reference.description + "(" + $0.commit.prefix(6) + ")" })")
 
                     mergeReleaseInfo(package: package, into: newVersions)
 
@@ -206,6 +207,8 @@ extension Analyze {
                     for version in newVersions {
                         if let pkgInfo = try? await getPackageInfo(package: package, version: version) {
                             versionsPkgInfo.append((version, pkgInfo))
+                        } else {
+                            logger.debug("getPackageInfo failed for version \(version.reference)")
                         }
                     }
                     if !newVersions.isEmpty && versionsPkgInfo.isEmpty {
@@ -583,13 +586,19 @@ extension Analyze {
         // check out version in cache directory
         @Dependency(\.fileManager) var fileManager
         @Dependency(\.shell) var shell
+        @Dependency(\.logger) var logger
 
         guard let cacheDir = fileManager.cacheDirectoryPath(for: package.model) else {
             throw AppError.invalidPackageCachePath(package.model.id,
                                                    package.model.url)
         }
 
-        try await shell.run(command: .gitCheckout(branch: version.reference.description), at: cacheDir)
+        do {
+            try await shell.run(command: .gitCheckout(branch: version.reference.description), at: cacheDir)
+        } catch {
+            logger.debug("error in getPackageInfo: \(error)")
+            throw error
+        }
 
         do {
             let packageManifest = try await dumpPackage(at: cacheDir)
@@ -599,8 +608,12 @@ extension Analyze {
             return PackageInfo(packageManifest: packageManifest,
                                spiManifest: spiManifest)
         } catch let AppError.invalidRevision(_, msg) {
+            logger.debug("invalidRevision: \(version.reference)")
             // re-package error to attach version.id
             throw AppError.invalidRevision(version.id, msg)
+        } catch {
+            logger.debug("error in getPackageInfo: \(error)")
+            throw error
         }
     }
 


### PR DESCRIPTION
Adds debug logging to track down issue #4120 

Analysis fails when run manually:

```
root@9edf710eb548:/app# ./Run analyze --id ff6a07b5-9bbe-4536-a20a-b28aa179b27c
[ INFO ] Analyzing (id: FF6A07B5-9BBE-4536-A20A-B28AA179B27C) ... [component: analyze]
[ INFO ] Checkout directory: /checkouts [component: analyze]
[ INFO ] pulling https://github.com/apache/spark-connect-swift.git in /checkouts/github.com-apache-spark-connect-swift [component: analyze]
[ WARNING ] stderr: From https://github.com/apache/spark-connect-swift
   02e33e0..c627124  main       -> origin/main [component: analyze]
[ CRITICAL ] updatePackages: unusually high error rate: 1/1 = 100.0% [component: analyze]
[ WARNING ] App.AppError.noValidVersions(Optional(FF6A07B5-9BBE-4536-A20A-B28AA179B27C), "https://github.com/apache/spark-connect-swift.git") [component: analyze]
```

It passes running locally, against a db snapshot (but without a copy of the checkout).

This is to give us more info into what exactly is failing (likely `getPackageInfo`).