### PR TITLE
Handle non-AbortError errors in ErrorMiddleware

### DIFF
--- a/Sources/App/Core/ErrorMiddleware.swift
+++ b/Sources/App/Core/ErrorMiddleware.swift
@@ -25,9 +25,14 @@ final class ErrorMiddleware: AsyncMiddleware {
     func respond(to req: Request, chainingTo next: AsyncResponder) async throws -> Response {
         do {
             return try await next.respond(to: req)
-        } catch let error as AbortError where error.status.code >= 400 {
-            let statusCode = error.status.code
-            let isCritical = (statusCode >= 500)
+        } catch let error as AbortError where error.status.code < 400 {
+            throw error
+        } catch {
+            // Errors that aren't `AbortError`s would otherwise escape this middleware and be
+            // turned into an unlogged, raw 500 by Vapor's default error handling.
+            // See https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3944
+            let abortError = error as? AbortError ?? Abort(.internalServerError)
+            let isCritical = (abortError.status.code >= 500)
 
             @Dependency(\.logger) var logger
 
@@ -37,9 +42,9 @@ final class ErrorMiddleware: AsyncMiddleware {
                 logger.error("\(error): \(req.url)")
             }
 
-            return ErrorPage.View(path: req.url.path, error: error)
+            return ErrorPage.View(path: req.url.path, error: abortError)
                 .document()
-                .encodeResponse(status: error.status)
+                .encodeResponse(status: abortError.status)
         }
     }
 

--- a/Tests/AppTests/ErrorMiddlewareTests.swift
+++ b/Tests/AppTests/ErrorMiddlewareTests.swift
@@ -26,7 +26,10 @@ extension AllTests.ErrorMiddlewareTests {
         app.get("ok") { _ in return "ok" }
         app.get("404") { req async throws -> Response in throw Abort(.notFound) }
         app.get("500") { req async throws -> Response in throw Abort(.internalServerError) }
+        app.get("unknown-error") { req async throws -> Response in throw TestError() }
     }
+
+    struct TestError: Error { }
 
     @Test func custom_routes() async throws {
         try await withSPIApp(setup) { app in
@@ -67,6 +70,22 @@ extension AllTests.ErrorMiddlewareTests {
                 try await app.testing().test(.GET, "500", afterResponse: { response async in
                     #expect(response.status == .internalServerError)
                     #expect(response.content.contentType == .html)
+                })
+            }
+        }
+    }
+
+    @Test func non_abort_error() async throws {
+        // Ensure errors that aren't AbortErrors are also converted to html error pages
+        // https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3944
+        try await withDependencies {
+            $0.environment.dbId = { nil }
+        } operation: {
+            try await withSPIApp(setup) { app in
+                try await app.testing().test(.GET, "unknown-error", afterResponse: { response async in
+                    #expect(response.status == .internalServerError)
+                    #expect(response.content.contentType == .html)
+                    #expect(response.body.asString().contains("500 - Internal Server Error"))
                 })
             }
         }


### PR DESCRIPTION
Refs #3944

### Problem

`ErrorMiddleware` only catches `AbortError`s. Any other error thrown from a route escapes the middleware, is converted into a raw 500 by Vapor's internal error handling, and is **never logged** by the application — so intermittent failures leave no trace.

This also explains the "An unknown error occurred" pages reported in #3944: swift-docc-render shows "page not found" for a 404 on a `/data/…json` request, but "An unknown error occurred" for [any other error status](https://github.com/swiftlang/swift-docc-render/blob/main/src/utils/data.js#L97-L105). An unlogged raw 500 from a non-`AbortError` produces exactly that, with nothing in the logs to diagnose it.

(Credit to @DePasqualeOrg, who tracked this down in https://github.com/SwiftPackageIndex/SwiftPackageIndex-Server/issues/3944#issuecomment.)

### Change

`ErrorMiddleware` now catches every error, not just `AbortError`. Non-`AbortError`s are treated as `.internalServerError`, logged at `critical` with the underlying error description, and rendered with the usual HTML error page. `AbortError`s with a status below 400 keep propagating, as before.

The user-facing page only shows the generic "500 - Internal Server Error" text — the underlying error description goes to the log, not the response.

### Notes

- This is a visibility/robustness fix; it doesn't itself identify what is intermittently failing, but it makes the failure show up in the logs.
- `swift build` passes locally. I couldn't run the test suite here (the toolchain in my environment can't resolve the `Testing` module for the test targets, which also fails on a clean checkout), so the added test is only verified by inspection — please let CI have the final word.