### PR TITLE
Bind mount docker socket.

### DIFF
--- a/app.yml
+++ b/app.yml
@@ -146,6 +146,8 @@ services:
         max_attempts: 5
     networks:
       - backend
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
 
   trigger_builds:


### PR DESCRIPTION
Harden analysis -#4147 runs the package-dump in a sub-container, and this requires the docker socket available in the analysis container.

Add bind mount of the docker socket.