### PR TITLE
Fix emoji replacement issue affecting strings containing non-BMP characters

### DIFF
--- a/Sources/App/Core/Emoji.swift
+++ b/Sources/App/Core/Emoji.swift
@@ -64,7 +64,7 @@ struct EmojiStorage {
             return string
         }
 
-        let nsRange = NSRange(location: 0, length: string.count)
+        let nsRange = NSRange(location: 0, length: string.utf16.count)
         let results = regEx.matches(in: string, options: [], range: nsRange)
 
         var mutableString = string

--- a/Tests/AppTests/EmojiTests.swift
+++ b/Tests/AppTests/EmojiTests.swift
@@ -16,7 +16,6 @@
 
 import Testing
 
-
 extension AllTests.EmojiTests {
 
     @Test func emojiReplacement() throws {
@@ -40,4 +39,11 @@ extension AllTests.EmojiTests {
         #expect(emojis[":grinning:"] == "😀")
     }
 
+    // Regression: `replace(inString:)` built its `NSRange` from `string.count`,
+    // but Foundation regex ranges are UTF-16 offsets.
+    @Test func emojiReplacementAfterUnicodePrefix() throws {
+        // Non-BMP characters contain two UTF-16 code units per Character
+        let questionableText = "𝐇𝐞𝐥𝐥𝐨, 𝐰𝐨𝐫𝐥𝐝 "
+        #expect((questionableText + ":smile:").replaceShorthandEmojis() == questionableText + "😄")
+    }
 }


### PR DESCRIPTION
This PR fixes a tiny bug introduced in #487 where the length given to the `NSRange` used for the regex lookup is passed the `String.count`, which only matches the whole string when it contains BMP-only characters.