### PR TITLE
Fix typo in example in FAQ

### DIFF
--- a/Resources/Markdown/faq.md
+++ b/Resources/Markdown/faq.md
@@ -130,7 +130,7 @@ Similarly, you can search for packages that contain keywords with a `keyword` fi
 
 #### Querying Platform values
 
-You can search for packages that are compatible with a platform using a `platform` filter. Specify multiple platforms together with commas. For example, [`testing platform:ios,linux`](https://swiftpackageindex.com/search?query=testing+platform%3Aios%2Clinux) shows packages matching the word "layout" that are compatible with both iOS and Linux.
+You can search for packages that are compatible with a platform using a `platform` filter. Specify multiple platforms together with commas. For example, [`testing platform:ios,linux`](https://swiftpackageindex.com/search?query=testing+platform%3Aios%2Clinux) shows packages matching the word "testing" that are compatible with both iOS and Linux.
 
 **Note:** Platform compatibility data comes from the [build system](/docs/builds) and is sourced from real-world build results.
 


### PR DESCRIPTION
The query in the example searches for "testing", but the text says that the query will find packages matching "layout".

This is fixed so that the link text, the link URL, and text all match.