### PR TITLE
Add missing DEPLOYMENT to build trigger.

### DIFF
--- a/Sources/App/Core/Dependencies/EnvironmentClient.swift
+++ b/Sources/App/Core/Dependencies/EnvironmentClient.swift
@@ -53,6 +53,7 @@ struct EnvironmentClient {
     var collectionSigningPrivateKey: @Sendable () -> Data?
     var current: @Sendable () -> Environment = { XCTFail("current"); return .development }
     var dbId: @Sendable () -> String?
+    var deployment: @Sendable () -> String?
     var gitlabApiToken: @Sendable () -> String?
     var gitlabPipelineLimit: @Sendable () -> Int = { XCTFail("gitlabPipelineLimit"); return 100 }
     var gitlabPipelineToken: @Sendable () -> String?
@@ -147,6 +148,7 @@ extension EnvironmentClient: DependencyKey {
             },
             current: { (try? Environment.detect()) ?? .development },
             dbId: { Environment.get("DATABASE_ID") },
+            deployment: { Environment.get("DEPLOYMENT") },
             gitlabApiToken: { Environment.get("GITLAB_API_TOKEN") },
             gitlabPipelineLimit: {
                 Environment.get("GITLAB_PIPELINE_LIMIT").flatMap(Int.init)

--- a/Sources/App/Core/Dependencies/EnvironmentClient.swift
+++ b/Sources/App/Core/Dependencies/EnvironmentClient.swift
@@ -216,6 +216,7 @@ extension EnvironmentClient: TestDependencyKey {
         var mock = Self()
         mock.appVersion = { "test" }
         mock.current = { .development }
+        mock.deployment = { nil }
         mock.hideStagingBanner = { false }
         mock.siteURL = { "http://localhost:8080" }
         mock.shouldFail = { @Sendable _ in false }

--- a/Sources/App/Core/Gitlab.swift
+++ b/Sources/App/Core/Gitlab.swift
@@ -107,6 +107,11 @@ extension Gitlab.Builder {
             "VERSION_ID": versionID.uuidString
         ]
 
+        // Add deployment environment if available
+        if let deployment = environment.deployment() {
+            variables["DEPLOYMENT"] = deployment
+        }
+
         // Conditionally generate pre-signed URL for package upload
         if environment.enablePackageUploadPreSignedURLs() {
             if isDocBuild {

--- a/Tests/AppTests/GitlabBuilderTests.swift
+++ b/Tests/AppTests/GitlabBuilderTests.swift
@@ -99,6 +99,43 @@ extension AllTests.GitlabBuilderTests {
         }
     }
 
+    @Test func triggerBuild_deployment() async throws {
+        let buildId = UUID.id0
+        let versionId = UUID.id1
+        let called = QueueIsolated(false)
+        try await withDependencies {
+            $0.environment.awsDocsBucket = { "docs-bucket" }
+            $0.environment.builderToken = { "builder token" }
+            $0.environment.buildTimeout = { 10 }
+            $0.environment.deployment = { "production" }
+            $0.environment.enableBuildLogsPreSignedURLs = { false }
+            $0.environment.enablePackageUploadPreSignedURLs = { false }
+            $0.environment.gitlabPipelineToken = { "pipeline token" }
+            $0.environment.gitlabProjectId = { 19564054 }
+            $0.environment.siteURL = { "http://example.com" }
+            $0.httpClient.post = { @Sendable _, _, body in
+                called.setValue(true)
+                let body = try #require(body)
+                // validate
+                let deployment = (try? URLEncodedFormDecoder().decode(Gitlab.Builder.PostDTO.self, from: body))
+                    .flatMap { $0.variables["DEPLOYMENT"] }
+                #expect(deployment == "production")
+                return try .created(jsonEncode: Gitlab.Builder.Response(webUrl: "http://web_url"))
+            }
+            $0.logger = .noop
+        } operation: {
+            // MUT
+            _ = try await Gitlab.Builder.triggerBuild(buildId: buildId,
+                                                      cloneURL: "https://github.com/daveverwer/LeftPad.git",
+                                                      isDocBuild: false,
+                                                      platform: .macosSpm,
+                                                      reference: .tag(.init(1, 2, 3)),
+                                                      swiftVersion: .init(5, 2, 4),
+                                                      versionID: versionId)
+            #expect(called.value)
+        }
+    }
+
     @Test func issue_588() async throws {
         let called = QueueIsolated(false)
         try await withDependencies {


### PR DESCRIPTION
The DEPLOYMENT variable was not set as part
of the gitlab trigger, this was omitted as part of the AWS changes.

Add the variable back in.