### PR TITLE
Restore S3 pre-signed URL changes

### DIFF
--- a/Sources/App/Core/Extensions/S3Readme+ext.swift
+++ b/Sources/App/Core/Extensions/S3Readme+ext.swift
@@ -62,9 +62,15 @@ extension S3Readme {
         @Dependency(\.environment) var environment
         @Dependency(\.logger) var logger
 
-        guard let accessKeyId = environment.awsAccessKeyId() else { throw .envVariableNotSet("AWS_ACCESS_KEY_ID") }
-        guard let secretAccessKey = environment.awsSecretAccessKey() else { throw .envVariableNotSet("AWS_SECRET_ACCESS_KEY")}
-        let store = S3Store(credentials: .init(keyId: accessKeyId, secret: secretAccessKey))
+        let store: S3Store
+        if environment.awsUseIamRole() {
+            let region = environment.awsReadmeBucketRegion() ?? environment.awsRegion()
+            store = S3Store(region: region)
+        } else {
+            guard let accessKeyId = environment.awsAccessKeyId() else { throw .envVariableNotSet("AWS_ACCESS_KEY_ID") }
+            guard let secretAccessKey = environment.awsSecretAccessKey() else { throw .envVariableNotSet("AWS_SECRET_ACCESS_KEY") }
+            store = S3Store(credentials: .init(keyId: accessKeyId, secret: secretAccessKey))
+        }
         let key = try S3Store.Key.readme(owner: owner, repository: repository)
 
         logger.debug("Copying readme to \(key.s3Uri) ...")
@@ -82,10 +88,15 @@ extension S3Readme {
         @Dependency(\.httpClient) var httpClient
         @Dependency(\.logger) var logger
 
-        guard let accessKeyId = environment.awsAccessKeyId() else { throw .envVariableNotSet("AWS_ACCESS_KEY_ID") }
-        guard let secretAccessKey = environment.awsSecretAccessKey() else { throw .envVariableNotSet("AWS_SECRET_ACCESS_KEY")}
-
-        let store = S3Store(credentials: .init(keyId: accessKeyId, secret: secretAccessKey))
+        let store: S3Store
+        if environment.awsUseIamRole() {
+            let region = environment.awsReadmeBucketRegion() ?? environment.awsRegion()
+            store = S3Store(region: region)
+        } else {
+            guard let accessKeyId = environment.awsAccessKeyId() else { throw .envVariableNotSet("AWS_ACCESS_KEY_ID") }
+            guard let secretAccessKey = environment.awsSecretAccessKey() else { throw .envVariableNotSet("AWS_SECRET_ACCESS_KEY") }
+            store = S3Store(credentials: .init(keyId: accessKeyId, secret: secretAccessKey))
+        }
         for imageToCache in imagesToCache {
             logger.debug("Copying readme image to \(imageToCache.s3Key.s3Uri) ...")
             do {


### PR DESCRIPTION
I can't quite figure out where it happened but it seems like we lost the pre-signed URL changes at some point. This should fix issue #4142 

What I can't figure out is how we end up with what seem like recent, valid entries in the db:

<img width="1558" height="864" alt="CleanShot 2026-08-20 at 15 56 39@2x" src="https://github.com/user-attachments/assets/1bb95243-fe4a-453f-9d77-b026462b857d" />

We should be persisting this error in every case. From `Ingestion.swift`:

```
            do throws(S3Readme.Error) {
                s3Readme = try await storeS3Readme(repository: repo, metadata: metadata, readme: readme)
            } catch {
                // We don't want to fail ingestion in case storing the readme fails - warn and continue.
                logger.warning("storeS3Readme failed: \(error)")
                s3Readme = .error("\(error)")
            }
```

But regardless, this fix seems obvious, doesn't it?