### PR TITLE
Build backlog stats

### DIFF
--- a/Sources/App/Commands/BuildBacklogStats.swift
+++ b/Sources/App/Commands/BuildBacklogStats.swift
@@ -23,6 +23,9 @@ enum BuildBacklogStats {
         struct Signature: CommandSignature {
             @Option(name: "limit", short: "l")
             var limit: Int?
+
+            @Flag(name: "without-latest-swift-version")
+            var withoutLatestSwiftVersion: Bool
         }
 
         func run(using context: CommandContext, signature: Signature) async throws {
@@ -32,6 +35,52 @@ enum BuildBacklogStats {
             @Dependency(\.logger) var logger
 
             logger.info("Running build-backlog-stats...")
+
+            let packageIds = try await fetchBuildCandidates(
+                context.application.db,
+                withLatestSwiftVersion: !signature.withoutLatestSwiftVersion
+            )
+
+            if let limit = signature.limit {
+                logger.info("Checking \(limit) of \(packageIds.count) candidates...")
+            } else {
+                logger.info("Checkign all \(packageIds.count) candidates")
+            }
+
+            var totalBuildCount = 0
+            var platformCounts = [Build.Platform: Int]()
+            var swiftVersionCounts = [SwiftVersion: Int]()
+
+            for (idx, pkgId) in packageIds.prefix(signature.limit ?? packageIds.count).enumerated() {
+                if idx > 0, idx % 50 == 0 {
+                    logger.info("Checking candidate #\(idx)")
+                }
+                let triggerInfo = try await findMissingBuilds(
+                    context.application.db,
+                    packageId: pkgId
+                )
+                for trigger in triggerInfo {
+                    for pair in trigger.buildPairs {
+                        totalBuildCount += 1
+                        platformCounts[pair.platform, default: 0] += 1
+                        swiftVersionCounts[pair.swiftVersion, default: 0] += 1
+                    }
+                }
+            }
+
+            logger.info("Total build count: \(totalBuildCount)")
+
+            for platform in Build.Platform.allActive {
+                if let count = platformCounts[platform] {
+                    logger.info("\(platform): \(count)")
+                }
+            }
+
+            for swiftVersion in SwiftVersion.allActive {
+                if let count = swiftVersionCounts[swiftVersion] {
+                    logger.info("\(swiftVersion): \(count)")
+                }
+            }
         }
     }
 }

--- a/Sources/App/Commands/BuildBacklogStats.swift
+++ b/Sources/App/Commands/BuildBacklogStats.swift
@@ -1,0 +1,37 @@
+// Copyright Dave Verwer, Sven A. Schmidt, and other contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import Dependencies
+import Vapor
+
+
+enum BuildBacklogStats {
+    struct Command: AsyncCommand {
+        var help: String { "Show build backlog statistics" }
+
+        struct Signature: CommandSignature {
+            @Option(name: "limit", short: "l")
+            var limit: Int?
+        }
+
+        func run(using context: CommandContext, signature: Signature) async throws {
+            prepareDependencies {
+                $0.logger = Logger(component: "build-backlog-stats")
+            }
+            @Dependency(\.logger) var logger
+
+            logger.info("Running build-backlog-stats...")
+        }
+    }
+}

--- a/Sources/App/configure.swift
+++ b/Sources/App/configure.swift
@@ -348,6 +348,7 @@ public func configure(_ app: Application, databaseHost: String? = nil, databaseP
     }
 
     app.asyncCommands.use(Analyze.Command(), as: "analyze")
+    app.asyncCommands.use(BuildBacklogStats.Command(), as: "build-backlog-stats")
     app.asyncCommands.use(CreateRestfileCommand(), as: "create-restfile")
     app.asyncCommands.use(DeleteBuildsCommand(), as: "delete-builds")
     app.asyncCommands.use(Ingestion.Command(), as: "ingest")


### PR DESCRIPTION
This adds a command to collect build backlog stats by running the `fetchBuildCandidates` function (query) and then iterating over the candidate packages to find their missing builds.

Ideally, we'd have this breakdown as part of our Prometheus stats. However, only the `fetchBuildCandidates` query can be run efficiently. In order to find the actual missing builds, a subsequent query needs to be run for each package, which is prohibitive on a schedule.

It is also very difficult to express the search for missing builds in pure SQL, so it's not something we could put in a materialised view.

Below is an example run against a PROD snapshot from yesterday. (This is the best way to run this command, although running it occasionally against the database itself should be fine, too.)

```
[ INFO ] Running build-backlog-stats... [component: build-backlog-stats]
[ INFO ] Checkign all 627 candidates [component: build-backlog-stats]
[ INFO ] Checking candidate #50 [component: build-backlog-stats]
[ INFO ] Checking candidate #100 [component: build-backlog-stats]
[ INFO ] Checking candidate #150 [component: build-backlog-stats]
[ INFO ] Checking candidate #200 [component: build-backlog-stats]
[ INFO ] Checking candidate #250 [component: build-backlog-stats]
[ INFO ] Checking candidate #300 [component: build-backlog-stats]
[ INFO ] Checking candidate #350 [component: build-backlog-stats]
[ INFO ] Checking candidate #400 [component: build-backlog-stats]
[ INFO ] Checking candidate #450 [component: build-backlog-stats]
[ INFO ] Checking candidate #500 [component: build-backlog-stats]
[ INFO ] Checking candidate #550 [component: build-backlog-stats]
[ INFO ] Checking candidate #600 [component: build-backlog-stats]
[ INFO ] Total build count: 32875 [component: build-backlog-stats]
[ INFO ] ios: 3853 [component: build-backlog-stats]
[ INFO ] macos-spm: 3854 [component: build-backlog-stats]
[ INFO ] macos-xcodebuild: 3853 [component: build-backlog-stats]
[ INFO ] visionos: 3853 [component: build-backlog-stats]
[ INFO ] tvos: 3852 [component: build-backlog-stats]
[ INFO ] watchos: 3852 [component: build-backlog-stats]
[ INFO ] linux: 3904 [component: build-backlog-stats]
[ INFO ] wasm: 2926 [component: build-backlog-stats]
[ INFO ] android: 2928 [component: build-backlog-stats]
[ INFO ] 6.0.0: 6753 [component: build-backlog-stats]
[ INFO ] 6.1.0: 8706 [component: build-backlog-stats]
[ INFO ] 6.2.0: 8706 [component: build-backlog-stats]
[ INFO ] 6.3.0: 8710 [component: build-backlog-stats]
```

The results show that we had a ~32k builds backlog across 627 packages with an equal distribution across all platforms and Swift versions.

There's no indication that the backlog is due to any inefficiencies in the build system itself (due to for example one or more platforms being unavailable or slow).
